### PR TITLE
tun panic if from debug

### DIFF
--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -231,9 +231,9 @@ func (c *Core) DEBUG_startTunWithMTU(ifname string, iftapmode bool, mtu int) {
 		if err != nil {
 			panic(err)
 		}
-		go c.tun.read()
+		go func() { panic(c.tun.read()) }()
 	}
-	go c.tun.write()
+	go func() { panic(c.tun.write()) }()
 }
 
 func (c *Core) DEBUG_stopTun() {


### PR DESCRIPTION
If a tun/tap device is launched from debug.go, then then there's nothing to handle any errors that the read or write functions may return. In such cases, if these functions return an error, then the program would silently enter a broken state.

This *shouldn't* happen, but if it does, use panic to throw the error and crash the program with a traceback. This is marginally better than silently breaking, I guess... it would be better to handle the error and either log that there was a problem, or just restart the read/write loop, but I'm not sure what the best course of action is. I guess for now, just panic, and if it ever runs into this problem for a non-fatal error, then we can implement better error handling.