### PR TITLE
Adds support for FreeBSD

### DIFF
--- a/misc/tests/tunbench-client.go
+++ b/misc/tests/tunbench-client.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/neilalexander/water"
+	"github.com/yggdrasil-network/water"
 )
 
 const mtu = 65535

--- a/misc/tests/tunbench-server.go
+++ b/misc/tests/tunbench-server.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os/exec"
 
-	"github.com/neilalexander/water"
+	"github.com/yggdrasil-network/water"
 )
 
 const mtu = 65535

--- a/misc/tests/tunbench.go
+++ b/misc/tests/tunbench.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os/exec"
 
-	"github.com/neilalexander/water"
+	"github.com/yggdrasil-network/water"
 )
 
 const mtu = 65535

--- a/src/yggdrasil/tun_darwin.go
+++ b/src/yggdrasil/tun_darwin.go
@@ -8,7 +8,7 @@ import "strconv"
 import "encoding/binary"
 import "golang.org/x/sys/unix"
 
-import water "github.com/neilalexander/water"
+import water "github.com/yggdrasil-network/water"
 
 func getDefaults() tunDefaultParameters {
 	return tunDefaultParameters{

--- a/src/yggdrasil/tun_linux.go
+++ b/src/yggdrasil/tun_linux.go
@@ -7,7 +7,7 @@ import "errors"
 import "fmt"
 import "net"
 
-import water "github.com/neilalexander/water"
+import water "github.com/yggdrasil-network/water"
 
 import "github.com/docker/libcontainer/netlink"
 

--- a/src/yggdrasil/tun_other.go
+++ b/src/yggdrasil/tun_other.go
@@ -1,8 +1,8 @@
-// +build !linux,!darwin,!windows,!openbsd
+// +build !linux,!darwin,!windows,!openbsd,!freebsd
 
 package yggdrasil
 
-import water "github.com/neilalexander/water"
+import water "github.com/yggdrasil-network/water"
 
 // This is to catch unsupported platforms
 // If your platform supports tun devices, you could try configuring it manually

--- a/src/yggdrasil/tun_windows.go
+++ b/src/yggdrasil/tun_windows.go
@@ -1,6 +1,6 @@
 package yggdrasil
 
-import water "github.com/neilalexander/water"
+import water "github.com/yggdrasil-network/water"
 import "os/exec"
 import "strings"
 import "fmt"


### PR DESCRIPTION
This adds support for FreeBSD. Some notable changes from the OpenBSD code include:

1. Different order of `struct tuninfo`
1. Flags not present in `struct tuninfo` for setting interface up and multicast/broadcast vs point-to-point status, although the defaults that FreeBSD picks for this seem to be fine

Currently this only works in TAP mode, as like OpenBSD, the 4-byte protocol information header causes problems in TUN mode. This needs to be fixed in the Water library by determining the packet family from the IP header.

This pull request also includes changing the reference from `neilalexander/water` to `yggdrasil-network/water`.