### PR TITLE
Deduplicate some BSD code

### DIFF
--- a/src/yggdrasil/tun_bsd.go
+++ b/src/yggdrasil/tun_bsd.go
@@ -1,0 +1,98 @@
+package yggdrasil
+
+import "os/exec"
+import "unsafe"
+//import "syscall"
+import "golang.org/x/sys/unix"
+
+import water "github.com/yggdrasil-network/water"
+
+type in6_addrlifetime struct {
+	ia6t_expire    float64
+	ia6t_preferred float64
+	ia6t_vltime    uint32
+	ia6t_pltime    uint32
+}
+
+type sockaddr_in6 struct {
+	sin6_len      uint8
+	sin6_family   uint8
+	sin6_port     uint8
+	sin6_flowinfo uint32
+	sin6_addr     [8]uint16
+	sin6_scope_id uint32
+}
+
+type in6_aliasreq struct {
+	ifra_name       [16]byte
+	ifra_addr       sockaddr_in6
+	ifra_dstaddr    sockaddr_in6
+	ifra_prefixmask sockaddr_in6
+	ifra_flags      uint32
+	ifra_lifetime   in6_addrlifetime
+}
+
+func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
+	var config water.Config
+	if ifname[:4] == "auto" {
+		ifname = "/dev/tap0"
+	}
+	if len(ifname) < 9 {
+		panic("TUN/TAP name must be in format /dev/tunX or /dev/tapX")
+	}
+	switch {
+	case iftapmode || ifname[:8] == "/dev/tap":
+		config = water.Config{DeviceType: water.TAP}
+	case !iftapmode || ifname[:8] == "/dev/tun":
+		//config = water.Config{DeviceType: water.TUN}
+		panic("TUN mode is not currently supported on this platform, please use TAP instead")
+	default:
+		panic("TUN/TAP name must be in format /dev/tunX or /dev/tapX")
+	}
+	config.Name = ifname
+	iface, err := water.New(config)
+	if err != nil {
+		panic(err)
+	}
+	tun.iface = iface
+	tun.mtu = getSupportedMTU(mtu)
+	return tun.setupAddress(addr)
+}
+
+func (tun *tunDevice) setupAddress(addr string) error {
+	fd := tun.iface.FD().Fd()
+	var err error
+  var ti tuninfo
+
+	tun.core.log.Printf("Interface name: %s", tun.iface.Name())
+	tun.core.log.Printf("Interface IPv6: %s", addr)
+	tun.core.log.Printf("Interface MTU: %d", tun.mtu)
+
+	// Get the existing interface flags
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(TUNGIFINFO), uintptr(unsafe.Pointer(&ti))); errno != 0 {
+		err = errno
+		tun.core.log.Printf("Error in TUNGIFINFO: %v", errno)
+		return err
+	}
+
+  // Update with any OS-specific flags, MTU, etc.
+  ti.setInfo(tun)
+
+	// Set the new interface flags
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(TUNSIFINFO), uintptr(unsafe.Pointer(&ti))); errno != 0 {
+		err = errno
+		tun.core.log.Printf("Error in TUNSIFINFO: %v", errno)
+		return err
+	}
+
+	// Set address
+	cmd := exec.Command("ifconfig", tun.iface.Name(), "inet6", addr)
+	//tun.core.log.Printf("ifconfig command: %v", strings.Join(cmd.Args, " "))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		tun.core.log.Printf("ifconfig failed: %v.", err)
+		tun.core.log.Println(string(output))
+	}
+
+	return nil
+}

--- a/src/yggdrasil/tun_bsd.go
+++ b/src/yggdrasil/tun_bsd.go
@@ -2,7 +2,7 @@ package yggdrasil
 
 import "os/exec"
 import "unsafe"
-//import "syscall"
+
 import "golang.org/x/sys/unix"
 
 import water "github.com/yggdrasil-network/water"
@@ -44,7 +44,6 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 	case iftapmode || ifname[:8] == "/dev/tap":
 		config = water.Config{DeviceType: water.TAP}
 	case !iftapmode || ifname[:8] == "/dev/tun":
-		//config = water.Config{DeviceType: water.TUN}
 		panic("TUN mode is not currently supported on this platform, please use TAP instead")
 	default:
 		panic("TUN/TAP name must be in format /dev/tunX or /dev/tapX")
@@ -62,7 +61,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 func (tun *tunDevice) setupAddress(addr string) error {
 	fd := tun.iface.FD().Fd()
 	var err error
-  var ti tuninfo
+	var ti tuninfo
 
 	tun.core.log.Printf("Interface name: %s", tun.iface.Name())
 	tun.core.log.Printf("Interface IPv6: %s", addr)
@@ -75,8 +74,8 @@ func (tun *tunDevice) setupAddress(addr string) error {
 		return err
 	}
 
-  // Update with any OS-specific flags, MTU, etc.
-  ti.setInfo(tun)
+	// Update with any OS-specific flags, MTU, etc.
+	ti.setInfo(tun)
 
 	// Set the new interface flags
 	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(TUNSIFINFO), uintptr(unsafe.Pointer(&ti))); errno != 0 {

--- a/src/yggdrasil/tun_bsd.go
+++ b/src/yggdrasil/tun_bsd.go
@@ -1,3 +1,5 @@
+// +build openbsd freebsd
+
 package yggdrasil
 
 import "os/exec"

--- a/src/yggdrasil/tun_freebsd.go
+++ b/src/yggdrasil/tun_freebsd.go
@@ -1,12 +1,5 @@
 package yggdrasil
 
-import "os/exec"
-import "unsafe"
-//import "syscall"
-import "golang.org/x/sys/unix"
-
-import water "github.com/yggdrasil-network/water"
-
 // This is to catch FreeBSD and NetBSD
 
 func getDefaults() tunDefaultParameters {
@@ -40,99 +33,12 @@ type tuninfo struct {
 	tun_dummy    uint8
 }
 
+func (ti *tuninfo) setInfo(tun *tunDevice) {
+  ti.tun_mtu = int16(tun.mtu)
+}
+
 const TUNSIFINFO = (0x80000000) | ((8 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 91
 const TUNGIFINFO = (0x40000000) | ((8 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 92
 const TUNSIFHEAD = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 96
 const SIOCAIFADDR_IN6 = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('i'))<<8 | 27
 
-// Below this point seems to be fairly standard at least...
-
-type in6_addrlifetime struct {
-	ia6t_expire    float64
-	ia6t_preferred float64
-	ia6t_vltime    uint32
-	ia6t_pltime    uint32
-}
-
-type sockaddr_in6 struct {
-	sin6_len      uint8
-	sin6_family   uint8
-	sin6_port     uint8
-	sin6_flowinfo uint32
-	sin6_addr     [8]uint16
-	sin6_scope_id uint32
-}
-
-type in6_aliasreq struct {
-	ifra_name       [16]byte
-	ifra_addr       sockaddr_in6
-	ifra_dstaddr    sockaddr_in6
-	ifra_prefixmask sockaddr_in6
-	ifra_flags      uint32
-	ifra_lifetime   in6_addrlifetime
-}
-
-func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
-	var config water.Config
-	if ifname[:4] == "auto" {
-		ifname = "/dev/tap0"
-	}
-	if len(ifname) < 9 {
-		panic("TUN/TAP name must be in format /dev/tunX or /dev/tapX")
-	}
-	switch {
-	case iftapmode || ifname[:8] == "/dev/tap":
-		config = water.Config{DeviceType: water.TAP}
-	case !iftapmode || ifname[:8] == "/dev/tun":
-		//config = water.Config{DeviceType: water.TUN}
-		panic("TUN mode is not currently supported on this platform, please use TAP instead")
-	default:
-		panic("TUN/TAP name must be in format /dev/tunX or /dev/tapX")
-	}
-	config.Name = ifname
-	iface, err := water.New(config)
-	if err != nil {
-		panic(err)
-	}
-	tun.iface = iface
-	tun.mtu = getSupportedMTU(mtu)
-	return tun.setupAddress(addr)
-}
-
-func (tun *tunDevice) setupAddress(addr string) error {
-	fd := tun.iface.FD().Fd()
-	var err error
-	var ti tuninfo
-
-	tun.core.log.Printf("Interface name: %s", tun.iface.Name())
-	tun.core.log.Printf("Interface IPv6: %s", addr)
-	tun.core.log.Printf("Interface MTU: %d", tun.mtu)
-
-	// Get the existing interface flags
-	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(TUNGIFINFO), uintptr(unsafe.Pointer(&ti))); errno != 0 {
-		err = errno
-		tun.core.log.Printf("Error in TUNGIFINFO: %v", errno)
-		return err
-	}
-
-	// Set the new MTU
-	ti.tun_mtu = int16(tun.mtu)
-
-	// Set the new interface flags
-	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(TUNSIFINFO), uintptr(unsafe.Pointer(&ti))); errno != 0 {
-		err = errno
-		tun.core.log.Printf("Error in TUNSIFINFO: %v", errno)
-		return err
-	}
-
-	// Set address
-	cmd := exec.Command("ifconfig", tun.iface.Name(), "inet6", addr)
-	//tun.core.log.Printf("ifconfig command: %v", strings.Join(cmd.Args, " "))
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		tun.core.log.Printf("ifconfig failed: %v.", err)
-		tun.core.log.Println(string(output))
-	}
-
-	return nil
-}

--- a/src/yggdrasil/tun_freebsd.go
+++ b/src/yggdrasil/tun_freebsd.go
@@ -34,11 +34,10 @@ type tuninfo struct {
 }
 
 func (ti *tuninfo) setInfo(tun *tunDevice) {
-  ti.tun_mtu = int16(tun.mtu)
+	ti.tun_mtu = int16(tun.mtu)
 }
 
 const TUNSIFINFO = (0x80000000) | ((8 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 91
 const TUNGIFINFO = (0x40000000) | ((8 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 92
 const TUNSIFHEAD = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 96
 const SIOCAIFADDR_IN6 = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('i'))<<8 | 27
-

--- a/src/yggdrasil/tun_openbsd.go
+++ b/src/yggdrasil/tun_openbsd.go
@@ -1,11 +1,6 @@
 package yggdrasil
 
-import "os/exec"
-import "unsafe"
 import "syscall"
-import "golang.org/x/sys/unix"
-
-import water "github.com/yggdrasil-network/water"
 
 // This is to catch OpenBSD
 
@@ -44,85 +39,7 @@ type tuninfo struct {
 	tun_baudrate uint32
 }
 
-const TUNSIFINFO = (0x80000000) | ((12 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 91
-const TUNGIFINFO = (0x40000000) | ((12 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 92
-const SIOCAIFADDR_IN6 = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('i'))<<8 | 27
-
-// Below this point seems to be fairly standard at least...
-
-type in6_addrlifetime struct {
-	ia6t_expire    float64
-	ia6t_preferred float64
-	ia6t_vltime    uint32
-	ia6t_pltime    uint32
-}
-
-type sockaddr_in6 struct {
-	sin6_len      uint8
-	sin6_family   uint8
-	sin6_port     uint8
-	sin6_flowinfo uint32
-	sin6_addr     [8]uint16
-	sin6_scope_id uint32
-}
-
-type in6_aliasreq struct {
-	ifra_name       [16]byte
-	ifra_addr       sockaddr_in6
-	ifra_dstaddr    sockaddr_in6
-	ifra_prefixmask sockaddr_in6
-	ifra_flags      uint32
-	ifra_lifetime   in6_addrlifetime
-}
-
-func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int) error {
-	var config water.Config
-	if ifname[:4] == "auto" {
-		ifname = "/dev/tap0"
-	}
-	if len(ifname) < 9 {
-		panic("TUN/TAP name must be in format /dev/tunX or /dev/tapX")
-	}
-	switch {
-	case iftapmode || ifname[:8] == "/dev/tap":
-		config = water.Config{DeviceType: water.TAP}
-	case !iftapmode || ifname[:8] == "/dev/tun":
-		// config = water.Config{DeviceType: water.TUN}
-		panic("TUN mode is not currently supported on this platform, please use TAP instead")
-	default:
-		panic("TUN/TAP name must be in format /dev/tunX or /dev/tapX")
-	}
-	config.Name = ifname
-	iface, err := water.New(config)
-	if err != nil {
-		panic(err)
-	}
-	tun.iface = iface
-	tun.mtu = getSupportedMTU(mtu)
-	return tun.setupAddress(addr)
-}
-
-func (tun *tunDevice) setupAddress(addr string) error {
-	fd := tun.iface.FD().Fd()
-	var err error
-	var ti tuninfo
-
-	tun.core.log.Printf("Interface name: %s", tun.iface.Name())
-	tun.core.log.Printf("Interface IPv6: %s", addr)
-	tun.core.log.Printf("Interface MTU: %d", tun.mtu)
-
-	// Get the existing interface flags
-	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(TUNGIFINFO), uintptr(unsafe.Pointer(&ti))); errno != 0 {
-		err = errno
-		tun.core.log.Printf("Error in TUNGIFINFO: %v", errno)
-		return err
-	}
-	//tun.core.log.Printf("TUNGIFINFO: %+v", ti)
-
-	// Set the new MTU
-	ti.tun_mtu = uint32(tun.mtu)
-
-	// Set the new interface flags
+func (ti *tuninfo) setInfo(tun *tunDevice) {
 	ti.tun_flags |= syscall.IFF_UP
 	switch {
 	case tun.iface.IsTAP():
@@ -131,23 +48,10 @@ func (tun *tunDevice) setupAddress(addr string) error {
 	case tun.iface.IsTUN():
 		ti.tun_flags |= syscall.IFF_POINTOPOINT
 	}
-
-	// Set the new interface flags
-	//tun.core.log.Printf("TUNSIFINFO: %+v", ti)
-	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(TUNSIFINFO), uintptr(unsafe.Pointer(&ti))); errno != 0 {
-		err = errno
-		tun.core.log.Printf("Error in TUNSIFINFO: %v", errno)
-		return err
-	}
-
-	// Set address
-	cmd := exec.Command("ifconfig", tun.iface.Name(), "inet6", addr)
-	//tun.core.log.Printf("ifconfig command: %v", strings.Join(cmd.Args, " "))
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		tun.core.log.Printf("ifconfig failed: %v.", err)
-		tun.core.log.Println(string(output))
-	}
-
-	return nil
+  ti.tun_mtu = uint32(tun.mtu)
 }
+
+const TUNSIFINFO = (0x80000000) | ((12 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 91
+const TUNGIFINFO = (0x40000000) | ((12 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 92
+const SIOCAIFADDR_IN6 = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('i'))<<8 | 27
+

--- a/src/yggdrasil/tun_openbsd.go
+++ b/src/yggdrasil/tun_openbsd.go
@@ -48,10 +48,9 @@ func (ti *tuninfo) setInfo(tun *tunDevice) {
 	case tun.iface.IsTUN():
 		ti.tun_flags |= syscall.IFF_POINTOPOINT
 	}
-  ti.tun_mtu = uint32(tun.mtu)
+	ti.tun_mtu = uint32(tun.mtu)
 }
 
 const TUNSIFINFO = (0x80000000) | ((12 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 91
 const TUNGIFINFO = (0x40000000) | ((12 & 0x1fff) << 16) | uint32(byte('t'))<<8 | 92
 const SIOCAIFADDR_IN6 = (0x80000000) | ((4 & 0x1fff) << 16) | uint32(byte('i'))<<8 | 27
-


### PR DESCRIPTION
This compiles but hasn't been tested yet, so don't pull unless/until that happens. It's mostly for documentatin purposes.

The idea is to merge the common parts of `tun_freebsd.go` and `tun_openbsd.go` into `tun_bsd.go`, and set a `+build` flag to only build it on those platforms, so it doesn't also try to build on darwin. We could probably merge darwin in too, if we either start using SIOCAIFADDR_IN6 to set up the address on all bsd flavors, or fall back to using ifconfig for darwin.