### PR TITLE
Don't use water.Interface.FD()

### DIFF
--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -2,21 +2,11 @@ package yggdrasil
 
 // This manages the tun driver to send/recv packets to/from applications
 
-import "os"
-import ethernet "github.com/songgao/packets/ethernet"
+import "github.com/songgao/packets/ethernet"
+import "github.com/yggdrasil-network/water"
 
 const IPv6_HEADER_LENGTH = 40
 const ETHER_HEADER_LENGTH = 14
-
-type tunInterface interface {
-	IsTUN() bool
-	IsTAP() bool
-	Name() string
-	Read(to []byte) (int, error)
-	Write(from []byte) (int, error)
-	Close() error
-	FD() *os.File
-}
 
 type tunDevice struct {
 	core   *Core
@@ -24,7 +14,7 @@ type tunDevice struct {
 	send   chan<- []byte
 	recv   <-chan []byte
 	mtu    int
-	iface  tunInterface
+	iface  *water.Interface
 }
 
 type tunDefaultParameters struct {

--- a/src/yggdrasil/tun_bsd.go
+++ b/src/yggdrasil/tun_bsd.go
@@ -2,12 +2,13 @@
 
 package yggdrasil
 
+import "os"
 import "os/exec"
 import "unsafe"
 
 import "golang.org/x/sys/unix"
 
-import water "github.com/yggdrasil-network/water"
+import "github.com/yggdrasil-network/water"
 
 type in6_addrlifetime struct {
 	ia6t_expire    float64
@@ -61,7 +62,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 }
 
 func (tun *tunDevice) setupAddress(addr string) error {
-	fd := tun.iface.FD().Fd()
+	fd := tun.iface.ReadWriteCloser.(*os.File).Fd()
 	var err error
 	var ti tuninfo
 


### PR DESCRIPTION
Since we're not using tunInterface, and we have our own fork of water anyway, just directly use water.Interface for everything. We can always change it back later if we need to. This lets us get to the ReadWriteCloser, which we can cast to an `*os.File` and ask for the `Fd()`. Untested but I think it should work.