### PR TITLE
Use semantic versioning (fixes #45)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           command: |
               mkdir /tmp/upload
               echo 'export CINAME=$(sh contrib/semver/name.sh)' >> $BASH_ENV
-              echo 'export CIVERSION=$(sh contrib/semver/version.sh)' >> $BASH_ENV
+              echo 'export CIVERSION=$(sh contrib/semver/version.sh | cut -c 2-)' >> $BASH_ENV
 
       - run:
           name: Build for Linux (including Debian packages)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,48 +15,47 @@ jobs:
           name: Create artifact upload directory and set variables
           command: |
               mkdir /tmp/upload
-              echo 'export CIBUILD=$(cat VERSION).$(git rev-list HEAD --count | xargs printf "%04d")' >> $BASH_ENV
-              echo 'export CIBRANCH=$(git name-rev --name-only HEAD)' >> $BASH_ENV
-              echo '[ "$CIBRANCH" != "master" ] && export CIVERSION=$CIBRANCH-$CIBUILD || export CIVERSION=$CIBUILD' >> $BASH_ENV
+              echo 'export CINAME=$(sh contrib/semver/name.sh)' >> $BASH_ENV
+              echo 'export CIVERSION=$(sh contrib/semver/version.sh)' >> $BASH_ENV
 
       - run:
           name: Build for Linux (including Debian packages)
           command: |
-              PKGARCH=amd64 sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-linux-amd64;
-              PKGARCH=i386 sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-linux-i386;
-              PKGARCH=mipsel sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-linux-mipsel;
-              PKGARCH=mips sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-linux-mips;
+              PKGARCH=amd64 sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-linux-amd64;
+              PKGARCH=i386 sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-linux-i386;
+              PKGARCH=mipsel sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-linux-mipsel;
+              PKGARCH=mips sh contrib/deb/generate.sh && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-linux-mips;
               mv *.deb /tmp/upload/
 
       - run:
           name: Build for macOS
           command: |
-              GOOS=darwin GOARCH=amd64 ./build && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-darwin-amd64;
-              GOOS=darwin GOARCH=386 ./build && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-darwin-i386;
+              GOOS=darwin GOARCH=amd64 ./build && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-darwin-amd64;
+              GOOS=darwin GOARCH=386 ./build && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-darwin-i386;
 
       - run:
           name: Build for OpenBSD
           command: |
-              GOOS=openbsd GOARCH=amd64 ./build && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-openbsd-amd64;
-              GOOS=openbsd GOARCH=386 ./build && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-openbsd-i386;
+              GOOS=openbsd GOARCH=amd64 ./build && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-openbsd-amd64;
+              GOOS=openbsd GOARCH=386 ./build && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-openbsd-i386;
 
       - run:
           name: Build for FreeBSD
           command: |
-              GOOS=freebsd GOARCH=amd64 ./build && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-freebsd-amd64;
-              GOOS=freebsd GOARCH=386 ./build && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-freebsd-i386;
+              GOOS=freebsd GOARCH=amd64 ./build && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-freebsd-amd64;
+              GOOS=freebsd GOARCH=386 ./build && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-freebsd-i386;
 
       - run:
           name: Build for NetBSD
           command: |
-              GOOS=netbsd GOARCH=amd64 ./build && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-netbsd-amd64;
-              GOOS=netbsd GOARCH=386 ./build && mv yggdrasil /tmp/upload/yggdrasil-$CIVERSION-netbsd-i386;
+              GOOS=netbsd GOARCH=amd64 ./build && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-netbsd-amd64;
+              GOOS=netbsd GOARCH=386 ./build && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-netbsd-i386;
 
       - run:
           name: Build for Windows
           command: |
-              GOOS=windows GOARCH=amd64 ./build && mv yggdrasil.exe /tmp/upload/yggdrasil-$CIVERSION-windows-amd64.exe;
-              GOOS=windows GOARCH=386 ./build && mv yggdrasil.exe /tmp/upload/yggdrasil-$CIVERSION-windows-i386.exe;
+              GOOS=windows GOARCH=amd64 ./build && mv yggdrasil.exe /tmp/upload/$CINAME-$CIVERSION-windows-amd64.exe;
+              GOOS=windows GOARCH=386 ./build && mv yggdrasil.exe /tmp/upload/$CINAME-$CIVERSION-windows-i386.exe;
 
       - run:
           name: Build for EdgeRouter

--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -11,10 +11,9 @@ then
 fi
 
 PKGBRANCH=$(basename `git name-rev --name-only HEAD`)
-if [ "$PKGBRANCH" = "master" ]; then PKGNAME=yggdrasil
-else PKGNAME=yggdrasil-${PKGBRANCH}; fi
+PKGNAME=$(sh contrib/semver/name.sh)
+PKGVERSION=$(sh contrib/semver/version.sh | cut -c 2-)
 PKGARCH=${PKGARCH-amd64}
-PKGVERSION=$(cat VERSION).$(git rev-list HEAD --count 2>/dev/null | xargs printf "%04d")
 PKGFILE=$PKGNAME-$PKGVERSION-$PKGARCH.deb
 
 if [ $PKGARCH = "amd64" ]; then GOARCH=amd64 GOOS=linux ./build

--- a/contrib/semver/name.sh
+++ b/contrib/semver/name.sh
@@ -3,12 +3,6 @@
 # Get the branch name
 BRANCH=$(git name-rev --name-only HEAD 2>/dev/null)
 
-# Check if the branch name check fails
-if [ $? != 0 ]; then
-  printf "yggdrasil"
-  exit 0
-fi
-
 # Check if the branch name is not master
 if [ "$BRANCH" = "master" ]; then
   printf "yggdrasil"

--- a/contrib/semver/name.sh
+++ b/contrib/semver/name.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Get the branch name
+BRANCH=$(git name-rev --name-only HEAD 2>/dev/null)
+
+# Check if the branch name check fails
+if [ $? != 0 ]; then
+  printf "yggdrasil"
+  exit 0
+fi
+
+# Check if the branch name is not master
+if [ "$BRANCH" = "master" ]; then
+  printf "yggdrasil"
+  exit 0
+fi
+
+# If it is something other than master, append it
+printf "yggdrasil-%s" "$BRANCH"

--- a/contrib/semver/name.sh
+++ b/contrib/semver/name.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Get the branch name
-BRANCH=$(git name-rev --name-only HEAD 2>/dev/null)
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null)
 
 # Check if the branch name is not master
 if [ "$BRANCH" = "master" ]; then

--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Get the last tag
+TAG=$(git describe --abbrev=0 --tags 2>/dev/null)
+
+# Get the number of commits from the last tag, or if not, from
+# the first commit
+COUNT=$( \
+  git rev-list v$TAG..HEAD --count 2>/dev/null || \
+  git rev-list HEAD --count 2>/dev/null \
+)
+
+# Check if it matches the vX.Y.Z format
+grep "v[0-9]*\.[0-9]*\.[0-9]*" <<< $TAG &>/dev/null
+
+# If it doesn't, abort
+if [ $? -ne 0 ]; then
+  printf 'v0.0.0-%d' "$COUNT"
+  exit -1
+fi
+
+# Trim the "v" off the front
+TAG=$(echo $TAG | cut -c 2-)
+
+# Split out into major, minor and patch numbers
+MAJOR=$(echo $TAG | cut -d "." -f 1)
+MINOR=$(echo $TAG | cut -d "." -f 2)
+PATCH=$(echo $TAG | cut -d "." -f 3)
+
+# Output in the desired format
+printf 'v%d.%d.%d-%d' "$MAJOR" "$MINOR" "$PATCH" "$COUNT"

--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Get the last tag
-TAG=$(git describe --abbrev=0 --tags 2>/dev/null)
+TAG=$(git describe --abbrev=0 --tags --match=v* 2>/dev/null)
 
 # Get the number of commits from the last tag, or if not, from
 # the first commit

--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -1,20 +1,15 @@
 #!/bin/sh
 
 # Get the last tag
-TAG=$(git describe --abbrev=0 --tags --match=v* 2>/dev/null)
+TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*\.[0-9]*" 2>/dev/null)
 
-# Get the number of commits from the last tag, or if not, from
-# the first commit
-COUNT=$( \
-  git rev-list v$TAG..HEAD --count 2>/dev/null || \
-  git rev-list HEAD --count 2>/dev/null \
-)
+# Get the number of commits from the last tag
+COUNT=$(git rev-list $TAG..HEAD --count 2>/dev/null)
 
-# Check if it matches the vX.Y.Z format
-grep "v[0-9]*\.[0-9]*\.[0-9]*" <<< $TAG &>/dev/null
+# If it fails then there's no last tag - go from the first commit
+if [ $? != 0 ]; then
+  COUNT=$(git rev-list HEAD --count 2>/dev/null)
 
-# If it doesn't, abort
-if [ $? -ne 0 ]; then
   printf 'v0.0.0-%d' "$COUNT"
   exit -1
 fi

--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Get the last tag
-TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*\.[0-9]*" 2>/dev/null)
+TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*" 2>/dev/null)
 
 # Get the number of commits from the last tag
 COUNT=$(git rev-list $TAG..HEAD --count 2>/dev/null)
@@ -10,17 +10,17 @@ COUNT=$(git rev-list $TAG..HEAD --count 2>/dev/null)
 if [ $? != 0 ]; then
   COUNT=$(git rev-list HEAD --count 2>/dev/null)
 
-  printf 'v0.0.0-%d' "$COUNT"
+  printf 'v0.0.%d' "$COUNT"
   exit -1
 fi
 
-# Trim the "v" off the front
-TAG=$(echo $TAG | cut -c 2-)
-
 # Split out into major, minor and patch numbers
-MAJOR=$(echo $TAG | cut -d "." -f 1)
-MINOR=$(echo $TAG | cut -d "." -f 2)
-PATCH=$(echo $TAG | cut -d "." -f 3)
+MAJOR=$(echo $TAG | cut -c 2- | cut -d "." -f 1)
+MINOR=$(echo $TAG | cut -c 2- | cut -d "." -f 2)
 
 # Output in the desired format
-printf 'v%d.%d.%d-%d' "$MAJOR" "$MINOR" "$PATCH" "$COUNT"
+if [ $COUNT = 0 ]; then
+  printf 'v%d.%d' "$MAJOR" "$MINOR"
+else
+  printf 'v%d.%d.%d' "$MAJOR" "$MINOR" "$COUNT"
+fi


### PR DESCRIPTION
Fixes issue #45 by introducing semantic versioning.

The format is `X.Y.Z`, where `X` and `Y` are derived from tags of format `vX.Y` and `Z` is derived from the number of commits since the last tag.