### PR TITLE
Show both UDP and TCP listen addresses in stdout (#51)

### DIFF
--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -51,7 +51,7 @@ func (iface *tcpInterface) init(core *Core, addr string) {
 
 func (iface *tcpInterface) listener() {
 	defer iface.serv.Close()
-	iface.core.log.Println("Listening on:", iface.serv.Addr().String())
+	iface.core.log.Println("Listening for TCP on:", iface.serv.Addr().String())
 	for {
 		sock, err := iface.serv.AcceptTCP()
 		if err != nil {

--- a/src/yggdrasil/udp.go
+++ b/src/yggdrasil/udp.go
@@ -265,6 +265,7 @@ func (iface *udpInterface) handlePacket(msg []byte, addr connAddr) {
 }
 
 func (iface *udpInterface) reader() {
+	iface.core.log.Println("Listening for UDP on:", iface.sock.LocalAddr().String())
 	bs := make([]byte, 65536) // This needs to be large enough for everything...
 	for {
 		n, udpAddr, err := iface.sock.ReadFromUDP(bs)


### PR DESCRIPTION
Currently only the TCP listen address is printed to stdout, as identified in #51. This PR adds the UDP listen address too.

Example output with `-autoconf`:
```
2018/03/07 09:19:35 Listening for TCP on: [::]:62288
2018/03/07 09:19:35 Listening for UDP on: [::]:62865
```