### PR TITLE
DHT peers/other partitioning

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -290,7 +290,16 @@ func (a *admin) getData_getDHT() []admin_nodeInfo {
 	getDHT := func() {
 		for i := 0; i < a.core.dht.nBuckets(); i++ {
 			b := a.core.dht.getBucket(i)
-			for _, v := range b.infos {
+			for _, v := range b.other {
+				addr := *address_addrForNodeID(v.getNodeID())
+				info := admin_nodeInfo{
+					{"IP", net.IP(addr[:]).String()},
+					{"coords", fmt.Sprint(v.coords)},
+					{"bucket", fmt.Sprint(i)},
+				}
+				infos = append(infos, info)
+			}
+			for _, v := range b.peers {
 				addr := *address_addrForNodeID(v.getNodeID())
 				info := admin_nodeInfo{
 					{"IP", net.IP(addr[:]).String()},

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -154,7 +154,8 @@ func (c *Core) DEBUG_getDHTSize() int {
 	total := 0
 	for bidx := 0; bidx < c.dht.nBuckets(); bidx++ {
 		b := c.dht.getBucket(bidx)
-		total += len(b.infos)
+		total += len(b.peers)
+		total += len(b.other)
 	}
 	return total
 }

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -485,3 +485,9 @@ func dht_firstCloserThanThird(first *NodeID,
 	}
 	return false
 }
+
+func (t *dht) resetPeers() {
+	for _, b := range t.buckets_hidden {
+		b.peers = b.peers[:0]
+	}
+}

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -77,7 +77,7 @@ func (r *router) mainLoop() {
 		case p := <-r.send:
 			r.sendPacket(p)
 		case info := <-r.core.dht.peers:
-			r.core.dht.insert(info) //r.core.dht.insertIfNew(info)
+			r.core.dht.insertIfNew(info, true)
 		case <-r.reset:
 			r.core.sessions.resetInits()
 		case <-ticker.C:

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -80,6 +80,7 @@ func (r *router) mainLoop() {
 			r.core.dht.insertIfNew(info, true)
 		case <-r.reset:
 			r.core.sessions.resetInits()
+			r.core.dht.resetPeers()
 		case <-ticker.C:
 			{
 				// Any periodic maintenance stuff goes here

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -113,7 +113,7 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 		cfg.Listen = "[::]:0"
 	} else {
 		r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
-		cfg.Listen = fmt.Sprintf("[::]:%d", r1.Intn(65534 - 32768) + 32768)
+		cfg.Listen = fmt.Sprintf("[::]:%d", r1.Intn(65534-32768)+32768)
 	}
 	cfg.AdminListen = "[::1]:9001"
 	cfg.BoxPub = hex.EncodeToString(bpub[:])


### PR DESCRIPTION
I think this fixes #54, but I'm not completely convinced this is the right way to do it.

Roughly speaking, the problem is addressed by:

1. Split buckets into `peers` and `other` nodes.
2. Adding a node to a bucket will remove it from both `peers` and `other`, then insert it into one of them.
3. The router occasionally adds a peer to the `peers` side of the appropriate bucket.
4. Nodes we hear about from a dht request/response are only added to the bucket if not already present (already present nodes will get pinged periodically if the bucket is sparsely populated, or else pushed out by new nodes eventually, with peers sticking around forever--hopefully).

This means that a node added as a peer *should* only appear in peers. Remaining edge case issues/weirdness are:

1. If a node is added as an `other` before the peer connection is established. If the node is ever flushed from the DHT, then it should almost immediately be re-added to `peers`, so I guess this is OK from the standpoint of issue #54 (but still ugly).
2. If a node is added to `peers`, then the peer connection is lost, *but the node does not change coords*, then it will sit around as an extra entry in the `peers` side of the bucket. This doesn't break anything, but it does add needless overhead. On the up side, when peers disconnect from eachother, it's likely that either one went offline or one is mobile, so the case where both nodes stay online *and* keep the same coords is probably uncommon. Fixable in other ways (require that nodes in the `peers` part of a bucket get regular-ish updates from outside?), but I'm not sure how to do this a way that I like, so left as-is for now.