### PR TITLE
Add launchd script for macOS to contrib

### DIFF
--- a/contrib/macos/yggdrasil.plist
+++ b/contrib/macos/yggdrasil.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>yggdrasil</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>sh</string>
+      <string>-c</string>
+      <string>/usr/bin/yggdrasil -useconf &lt; /etc/yggdrasil.conf</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+    <key>StandardOutPath</key>
+    <string>/tmp/yggdrasil.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/yggdrasil.stderr.log</string>
+  </dict>
+</plist>


### PR DESCRIPTION
The launchd script can be used to run Yggdrasil as a service on macOS. It assumes that the Yggdrasil binary is `/usr/bin/yggdrasil` and the configuration is in `/etc/yggdrasil.conf`. 

Install the script:
```
sudo cp contrib/macos/yggdrasil.plist /Library/LaunchDaemons/
```

Enable the service:
```
sudo launchctl load /Library/LaunchDaemons/yggdrasil.plist
```

Disable the service:
```
sudo launchctl unload /Library/LaunchDaemons/yggdrasil.plist
```