### PR TITLE
Default to previous scheme when url.Parse returns an error

### DIFF
--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -313,10 +313,7 @@ func (c *Core) DEBUG_maybeSendUDPKeys(saddr string) {
 
 func (c *Core) DEBUG_addPeer(addr string) {
 	u, err := url.Parse(addr)
-	if err != nil {
-		panic(err)
-	}
-	if len(u.Opaque) == 0 {
+	if err == nil {
 		switch strings.ToLower(u.Scheme) {
 		case "tcp":
 			c.DEBUG_addTCPConn(u.Host)


### PR DESCRIPTION
In response to:
```
panic: parse x.x.x.x:xxx: first path segment in URL cannot contain colon

goroutine 33 [running]:
yggdrasil.(*Core).DEBUG_addPeer(0x8e58000, 0x8e34080, 0x12)
        /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/src/yggdrasil/debug.go:317 +0x420
main.(*node).init.func1(0x8e48000, 0x8e58000)
        /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/yggdrasil.go:75 +0x70
created by main.(*node).init
        /go/src/github.com/{{ORG_NAME}}/{{REPO_NAME}}/yggdrasil.go:69 +0x410
```