### PR TITLE
netns fix

### DIFF
--- a/misc/run-schannel-netns
+++ b/misc/run-schannel-netns
@@ -44,6 +44,13 @@ ip netns exec node5 tc qdisc add dev veth54 root tbf rate 100mbit burst 8192 lat
 ip netns exec node4 tc qdisc add dev veth46 root tbf rate 10mbit burst 8192 latency 1ms
 ip netns exec node6 tc qdisc add dev veth64 root tbf rate 10mbit burst 8192 latency 1ms
 
+ip netns exec node1 ip link set lo up
+ip netns exec node2 ip link set lo up
+ip netns exec node3 ip link set lo up
+ip netns exec node4 ip link set lo up
+ip netns exec node5 ip link set lo up
+ip netns exec node6 ip link set lo up
+
 ip netns exec node1 ./run --autoconf --pprof &> /dev/null &
 ip netns exec node2 ./run --autoconf --pprof &> /dev/null &
 ip netns exec node3 ./run --autoconf --pprof &> /dev/null &

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -236,6 +236,7 @@ func (c *Core) DEBUG_startTunWithMTU(ifname string, iftapmode bool, mtu int) {
 		if err != nil {
 			panic(err)
 		}
+		c.log.Println("Setup TUN/TAP:", c.tun.iface.Name(), straddr)
 		go func() { panic(c.tun.read()) }()
 	}
 	go func() { panic(c.tun.write()) }()

--- a/src/yggdrasil/tun_linux.go
+++ b/src/yggdrasil/tun_linux.go
@@ -48,7 +48,8 @@ func (tun *tunDevice) setupAddress(addr string) error {
 	}
 	for _, ifce := range ifces {
 		if ifce.Name == tun.iface.Name() {
-			netIF = &ifce
+			var newIF = ifce
+			netIF = &newIF // Don't point inside ifces, it's apparently unsafe?...
 		}
 	}
 	if netIF == nil {


### PR DESCRIPTION
Fixes #69 (I think).

The issue seems to be that netIF was being set to a `*net.Interface` pointing to the iterator over the `ifaces` slice. Copying the iterator to a new struct, then pointing at that struct instead, seems to fix it.

I'm not completely sure why the problem was only occurring in network namespaces, and not everywhere.