### PR TITLE
Partial support for authenticated peers

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -377,7 +377,7 @@ func (a *admin) getAuthBoxPubs() string {
 
 func (a *admin) addAuthBoxPub(bstr string) (err error) {
 	boxBytes, err := hex.DecodeString(bstr)
-	if err != nil {
+	if err == nil {
 		var box boxPubKey
 		copy(box[:], boxBytes)
 		a.core.peers.addAuthBoxPub(&box)
@@ -387,7 +387,7 @@ func (a *admin) addAuthBoxPub(bstr string) (err error) {
 
 func (a *admin) removeAuthBoxPub(bstr string) (err error) {
 	boxBytes, err := hex.DecodeString(bstr)
-	if err != nil {
+	if err == nil {
 		var box boxPubKey
 		copy(box[:], boxBytes)
 		a.core.peers.removeAuthBoxPub(&box)

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -105,18 +105,18 @@ func (a *admin) init(c *Core, listenaddr string) {
 			*out = []byte(a.printInfos([]admin_nodeInfo{info}))
 		}
 	})
-	a.addHandler("getAuthBoxPubs", nil, func(out *[]byte, _ ...string) {
-		*out = []byte(a.getAuthBoxPubs())
+	a.addHandler("getAllowedBoxPubs", nil, func(out *[]byte, _ ...string) {
+		*out = []byte(a.getAllowedBoxPubs())
 	})
-	a.addHandler("addAuthBoxPub", []string{"<boxPubKey>"}, func(out *[]byte, saddr ...string) {
-		if a.addAuthBoxPub(saddr[0]) == nil {
+	a.addHandler("addAllowedBoxPub", []string{"<boxPubKey>"}, func(out *[]byte, saddr ...string) {
+		if a.addAllowedBoxPub(saddr[0]) == nil {
 			*out = []byte("Adding key: " + saddr[0] + "\n")
 		} else {
 			*out = []byte("Failed to add key: " + saddr[0] + "\n")
 		}
 	})
-	a.addHandler("removeAuthBoxPub", []string{"<boxPubKey>"}, func(out *[]byte, sport ...string) {
-		if a.removeAuthBoxPub(sport[0]) == nil {
+	a.addHandler("removeAllowedBoxPub", []string{"<boxPubKey>"}, func(out *[]byte, sport ...string) {
+		if a.removeAllowedBoxPub(sport[0]) == nil {
 			*out = []byte("Removing key: " + sport[0] + "\n")
 		} else {
 			*out = []byte("Failed to remove key: " + sport[0] + "\n")
@@ -365,8 +365,8 @@ func (a *admin) getData_getSessions() []admin_nodeInfo {
 	return infos
 }
 
-func (a *admin) getAuthBoxPubs() string {
-	pubs := a.core.peers.getAuthBoxPubs()
+func (a *admin) getAllowedBoxPubs() string {
+	pubs := a.core.peers.getAllowedBoxPubs()
 	var out []string
 	for _, pub := range pubs {
 		out = append(out, hex.EncodeToString(pub[:]))
@@ -375,22 +375,22 @@ func (a *admin) getAuthBoxPubs() string {
 	return strings.Join(out, "\n")
 }
 
-func (a *admin) addAuthBoxPub(bstr string) (err error) {
+func (a *admin) addAllowedBoxPub(bstr string) (err error) {
 	boxBytes, err := hex.DecodeString(bstr)
 	if err == nil {
 		var box boxPubKey
 		copy(box[:], boxBytes)
-		a.core.peers.addAuthBoxPub(&box)
+		a.core.peers.addAllowedBoxPub(&box)
 	}
 	return
 }
 
-func (a *admin) removeAuthBoxPub(bstr string) (err error) {
+func (a *admin) removeAllowedBoxPub(bstr string) (err error) {
 	boxBytes, err := hex.DecodeString(bstr)
 	if err == nil {
 		var box boxPubKey
 		copy(box[:], boxBytes)
-		a.core.peers.removeAuthBoxPub(&box)
+		a.core.peers.removeAllowedBoxPub(&box)
 	}
 	return
 }

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -3,6 +3,7 @@ package yggdrasil
 import "net"
 import "os"
 import "bytes"
+import "encoding/hex"
 import "errors"
 import "fmt"
 import "net/url"
@@ -102,6 +103,23 @@ func (a *admin) init(c *Core, listenaddr string) {
 				{"MTU", strconv.Itoa(ifmtu)},
 			}
 			*out = []byte(a.printInfos([]admin_nodeInfo{info}))
+		}
+	})
+	a.addHandler("getAuthBoxPubs", nil, func(out *[]byte, _ ...string) {
+		*out = []byte(a.getAuthBoxPubs())
+	})
+	a.addHandler("addAuthBoxPub", []string{"<boxPubKey>"}, func(out *[]byte, saddr ...string) {
+		if a.addAuthBoxPub(saddr[0]) == nil {
+			*out = []byte("Adding key: " + saddr[0] + "\n")
+		} else {
+			*out = []byte("Failed to add key: " + saddr[0] + "\n")
+		}
+	})
+	a.addHandler("removeAuthBoxPub", []string{"<boxPubKey>"}, func(out *[]byte, sport ...string) {
+		if a.removeAuthBoxPub(sport[0]) == nil {
+			*out = []byte("Removing key: " + sport[0] + "\n")
+		} else {
+			*out = []byte("Failed to remove key: " + sport[0] + "\n")
 		}
 	})
 	go a.listen()
@@ -345,6 +363,36 @@ func (a *admin) getData_getSessions() []admin_nodeInfo {
 	}
 	a.core.router.doAdmin(getSessions)
 	return infos
+}
+
+func (a *admin) getAuthBoxPubs() string {
+	pubs := a.core.peers.getAuthBoxPubs()
+	var out []string
+	for _, pub := range pubs {
+		out = append(out, hex.EncodeToString(pub[:]))
+	}
+	out = append(out, "")
+	return strings.Join(out, "\n")
+}
+
+func (a *admin) addAuthBoxPub(bstr string) (err error) {
+	boxBytes, err := hex.DecodeString(bstr)
+	if err != nil {
+		var box boxPubKey
+		copy(box[:], boxBytes)
+		a.core.peers.addAuthBoxPub(&box)
+	}
+	return
+}
+
+func (a *admin) removeAuthBoxPub(bstr string) (err error) {
+	boxBytes, err := hex.DecodeString(bstr)
+	if err != nil {
+		var box boxPubKey
+		copy(box[:], boxBytes)
+		a.core.peers.removeAuthBoxPub(&box)
+	}
+	return
 }
 
 func (a *admin) getResponse_dot() []byte {

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -5,6 +5,7 @@ type NodeConfig struct {
 	Listen      string
 	AdminListen string
 	Peers       []string
+	PeerBoxPubs []string
 	BoxPub      string
 	BoxPriv     string
 	SigPub      string

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -2,20 +2,20 @@ package config
 
 // NodeConfig defines all configuration values needed to run a signle yggdrasil node
 type NodeConfig struct {
-	Listen      string
-	AdminListen string
-	Peers       []string
-	PeerBoxPubs []string
-	BoxPub      string
-	BoxPriv     string
-	SigPub      string
-	SigPriv     string
-	Multicast   bool
-	LinkLocal   string
-	IfName      string
-	IfTAPMode   bool
-	IfMTU       int
-	Net         NetConfig
+	Listen         string
+	AdminListen    string
+	Peers          []string
+	AllowedBoxPubs []string
+	BoxPub         string
+	BoxPriv        string
+	SigPub         string
+	SigPriv        string
+	Multicast      bool
+	LinkLocal      string
+	IfName         string
+	IfTAPMode      bool
+	IfMTU          int
+	Net            NetConfig
 }
 
 // NetConfig defines network/proxy related configuration values

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -44,6 +44,7 @@ func (c *Core) init(bpub *boxPubKey,
 	c.log = log.New(ioutil.Discard, "", 0)
 	c.boxPub, c.boxPriv = *bpub, *bpriv
 	c.sigPub, c.sigPriv = *spub, *spriv
+	c.admin.core = c
 	c.sigs.init()
 	c.searches.init(c)
 	c.dht.init(c)

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -397,8 +397,8 @@ func (c *Core) DEBUG_setIfceExpr(expr *regexp.Regexp) {
 	c.ifceExpr = expr
 }
 
-func (c *Core) DEBUG_addAuthBoxPub(boxStr string) {
-	err := c.admin.addAuthBoxPub(boxStr)
+func (c *Core) DEBUG_addAllowedBoxPub(boxStr string) {
+	err := c.admin.addAllowedBoxPub(boxStr)
 	if err != nil {
 		panic(err)
 	}

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -400,7 +400,7 @@ func (c *Core) DEBUG_setIfceExpr(expr *regexp.Regexp) {
 func (c *Core) DEBUG_addAuthBoxPub(boxBytes []byte) {
 	var box boxPubKey
 	copy(box[:], boxBytes)
-	c.peers.authBoxPubs[box] = struct{}{}
+	c.peers.addAuthBoxPub(&box)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -397,10 +397,11 @@ func (c *Core) DEBUG_setIfceExpr(expr *regexp.Regexp) {
 	c.ifceExpr = expr
 }
 
-func (c *Core) DEBUG_addAuthBoxPub(boxBytes []byte) {
-	var box boxPubKey
-	copy(box[:], boxBytes)
-	c.peers.addAuthBoxPub(&box)
+func (c *Core) DEBUG_addAuthBoxPub(boxStr string) {
+	err := c.admin.addAuthBoxPub(boxStr)
+	if err != nil {
+		panic(err)
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -397,6 +397,12 @@ func (c *Core) DEBUG_setIfceExpr(expr *regexp.Regexp) {
 	c.ifceExpr = expr
 }
 
+func (c *Core) DEBUG_addAuthBoxPub(boxBytes []byte) {
+	var box boxPubKey
+	copy(box[:], boxBytes)
+	c.peers.authBoxPubs[box] = struct{}{}
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func DEBUG_simLinkPeers(p, q *peer) {

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -34,8 +34,8 @@ type peers struct {
 	mutex sync.Mutex   // Synchronize writes to atomic
 	ports atomic.Value //map[Port]*peer, use CoW semantics
 	//ports map[Port]*peer
-	authMutex   sync.RWMutex
-	authBoxPubs map[boxPubKey]struct{}
+	authMutex      sync.RWMutex
+	allowedBoxPubs map[boxPubKey]struct{}
 }
 
 func (ps *peers) init(c *Core) {
@@ -43,33 +43,33 @@ func (ps *peers) init(c *Core) {
 	defer ps.mutex.Unlock()
 	ps.putPorts(make(map[switchPort]*peer))
 	ps.core = c
-	ps.authBoxPubs = make(map[boxPubKey]struct{})
+	ps.allowedBoxPubs = make(map[boxPubKey]struct{})
 }
 
-func (ps *peers) isAuthBoxPub(box *boxPubKey) bool {
+func (ps *peers) isAllowedBoxPub(box *boxPubKey) bool {
 	ps.authMutex.RLock()
 	defer ps.authMutex.RUnlock()
-	_, isIn := ps.authBoxPubs[*box]
-	return isIn || len(ps.authBoxPubs) == 0
+	_, isIn := ps.allowedBoxPubs[*box]
+	return isIn || len(ps.allowedBoxPubs) == 0
 }
 
-func (ps *peers) addAuthBoxPub(box *boxPubKey) {
+func (ps *peers) addAllowedBoxPub(box *boxPubKey) {
 	ps.authMutex.Lock()
 	defer ps.authMutex.Unlock()
-	ps.authBoxPubs[*box] = struct{}{}
+	ps.allowedBoxPubs[*box] = struct{}{}
 }
 
-func (ps *peers) removeAuthBoxPub(box *boxPubKey) {
+func (ps *peers) removeAllowedBoxPub(box *boxPubKey) {
 	ps.authMutex.Lock()
 	defer ps.authMutex.Unlock()
-	delete(ps.authBoxPubs, *box)
+	delete(ps.allowedBoxPubs, *box)
 }
 
-func (ps *peers) getAuthBoxPubs() []boxPubKey {
+func (ps *peers) getAllowedBoxPubs() []boxPubKey {
 	ps.authMutex.RLock()
 	defer ps.authMutex.RUnlock()
-	keys := make([]boxPubKey, 0, len(ps.authBoxPubs))
-	for key := range ps.authBoxPubs {
+	keys := make([]boxPubKey, 0, len(ps.allowedBoxPubs))
+	for key := range ps.allowedBoxPubs {
 		keys = append(keys, key)
 	}
 	return keys

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -30,9 +30,10 @@ import "math"
 //import "fmt"
 
 type peers struct {
-	core  *Core
-	mutex sync.Mutex   // Synchronize writes to atomic
-	ports atomic.Value //map[Port]*peer, use CoW semantics
+	core        *Core
+	authBoxPubs map[boxPubKey]struct{}
+	mutex       sync.Mutex   // Synchronize writes to atomic
+	ports       atomic.Value //map[Port]*peer, use CoW semantics
 	//ports map[Port]*peer
 }
 
@@ -41,6 +42,12 @@ func (ps *peers) init(c *Core) {
 	defer ps.mutex.Unlock()
 	ps.putPorts(make(map[switchPort]*peer))
 	ps.core = c
+	ps.authBoxPubs = make(map[boxPubKey]struct{})
+}
+
+func (ps *peers) isAuthBoxPub(box *boxPubKey) bool {
+	_, isIn := ps.authBoxPubs[*box]
+	return isIn || len(ps.authBoxPubs) == 0
 }
 
 func (ps *peers) getPorts() map[switchPort]*peer {

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -151,7 +151,7 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 		return
 	}
 	// Check if we're authorized to connect to this key / IP
-	if incoming && !iface.core.peers.isAuthBoxPub(&info.box) {
+	if incoming && !iface.core.peers.isAllowedBoxPub(&info.box) {
 		// Allow unauthorized peers if they're link-local
 		raddrStr, _, _ := net.SplitHostPort(sock.RemoteAddr().String())
 		raddr := net.ParseIP(raddrStr)

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -62,7 +62,7 @@ func (iface *tcpInterface) listener() {
 		if err != nil {
 			panic(err)
 		}
-		go iface.handler(sock)
+		go iface.handler(sock, true)
 	}
 }
 
@@ -81,7 +81,7 @@ func (iface *tcpInterface) callWithConn(conn net.Conn) {
 				delete(iface.calls, raddr)
 				iface.mutex.Unlock()
 			}()
-			iface.handler(conn)
+			iface.handler(conn, false)
 		}
 	}()
 }
@@ -106,12 +106,12 @@ func (iface *tcpInterface) call(saddr string) {
 			if err != nil {
 				return
 			}
-			iface.handler(conn)
+			iface.handler(conn, false)
 		}
 	}()
 }
 
-func (iface *tcpInterface) handler(sock net.Conn) {
+func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 	defer sock.Close()
 	// Get our keys
 	keys := []byte{}
@@ -149,6 +149,15 @@ func (iface *tcpInterface) handler(sock net.Conn) {
 	} // testing
 	if equiv(info.sig[:], iface.core.sigPub[:]) {
 		return
+	}
+	// Check if we're authorized to connect to this key / IP
+	if incoming && !iface.core.peers.isAuthBoxPub(&info.box) {
+		// Allow unauthorized peers if they're link-local
+		raddrStr, _, _ := net.SplitHostPort(sock.RemoteAddr().String())
+		raddr := net.ParseIP(raddrStr)
+		if !raddr.IsLinkLocalUnicast() {
+			return
+		}
 	}
 	// Check if we already have a connection to this node, close and block if yes
 	info.localAddr, _, _ = net.SplitHostPort(sock.LocalAddr().String())

--- a/src/yggdrasil/udp.go
+++ b/src/yggdrasil/udp.go
@@ -204,6 +204,14 @@ func (iface *udpInterface) handleKeys(msg []byte, addr connAddr) {
 	iface.mutex.RUnlock()
 	if !isIn {
 		udpAddr := addr.toUDPAddr()
+		// Check if we're authorized to connect to this key / IP
+		// TODO monitor and always allow outgoing connections
+		if !iface.core.peers.isAuthBoxPub(&ks.box) {
+			// Allow unauthorized peers if they're link-local
+			if !udpAddr.IP.IsLinkLocalUnicast() {
+				return
+			}
+		}
 		themNodeID := getNodeID(&ks.box)
 		themAddr := address_addrForNodeID(themNodeID)
 		themAddrString := net.IP(themAddr[:]).String()

--- a/src/yggdrasil/udp.go
+++ b/src/yggdrasil/udp.go
@@ -206,7 +206,7 @@ func (iface *udpInterface) handleKeys(msg []byte, addr connAddr) {
 		udpAddr := addr.toUDPAddr()
 		// Check if we're authorized to connect to this key / IP
 		// TODO monitor and always allow outgoing connections
-		if !iface.core.peers.isAuthBoxPub(&ks.box) {
+		if !iface.core.peers.isAllowedBoxPub(&ks.box) {
 			// Allow unauthorized peers if they're link-local
 			if !udpAddr.IP.IsLinkLocalUnicast() {
 				return

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -58,13 +58,6 @@ func (n *node) init(cfg *nodeConfig, logger *log.Logger) {
 		panic(err)
 	}
 	n.core.DEBUG_setIfceExpr(ifceExpr)
-	for _, pBoxStr := range cfg.PeerBoxPubs {
-		pbox, err := hex.DecodeString(pBoxStr)
-		if err != nil {
-			panic(err)
-		}
-		n.core.DEBUG_addAuthBoxPub(pbox)
-	}
 
 	logger.Println("Starting interface...")
 	n.core.DEBUG_setupAndStartGlobalTCPInterface(cfg.Listen) // Listen for peers on TCP
@@ -73,6 +66,10 @@ func (n *node) init(cfg *nodeConfig, logger *log.Logger) {
 	logger.Println("Starting admin socket...")
 	n.core.DEBUG_setupAndStartAdminInterface(cfg.AdminListen)
 	logger.Println("Started admin socket")
+	for _, pBoxStr := range cfg.PeerBoxPubs {
+		n.core.DEBUG_addAuthBoxPub(pBoxStr)
+	}
+
 	go func() {
 		if len(cfg.Peers) == 0 {
 			return

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -58,6 +58,13 @@ func (n *node) init(cfg *nodeConfig, logger *log.Logger) {
 		panic(err)
 	}
 	n.core.DEBUG_setIfceExpr(ifceExpr)
+	for _, pBoxStr := range cfg.PeerBoxPubs {
+		pbox, err := hex.DecodeString(pBoxStr)
+		if err != nil {
+			panic(err)
+		}
+		n.core.DEBUG_addAuthBoxPub(pbox)
+	}
 
 	logger.Println("Starting interface...")
 	n.core.DEBUG_setupAndStartGlobalTCPInterface(cfg.Listen) // Listen for peers on TCP

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -104,6 +104,7 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 	cfg.SigPub = hex.EncodeToString(spub[:])
 	cfg.SigPriv = hex.EncodeToString(spriv[:])
 	cfg.Peers = []string{}
+	cfg.PeerBoxPubs = []string{}
 	cfg.Multicast = true
 	cfg.LinkLocal = ""
 	cfg.IfName = core.DEBUG_GetTUNDefaultIfName()

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -66,8 +66,8 @@ func (n *node) init(cfg *nodeConfig, logger *log.Logger) {
 	logger.Println("Starting admin socket...")
 	n.core.DEBUG_setupAndStartAdminInterface(cfg.AdminListen)
 	logger.Println("Started admin socket")
-	for _, pBoxStr := range cfg.PeerBoxPubs {
-		n.core.DEBUG_addAuthBoxPub(pBoxStr)
+	for _, pBoxStr := range cfg.AllowedBoxPubs {
+		n.core.DEBUG_addAllowedBoxPub(pBoxStr)
 	}
 
 	go func() {
@@ -101,7 +101,7 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 	cfg.SigPub = hex.EncodeToString(spub[:])
 	cfg.SigPriv = hex.EncodeToString(spriv[:])
 	cfg.Peers = []string{}
-	cfg.PeerBoxPubs = []string{}
+	cfg.AllowedBoxPubs = []string{}
 	cfg.Multicast = true
 	cfg.LinkLocal = ""
 	cfg.IfName = core.DEBUG_GetTUNDefaultIfName()


### PR DESCRIPTION
This is the backwards and (mostly) forwards compatible part of adding optional authentication to peers.

It adds a `PeerBoxPubs []string` to the config, and a `addAuthBoxPub` to the admin API. When connecting to a peer, the following rules are enforced:
1. Link-local IPv6 is always allowed, unless forbidden by other options in the config (multicast, linklocal).
2. All outgoing TCP (and `socks://...`) is always allowed.
3. Authorized incoming TCP is allowed.
4. Authorized incoming and outgoing UDP is allowed.
5. Other (unauthorized) links are not allowed.

If the list of authorized keys is empty (default), then all traffic is considered to be authorized (the current default behavior).

In addition, traffic from a peer is ignored until a successful switch announcement is received. If no switch announcement has been received for some time (currently 16 seconds), then a peer will close its connection. This partly mitigates attacks where an attacker observes authorized keys from the exchange and begins key exchanges to open connections and waste resources.

More elaborate replay attacks are still possible, such as by replaying one valid connection's link protocol traffic on top of multiple spoofed connections, which should cause switch announcements to get through. It would make sense to address this as part of the breaking changes for the next release.