### PR TITLE
Use HJSON for config instead of JSON

### DIFF
--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -5,7 +5,7 @@ type NodeConfig struct {
 	Listen         string    `comment:"Listen address for peer connections (default is to listen for all\nconnections over IPv4 and IPv6)"`
 	AdminListen    string    `comment:"Listen address for admin connections (default is to listen only\nfor local connections)"`
 	Peers          []string  `comment:"List of connection strings for static peers (i.e. tcp://a.b.c.d:e)"`
-	AllowedBoxPubs []string  `comment:"List of peer BoxPubs to allow UDP incoming TCP connections from"`
+	AllowedBoxPubs []string  `comment:"List of peer BoxPubs to allow UDP incoming TCP connections from\n(if left empty/undefined then connections will be allowed by default)"`
 	BoxPub         string    `comment:"Your public encryption key (your peers may ask you for this to put\ninto their AllowedBoxPubs configuration)"`
 	BoxPriv        string    `comment:"Your private encryption key (do not share this with anyone!)"`
 	SigPub         string    `comment:"Your public signing key"`
@@ -15,11 +15,11 @@ type NodeConfig struct {
 	IfName         string    `comment:"Local network interface name for TUN/TAP adapter, or \"auto\", or \"none\""`
 	IfTAPMode      bool      `comment:"Set local network interface to TAP mode rather than TUN mode (if supported\nby your platform, option will be ignored if not)"`
 	IfMTU          int       `comment:"Maximux Transmission Unit (MTU) size for your local network interface"`
-	Net            NetConfig `comment:"Incomplete options for configuring peerings over Tor/I2P"`
+	Net            NetConfig `comment:"Extended options for interoperability with other networks"`
 }
 
 // NetConfig defines network/proxy related configuration values
 type NetConfig struct {
-	Tor TorConfig
-	I2P I2PConfig
+	Tor TorConfig `comment:"Experimental options for configuring peerings over Tor"`
+	I2P I2PConfig `comment:"Experimental options for configuring peerings over I2P"`
 }

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -2,20 +2,20 @@ package config
 
 // NodeConfig defines all configuration values needed to run a signle yggdrasil node
 type NodeConfig struct {
-	Listen         string
-	AdminListen    string
-	Peers          []string
-	AllowedBoxPubs []string
-	BoxPub         string
-	BoxPriv        string
-	SigPub         string
-	SigPriv        string
-	Multicast      bool
-	LinkLocal      string
-	IfName         string
-	IfTAPMode      bool
-	IfMTU          int
-	Net            NetConfig
+	Listen         string    `comment:"Listen address for peer connections (default is to listen for all\nconnections over IPv4 and IPv6)"`
+	AdminListen    string    `comment:"Listen address for admin connections (default is to listen only\nfor local connections)"`
+	Peers          []string  `comment:"List of connection strings for static peers (i.e. tcp://a.b.c.d:e)"`
+	AllowedBoxPubs []string  `comment:"List of peer BoxPubs to allow UDP incoming TCP connections from"`
+	BoxPub         string    `comment:"Your public encryption key (your peers may ask you for this to put\ninto their AllowedBoxPubs configuration)"`
+	BoxPriv        string    `comment:"Your private encryption key (do not share this with anyone!)"`
+	SigPub         string    `comment:"Your public signing key"`
+	SigPriv        string    `comment:"Your private signing key (do not share this with anyone!)"`
+	Multicast      bool      `comment:"Enable or disable automatic peer discovery on the same LAN using multicast"`
+	LinkLocal      string    `comment:"Regex for which interfaces multicast peer discovery should be enabled on"`
+	IfName         string    `comment:"Local network interface name for TUN/TAP adapter, or \"auto\", or \"none\""`
+	IfTAPMode      bool      `comment:"Set local network interface to TAP mode rather than TUN mode (if supported\nby your platform, option will be ignored if not)"`
+	IfMTU          int       `comment:"Maximux Transmission Unit (MTU) size for your local network interface"`
+	Net            NetConfig `comment:"Incomplete options for configuring peerings over Tor/I2P"`
 }
 
 // NetConfig defines network/proxy related configuration values

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -1,8 +1,6 @@
 package main
 
-import "bytes"
 import "encoding/hex"
-import "encoding/json"
 import "flag"
 import "fmt"
 import "io/ioutil"
@@ -25,6 +23,8 @@ import "yggdrasil"
 import "yggdrasil/config"
 
 import "github.com/kardianos/minwinsvc"
+import "github.com/neilalexander/hjson-go"
+import "github.com/mitchellh/mapstructure"
 
 type nodeConfig = config.NodeConfig
 type Core = yggdrasil.Core
@@ -112,8 +112,9 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 }
 
 func doGenconf() string {
+
 	cfg := generateConfig(false)
-	bs, err := json.MarshalIndent(cfg, "", "  ")
+	bs, err := hjson.Marshal(cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -235,10 +236,12 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		decoder := json.NewDecoder(bytes.NewReader(config))
 		cfg = generateConfig(false)
-		err = decoder.Decode(cfg)
-		if err != nil {
+		var dat map[string]interface{}
+		if err := hjson.Unmarshal(config, &dat); err != nil {
+      panic(err)
+    }
+		if err = mapstructure.Decode(dat, &cfg); err != nil {
 			panic(err)
 		}
 	case *genconf:

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -112,7 +112,6 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 }
 
 func doGenconf() string {
-
 	cfg := generateConfig(false)
 	bs, err := hjson.Marshal(cfg)
 	if err != nil {
@@ -239,8 +238,8 @@ func main() {
 		cfg = generateConfig(false)
 		var dat map[string]interface{}
 		if err := hjson.Unmarshal(config, &dat); err != nil {
-      panic(err)
-    }
+			panic(err)
+		}
 		if err = mapstructure.Decode(dat, &cfg); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
JSON does not permit comments and may not be the most user-friendly format for the Yggdrasil configuration file.

After exploring YAML, TOML and others, I propose a switch to HJSON. I have made some modifications to the [hjson-go](https://github.com/neilalexander/hjson-go) library to support inserting comments using `struct` tags, and this has also been submitted as a PR for upstream acceptance.

This PR modifies `-genconf` to produce HJSON commented output, and modifies `-useconf` and `-useconffile` to parse HJSON.

It so happens that HJSON is backward-compatible with JSON, therefore existing configuration files should continue to work in the meantime and have done in my limited testing (until some changes are made to address #75 that is).