### PR TITLE
Add ability to select specific interface by friendly name on Windows

### DIFF
--- a/src/yggdrasil/tun_windows.go
+++ b/src/yggdrasil/tun_windows.go
@@ -23,6 +23,11 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 	config := water.Config{DeviceType: water.TAP}
 	config.PlatformSpecificParams.ComponentID = "tap0901"
 	config.PlatformSpecificParams.Network = "169.254.0.1/32"
+	if ifname == "auto" {
+		config.PlatformSpecificParams.InterfaceName = ""
+	} else {
+		config.PlatformSpecificParams.InterfaceName = ifname
+	}
 	iface, err := water.New(config)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixes #30 by allowing the `IfName` attribute to be set to an adapter friendly name (as in Network Adapters in Control Panel) on Windows. This way multiple `tap0901` adapters can be used and Yggdrasil can be configured to not conflict with other software using TAP devices on the system.

If the `IfName` is set to `auto`, as is default, the first adapter found is used. 

This has required some modifications to `syscalls_windows.go` and `params_windows.go` in https://github.com/yggdrasil-network/water.