### PR TITLE
More DHT updates

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -344,20 +344,21 @@ func (a *admin) getData_getDHT() []admin_nodeInfo {
 	getDHT := func() {
 		for i := 0; i < a.core.dht.nBuckets(); i++ {
 			b := a.core.dht.getBucket(i)
-			getInfo := func(vs []*dhtInfo) {
+			getInfo := func(vs []*dhtInfo, isPeer bool) {
 				for _, v := range vs {
 					addr := *address_addrForNodeID(v.getNodeID())
 					info := admin_nodeInfo{
 						{"IP", net.IP(addr[:]).String()},
 						{"coords", fmt.Sprint(v.coords)},
 						{"bucket", fmt.Sprint(i)},
+						{"peerOnly", fmt.Sprint(isPeer)},
 						{"lastSeen", fmt.Sprint(now.Sub(v.recv))},
 					}
 					infos = append(infos, info)
 				}
 			}
-			getInfo(b.other)
-			getInfo(b.peers)
+			getInfo(b.other, false)
+			getInfo(b.peers, true)
 		}
 	}
 	a.core.router.doAdmin(getDHT)

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -10,6 +10,7 @@ import "net/url"
 import "sort"
 import "strings"
 import "strconv"
+import "time"
 
 // TODO? Make all of this JSON
 // TODO: Add authentication
@@ -339,27 +340,24 @@ func (a *admin) getData_getSwitchPeers() []admin_nodeInfo {
 
 func (a *admin) getData_getDHT() []admin_nodeInfo {
 	var infos []admin_nodeInfo
+	now := time.Now()
 	getDHT := func() {
 		for i := 0; i < a.core.dht.nBuckets(); i++ {
 			b := a.core.dht.getBucket(i)
-			for _, v := range b.other {
-				addr := *address_addrForNodeID(v.getNodeID())
-				info := admin_nodeInfo{
-					{"IP", net.IP(addr[:]).String()},
-					{"coords", fmt.Sprint(v.coords)},
-					{"bucket", fmt.Sprint(i)},
+			getInfo := func(vs []*dhtInfo) {
+				for _, v := range vs {
+					addr := *address_addrForNodeID(v.getNodeID())
+					info := admin_nodeInfo{
+						{"IP", net.IP(addr[:]).String()},
+						{"coords", fmt.Sprint(v.coords)},
+						{"bucket", fmt.Sprint(i)},
+						{"lastSeen", fmt.Sprint(now.Sub(v.recv))},
+					}
+					infos = append(infos, info)
 				}
-				infos = append(infos, info)
 			}
-			for _, v := range b.peers {
-				addr := *address_addrForNodeID(v.getNodeID())
-				info := admin_nodeInfo{
-					{"IP", net.IP(addr[:]).String()},
-					{"coords", fmt.Sprint(v.coords)},
-					{"bucket", fmt.Sprint(i)},
-				}
-				infos = append(infos, info)
-			}
+			getInfo(b.other)
+			getInfo(b.peers)
 		}
 	}
 	a.core.router.doAdmin(getDHT)

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -77,7 +77,8 @@ func (r *router) mainLoop() {
 		case p := <-r.send:
 			r.sendPacket(p)
 		case info := <-r.core.dht.peers:
-			r.core.dht.insertIfNew(info, true)
+			r.core.dht.insertIfNew(info, false) // Insert as a normal node
+			r.core.dht.insertIfNew(info, true)  // Insert as a peer
 		case <-r.reset:
 			r.core.sessions.resetInits()
 			r.core.dht.reset()

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -84,7 +84,7 @@ func (s *searches) sendSearch(info *searchInfo) {
 }
 
 func (s *searches) handleSearchReq(req *searchReq) {
-	lookup := s.core.dht.lookup(&req.dest)
+	lookup := s.core.dht.lookup(&req.dest, false)
 	sent := false
 	//fmt.Println("DEBUG len:", len(lookup))
 	for _, info := range lookup {


### PR DESCRIPTION
Adds the time since a node was last seen by the DHT (ping response or, in the case of peers, manually inserted by the spanning tree).

Watching the times carefully (`watch "echo getDHT | nc localhost 9001"`), I saw that peers would eventually time out. Tracked it down to a combination of the DHT's `insertIfNew` and `insert` functions. Long story short, new peers could be inserted, but the ping response from an existing peer would never update it's time or reset the missed ping counter to 0, so they would eventually get dropped and re-added. Now, peers get added as normal nodes in the bucket, unless the bucket is already full with other/better nodes. If it's already full, then they get inserted into the separate bucket.peers slice, and get re-inserted every time the tree tries to update them (once every few seconds). This seems to fix the bug. Since nodes in the bucket.peers slice have a different meaning for timing, a `peerOnly` line was added to the getDHT results, to mark nodes that would not be in the DHT if they weren't a peer.

When adding a new non-peer node, the DHT sets the time the node was last seen to 1 hour in the past. This causes new nodes to be pinged for the first time much earlier. When a node connects to an existing network, this makes bootstrapping go a *lot* faster.

There's still some ugly bits: if a peer disconnects (from your node, not necessarily from the network), it will eventually hit the 1 minute of silence mark and get pinged several times. One way or another, it'll get purged from the DHT, but that will be either after some pointless ping packets, or by moving to the bucket.other slice, evicting a better node, and then promptly being replaced the next time anything happens with that bucket. I'll need to think more about the best way to fix this, but it should be nearly harmless for now.