### PR TITLE
Track TX/RX bytes over session and if MTU was adjusted, adjust MTU exchange behaviour, send session pings on TUN/TAP change

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -374,6 +374,9 @@ func (a *admin) getData_getSessions() []admin_nodeInfo {
 				{"IP", net.IP(sinfo.theirAddr[:]).String()},
 				{"coords", fmt.Sprint(sinfo.coords)},
 				{"MTU", fmt.Sprint(sinfo.getMTU())},
+				{"wasMTUFixed", fmt.Sprint(sinfo.wasMTUFixed)},
+				{"bytesSent", fmt.Sprint(sinfo.bytesSent)},
+				{"bytesRecvd", fmt.Sprint(sinfo.bytesRecvd)},
 			}
 			infos = append(infos, info)
 		}

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -280,6 +280,17 @@ func (a *admin) startTunWithMTU(ifname string, iftapmode bool, ifmtu int) error 
 		if err != nil {
 			return err
 		}
+		// If we have open sessions then we need to notify them
+		// that our MTU has now changed
+		for _, sinfo := range a.core.sessions.sinfos {
+			if ifname == "none" {
+				sinfo.myMTU = 0
+			} else {
+				sinfo.myMTU = uint16(ifmtu)
+			}
+			a.core.sessions.sendPingPong(sinfo, false)
+		}
+		// Aaaaand... go!
 		go a.core.tun.read()
 	}
 	go a.core.tun.write()

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -65,7 +65,7 @@ func (s *sessionInfo) update(p *sessionPing) bool {
 		s.theirNonce = boxNonce{}
 		s.nonceMask = 0
 	}
-	if p.mtu >= 1280 {
+	if p.mtu >= 1280 || p.mtu == 0 {
 		s.theirMTU = p.mtu
 	}
 	s.coords = append([]byte{}, p.coords...)
@@ -313,6 +313,9 @@ func (n *boxNonce) minus(m *boxNonce) int64 {
 }
 
 func (sinfo *sessionInfo) getMTU() uint16 {
+	if sinfo.theirMTU == 0 || sinfo.myMTU == 0 {
+		return 0
+	}
 	if sinfo.theirMTU < sinfo.myMTU {
 		return sinfo.theirMTU
 	}


### PR DESCRIPTION
This exposes three new fields to the `getSession` admin socket call:

- `bytesSent` shows the number of real traffic bytes sent over a session (not including overheads)
- `bytesRecvd` shows the number of real traffic bytes received over a session (not including overheads)
- `wasMTUFixed` shows if the MTU had to be adjusted to a lower value as a result of read errors