### PR TITLE
Add uptime and bytes sent/recvd to  the `peer` struct and getPeers results

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -10,6 +10,7 @@ import "net/url"
 import "sort"
 import "strings"
 import "strconv"
+import "sync/atomic"
 import "time"
 
 // TODO? Make all of this JSON
@@ -322,6 +323,9 @@ func (a *admin) getData_getPeers() []admin_nodeInfo {
 		info := admin_nodeInfo{
 			{"IP", net.IP(addr[:]).String()},
 			{"port", fmt.Sprint(port)},
+			{"uptime", fmt.Sprint(time.Since(p.firstSeen))},
+			{"bytesSent", fmt.Sprint(atomic.LoadUint64(&p.bytesSent))},
+			{"bytesRecvd", fmt.Sprint(atomic.LoadUint64(&p.bytesRecvd))},
 		}
 		peerInfos = append(peerInfos, info)
 	}


### PR DESCRIPTION
This is a mostly-trivial change to add a peer's uptime and bytes sent/received to the response of getPeers (and start tracking those things in the `peer` struct).

It's *technically* wrong, since it's possible that a packet could drop after `peer.sendPacket(packet)` is called and before it gets written to the wire, but that should be uncommon in practice. We can move the code there and change the internal workings at some point if it makes sense to do so. Note that it's also missing a little padding from the TCP stream (4 bytes + a variable packet length) and application-level UDP packet headers (3 bytes per chunk), as well as transport and IP overhead per packet, since those are harder to account for. I think these *should* be small, relative to typical packet sizes, but it means the running totals aren't an accurate picture of how much bandwidth is used down to the byte.

One annoying minor point, this adds an atomic add operation to each packet send, which, while it should be negligible overhead on most platforms, it's still more overhead than isolating the updated variable to one goroutine (e.g. the workers in tcp.go and upd.go) and then synchronizing only on reads. 

This is enough to calculate the average upload/download bandwidth used. Peer 0 is still the self peer, where all routed packets and DHT/search traffic are sent, so subtracting that from the per-peer numbers *should* give an estimate of the total bandwidth used by the per-peer spanning-tree/switch and keep-alive traffic.