### PR TITLE
Human-readable formatting in yggdrasilctl

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -249,7 +249,7 @@ func (a *admin) handleRequest(conn net.Conn) {
 
 		// Decode the input
 		if err := decoder.Decode(&recv); err != nil {
-		//	fmt.Println("Admin socket JSON decode error:", err)
+			//	fmt.Println("Admin socket JSON decode error:", err)
 			return
 		}
 
@@ -301,7 +301,7 @@ func (a *admin) handleRequest(conn net.Conn) {
 
 		// Send the response back
 		if err := encoder.Encode(&send); err != nil {
-		//	fmt.Println("Admin socket JSON encode error:", err)
+			//	fmt.Println("Admin socket JSON encode error:", err)
 			return
 		}
 

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -46,7 +46,7 @@ func (a *admin) init(c *Core, listenaddr string) {
 	a.addHandler("help", nil, func(in admin_info) (admin_info, error) {
 		handlers := make(map[string]interface{})
 		for _, handler := range a.handlers {
-			handlers[handler.name] = admin_info{ "fields": handler.args }
+			handlers[handler.name] = admin_info{"fields": handler.args}
 		}
 		return admin_info{"help": handlers}, nil
 	})
@@ -57,7 +57,7 @@ func (a *admin) init(c *Core, listenaddr string) {
 		self := a.getData_getSelf().asMap()
 		ip := fmt.Sprint(self["ip"])
 		delete(self, "ip")
-		return admin_info{"self": admin_info{ ip: self }}, nil
+		return admin_info{"self": admin_info{ip: self}}, nil
 	})
 	a.addHandler("getPeers", []string{}, func(in admin_info) (admin_info, error) {
 		sort := "ip"
@@ -136,7 +136,7 @@ func (a *admin) init(c *Core, listenaddr string) {
 	a.addHandler("getTunTap", []string{}, func(in admin_info) (r admin_info, e error) {
 		defer func() {
 			recover()
-			r = admin_info{ "tuntap": admin_info{ "none": admin_info{ } } }
+			r = admin_info{"none": admin_info{}}
 			e = nil
 		}()
 
@@ -278,7 +278,7 @@ func (a *admin) handleRequest(conn net.Conn) {
 					if _, ok := recv[arg]; !ok {
 						send = admin_info{
 							"status":    "error",
-							"error":     "Expected field missing",
+							"error":     "Expected field missing: " + arg,
 							"expecting": arg,
 						}
 						break handlers

--- a/yggdrasilctl.go
+++ b/yggdrasilctl.go
@@ -134,6 +134,27 @@ func main() {
 					fmt.Println("TAP mode:", tap_mode)
 				}
 			}
+		case "addPeer", "removePeer":
+			if _, ok := res["added"]; ok {
+				for _, v := range res["added"].([]interface{}) {
+					fmt.Println("Peer added:", fmt.Sprint(v))
+				}
+			}
+			if _, ok := res["not_added"]; ok {
+				for _, v := range res["not_added"].([]interface{}) {
+					fmt.Println("Peer not added:", fmt.Sprint(v))
+				}
+			}
+			if _, ok := res["removed"]; ok {
+				for _, v := range res["removed"].([]interface{}) {
+					fmt.Println("Peer removed:", fmt.Sprint(v))
+				}
+			}
+			if _, ok := res["not_removed"]; ok {
+				for _, v := range res["not_removed"].([]interface{}) {
+					fmt.Println("Peer not removed:", fmt.Sprint(v))
+				}
+			}
 		default:
 			if json, err := json.MarshalIndent(recv["response"], "", "  "); err == nil {
 				fmt.Println(string(json))

--- a/yggdrasilctl.go
+++ b/yggdrasilctl.go
@@ -13,11 +13,12 @@ type admin_info map[string]interface{}
 
 func main() {
 	server := flag.String("endpoint", "localhost:9001", "Admin socket endpoint")
+	injson := flag.Bool("json", false, "Output in JSON format")
 	flag.Parse()
 	args := flag.Args()
 
 	if len(args) == 0 {
-		fmt.Println("usage:", os.Args[0], "[-endpoint=localhost:9001] command [key=value] [...]")
+		fmt.Println("usage:", os.Args[0], "[-endpoint=localhost:9001] [-json] command [key=value] [...]")
 		fmt.Println("example:", os.Args[0], "getPeers")
 		fmt.Println("example:", os.Args[0], "setTunTap name=auto mtu=1500 tap_mode=false")
 		fmt.Println("example:", os.Args[0], "-endpoint=localhost:9001 getDHT")
@@ -77,6 +78,13 @@ func main() {
 		}
 		req := recv["request"].(map[string]interface{})
 		res := recv["response"].(map[string]interface{})
+
+		if *injson {
+			if json, err := json.MarshalIndent(res, "", "  "); err == nil {
+				fmt.Println(string(json))
+			}
+			os.Exit(0)
+		}
 
 		switch req["request"] {
 		case "dot":

--- a/yggdrasilctl.go
+++ b/yggdrasilctl.go
@@ -15,13 +15,13 @@ func main() {
 	flag.Parse()
 	args := flag.Args()
 
-  if len(args) == 0 {
-    fmt.Println("usage:", os.Args[0], "[-endpoint=localhost:9001] command [key=value] [...]")
-    fmt.Println("example:", os.Args[0], "getPeers")
-    fmt.Println("example:", os.Args[0], "setTunTap name=auto mtu=1500 tap_mode=false")
-    fmt.Println("example:", os.Args[0], "-endpoint=localhost:9001 getDHT")
-    return
-  }
+	if len(args) == 0 {
+		fmt.Println("usage:", os.Args[0], "[-endpoint=localhost:9001] command [key=value] [...]")
+		fmt.Println("example:", os.Args[0], "getPeers")
+		fmt.Println("example:", os.Args[0], "setTunTap name=auto mtu=1500 tap_mode=false")
+		fmt.Println("example:", os.Args[0], "-endpoint=localhost:9001 getDHT")
+		return
+	}
 
 	conn, err := net.Dial("tcp", *server)
 	if err != nil {
@@ -58,16 +58,16 @@ func main() {
 		panic(err)
 	}
 	if err := decoder.Decode(&recv); err == nil {
-    if _, ok := recv["request"]; !ok {
-      fmt.Println("Missing request")
-      return
-    }
-    if _, ok := recv["response"]; !ok {
-      fmt.Println("Missing response")
-      return
-    }
-    req := recv["request"].(map[string]interface{})
-    res := recv["response"].(map[string]interface{})
+		if _, ok := recv["request"]; !ok {
+			fmt.Println("Missing request")
+			return
+		}
+		if _, ok := recv["response"]; !ok {
+			fmt.Println("Missing response")
+			return
+		}
+		req := recv["request"].(map[string]interface{})
+		res := recv["response"].(map[string]interface{})
 		switch req["request"] {
 		case "dot":
 			fmt.Println(res["dot"])
@@ -78,8 +78,8 @@ func main() {
 		}
 	}
 
-  if v, ok := recv["status"]; ok && v == "error" {
-    os.Exit(1)
-  }
-  os.Exit(0)
+	if v, ok := recv["status"]; ok && v == "error" {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }


### PR DESCRIPTION
This adds human-readable formatting to `yggdrasilctl`, as well as the option to get raw JSON instead using the `-json` argument if desired.

Some example output:
```
$ ./yggdrasilctl getPeers
                                         bytes_recvd  bytes_sent  port  uptime
fd02:99b5:8f40:b678:ed4e:199f:f165:e366  154420       160072      1     20m7.696346366s
fd1f:f37f:3bf6:d516:e1:7bcf:59b8:3efd    91515        104819      2     10m30.325521459s
fd00:baf1:6864:d945:1f44:b820:6bb5:98a7  175863       158238      0     20m7.699687139s
```
```
$ ./yggdrasilctl getDHT
                                         bucket  coords       last_seen      peer_only
fd00:9586:4d69:f6ef:5184:a8e8:ba8b:c88d  3       [1 4]        40.352498266s  false
fd00:97a7:2568:7e53:e154:6c8a:46bb:a5d4  3       [6 4 3]      43.386410149s  false
fd00:e210:c279:26a9:3224:f86a:4a80:e0e8  2       [6 1 2]      37.339011561s  false
fd02:99b5:8f40:b678:ed4e:199f:f165:e366  0       [6 1]        5.430250786s   false
fd02:b2b1:f598:b926:52c5:7ea2:fa15:8d2c  0       [2 1 1 1 2]  55.352987858s  false
fd1f:f37f:3bf6:d516:e1:7bcf:59b8:3efd    0       [6]          39.224789ms    true
fd00:3769:3ad7:957f:7206:25ac:cbaa:540d  1       [5 3 3]      40.985326069s  false
fd00:3d55:c634:305d:7454:c02b:7d18:c735  1       [6 4]        46.387979644s  false
```
```
$ ./yggdrasilctl getTunTap
Interface name: none
```