### PR TITLE
Show IPv6 address and subnet on startup

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -249,7 +249,7 @@ func (a *admin) handleRequest(conn net.Conn) {
 
 		// Decode the input
 		if err := decoder.Decode(&recv); err != nil {
-		//	fmt.Println("Admin socket JSON decode error:", err)
+			//	fmt.Println("Admin socket JSON decode error:", err)
 			return
 		}
 
@@ -301,7 +301,7 @@ func (a *admin) handleRequest(conn net.Conn) {
 
 		// Send the response back
 		if err := encoder.Encode(&send); err != nil {
-		//	fmt.Println("Admin socket JSON encode error:", err)
+			//	fmt.Println("Admin socket JSON encode error:", err)
 			return
 		}
 

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -62,3 +62,11 @@ func (c *Core) GetNodeID() *NodeID {
 func (c *Core) GetTreeID() *TreeID {
 	return getTreeID(&c.sigPub)
 }
+
+func (c *Core) GetAddress() *address {
+	return address_addrForNodeID(c.GetNodeID())
+}
+
+func (c *Core) GetSubnet() *subnet {
+	return address_subnetForNodeID(c.GetNodeID())
+}

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -272,6 +272,11 @@ func main() {
 		n.core.DEBUG_stopTun()
 	}()
 	logger.Println("Started...")
+	address := (*n.core.GetAddress())[:]
+	subnet := (*n.core.GetSubnet())[:]
+	subnet = append(subnet, 0, 0, 0, 0, 0, 0, 0, 0)
+	logger.Printf("Your IPv6 address is %s", net.IP(address).String())
+	logger.Printf("Your IPv6 subnet is %s/64", net.IP(subnet).String())
 	if cfg.Multicast {
 		addr, err := net.ResolveUDPAddr("udp", multicastAddr)
 		if err != nil {

--- a/yggdrasilctl.go
+++ b/yggdrasilctl.go
@@ -15,13 +15,13 @@ func main() {
 	flag.Parse()
 	args := flag.Args()
 
-  if len(args) == 0 {
-    fmt.Println("usage:", os.Args[0], "[-endpoint=localhost:9001] command [key=value] [...]")
-    fmt.Println("example:", os.Args[0], "getPeers")
-    fmt.Println("example:", os.Args[0], "setTunTap name=auto mtu=1500 tap_mode=false")
-    fmt.Println("example:", os.Args[0], "-endpoint=localhost:9001 getDHT")
-    return
-  }
+	if len(args) == 0 {
+		fmt.Println("usage:", os.Args[0], "[-endpoint=localhost:9001] command [key=value] [...]")
+		fmt.Println("example:", os.Args[0], "getPeers")
+		fmt.Println("example:", os.Args[0], "setTunTap name=auto mtu=1500 tap_mode=false")
+		fmt.Println("example:", os.Args[0], "-endpoint=localhost:9001 getDHT")
+		return
+	}
 
 	conn, err := net.Dial("tcp", *server)
 	if err != nil {
@@ -58,16 +58,16 @@ func main() {
 		panic(err)
 	}
 	if err := decoder.Decode(&recv); err == nil {
-    if _, ok := recv["request"]; !ok {
-      fmt.Println("Missing request")
-      return
-    }
-    if _, ok := recv["response"]; !ok {
-      fmt.Println("Missing response")
-      return
-    }
-    req := recv["request"].(map[string]interface{})
-    res := recv["response"].(map[string]interface{})
+		if _, ok := recv["request"]; !ok {
+			fmt.Println("Missing request")
+			return
+		}
+		if _, ok := recv["response"]; !ok {
+			fmt.Println("Missing response")
+			return
+		}
+		req := recv["request"].(map[string]interface{})
+		res := recv["response"].(map[string]interface{})
 		switch req["request"] {
 		case "dot":
 			fmt.Println(res["dot"])
@@ -78,8 +78,8 @@ func main() {
 		}
 	}
 
-  if v, ok := recv["status"]; ok && v == "error" {
-    os.Exit(1)
-  }
-  os.Exit(0)
+	if v, ok := recv["status"]; ok && v == "error" {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }


### PR DESCRIPTION
This is a very minor fix to expose the IPv6 address and subnet from `Core`, which allows both to be displayed on stdout at startup.

This is really just for user-friendliness.

Sample output:
```
2018/05/21 16:15:13 Your IPv6 address is fd00:baf1:6864:d945:1f44:b820:6bb5:98a7
2018/05/21 16:15:13 Your IPv6 subnet is fd80:baf1:6864:d945::/64
```