### PR TITLE
Add getMulticastInterfaces and getSelf to yggdrasilctl

### DIFF
--- a/yggdrasilctl.go
+++ b/yggdrasilctl.go
@@ -155,6 +155,16 @@ func main() {
 					fmt.Println("TAP mode:", tap_mode)
 				}
 			}
+		case "getSelf":
+			for k, v := range res["self"].(map[string]interface{}) {
+				fmt.Println("address:", k)
+				if subnet, ok := v.(map[string]interface{})["subnet"].(string); ok {
+					fmt.Println("subnet:", subnet)
+				}
+				if coords, ok := v.(map[string]interface{})["coords"].(string); ok {
+					fmt.Println("coords:", coords)
+				}
+			}
 		case "addPeer", "removePeer", "addAllowedEncryptionPublicKey", "removeAllowedEncryptionPublicKey":
 			if _, ok := res["added"]; ok {
 				for _, v := range res["added"].([]interface{}) {
@@ -184,6 +194,17 @@ func main() {
 			} else {
 				fmt.Println("Connections are allowed only from the following public box keys:")
 				for _, v := range res["allowed_box_pubs"].([]interface{}) {
+					fmt.Println("-", v)
+				}
+			}
+		case "getMulticastInterfaces":
+			if _, ok := res["multicast_interfaces"]; !ok {
+				fmt.Println("No multicast interfaces found")
+			} else if res["multicast_interfaces"] == nil {
+				fmt.Println("No multicast interfaces found")
+			} else {
+				fmt.Println("Multicast peer discovery is active on:")
+				for _, v := range res["multicast_interfaces"].([]interface{}) {
 					fmt.Println("-", v)
 				}
 			}

--- a/yggdrasilctl.go
+++ b/yggdrasilctl.go
@@ -157,12 +157,12 @@ func main() {
 			}
 		case "getSelf":
 			for k, v := range res["self"].(map[string]interface{}) {
-				fmt.Println("address:", k)
+				fmt.Println("IPv6 address:", k)
 				if subnet, ok := v.(map[string]interface{})["subnet"].(string); ok {
-					fmt.Println("subnet:", subnet)
+					fmt.Println("IPv6 subnet:", subnet)
 				}
 				if coords, ok := v.(map[string]interface{})["coords"].(string); ok {
-					fmt.Println("coords:", coords)
+					fmt.Println("Coords:", coords)
 				}
 			}
 		case "addPeer", "removePeer", "addAllowedEncryptionPublicKey", "removeAllowedEncryptionPublicKey":


### PR DESCRIPTION
This adds the IPv6 subnet to the `getSelf` lookup, and adds pretty `getSelf` formatting to `yggdrasilctl`.

This also adds `getMulticastInterfaces`, which shows which interfaces multicast peer discovery is active on, and pretty formatting in `yggdrasilctl`.