### PR TITLE
Fix MulticastInterfaces and accidental truncation of addresses on macOS/BSD

### DIFF
--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -16,6 +16,10 @@ type multicast struct {
 func (m *multicast) init(core *Core) {
 	m.core = core
 	m.groupAddr = "[ff02::114]:9001"
+	// Check if we've been given any expressions
+	if len(m.core.ifceExpr) == 0 {
+		return
+	}
 	// Ask the system for network interfaces
 	allifaces, err := net.Interfaces()
 	if err != nil {

--- a/src/yggdrasil/tun_bsd.go
+++ b/src/yggdrasil/tun_bsd.go
@@ -137,7 +137,7 @@ func (tun *tunDevice) setupAddress(addr string) error {
 	copy(ar.ifr_name[:], tun.iface.Name())
 	ar.ifru_addr.sin6_len = uint8(unsafe.Sizeof(ar.ifru_addr))
 	ar.ifru_addr.sin6_family = unix.AF_INET6
-	parts := strings.Split(strings.TrimRight(addr, "/8"), ":")
+	parts := strings.Split(strings.Split(addr, "/")[0], ":")
 	for i := 0; i < 8; i++ {
 		addr, _ := strconv.ParseUint(parts[i], 16, 16)
 		b := make([]byte, 16)

--- a/src/yggdrasil/tun_darwin.go
+++ b/src/yggdrasil/tun_darwin.go
@@ -84,7 +84,7 @@ func (tun *tunDevice) setupAddress(addr string) error {
 
 	ar.ifra_addr.sin6_len = uint8(unsafe.Sizeof(ar.ifra_addr))
 	ar.ifra_addr.sin6_family = unix.AF_INET6
-	parts := strings.Split(strings.TrimRight(addr, "/8"), ":")
+	parts := strings.Split(strings.Split(addr, "/")[0], ":")
 	for i := 0; i < 8; i++ {
 		addr, _ := strconv.ParseUint(parts[i], 16, 16)
 		b := make([]byte, 16)

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -91,9 +91,11 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 	cfg := nodeConfig{}
 	if isAutoconf {
 		cfg.Listen = "[::]:0"
+		cfg.MulticastInterfaces = []string{".*"}
 	} else {
 		r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
 		cfg.Listen = fmt.Sprintf("[::]:%d", r1.Intn(65534-32768)+32768)
+		cfg.MulticastInterfaces = []string{}
 	}
 	cfg.AdminListen = "[::1]:9001"
 	cfg.EncryptionPublicKey = hex.EncodeToString(bpub[:])
@@ -102,7 +104,6 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 	cfg.SigningPrivateKey = hex.EncodeToString(spriv[:])
 	cfg.Peers = []string{}
 	cfg.AllowedEncryptionPublicKeys = []string{}
-	cfg.MulticastInterfaces = []string{".*"}
 	cfg.IfName = core.DEBUG_GetTUNDefaultIfName()
 	cfg.IfMTU = core.DEBUG_GetTUNDefaultIfMTU()
 	cfg.IfTAPMode = core.DEBUG_GetTUNDefaultIfTAPMode()
@@ -112,6 +113,7 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 
 func doGenconf() string {
 	cfg := generateConfig(false)
+	cfg.MulticastInterfaces = append(cfg.MulticastInterfaces, ".*")
 	bs, err := hjson.Marshal(cfg)
 	if err != nil {
 		panic(err)
@@ -151,12 +153,12 @@ func main() {
 		// For now we will do a little bit to help the user adjust their
 		// configuration to match the new configuration format
 		changes := map[string]string{
-			"Multicast": "",
-			"LinkLocal": "MulticastInterfaces",
-			"BoxPub": "EncryptionPublicKey",
-			"BoxPriv": "EncryptionPrivateKey",
-			"SigPub": "SigningPublicKey",
-			"SigPriv": "SigningPrivateKey",
+			"Multicast":      "",
+			"LinkLocal":      "MulticastInterfaces",
+			"BoxPub":         "EncryptionPublicKey",
+			"BoxPriv":        "EncryptionPrivateKey",
+			"SigPub":         "SigningPublicKey",
+			"SigPriv":        "SigningPrivateKey",
 			"AllowedBoxPubs": "AllowedEncryptionPublicKeys",
 		}
 		for from, to := range changes {


### PR DESCRIPTION
This fixes a couple of bugs:

- Since `MulticastInterfaces` works by using `append`, the `MulticastInterfaces` must be empty by default or else multicast cannot be disabled. Beforehand, `.*` was always being added to the default configuration. This fixes this.
- On macOS, IPv6 addresses ending with `8` would be truncated by a faulty `strings.TrimRight` statement. This has been fixed.