### PR TITLE
hjson bugfixes

### DIFF
--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -284,9 +284,10 @@ func (c *Core) DEBUG_init(bpub []byte,
 ////////////////////////////////////////////////////////////////////////////////
 
 func (c *Core) DEBUG_setupAndStartGlobalUDPInterface(addrport string) {
-	iface := udpInterface{}
-	iface.init(c, addrport)
-	c.udp = &iface
+	if err := c.udp.init(c, addrport); err != nil {
+		c.log.Println("Failed to start UDP interface:", err)
+		panic(err)
+	}
 }
 
 func (c *Core) DEBUG_getGlobalUDPAddr() *net.UDPAddr {
@@ -337,9 +338,10 @@ func (c *Core) DEBUG_addSOCKSConn(socksaddr, peeraddr string) {
 
 //*
 func (c *Core) DEBUG_setupAndStartGlobalTCPInterface(addrport string) {
-	iface := tcpInterface{}
-	iface.init(c, addrport)
-	c.tcp = &iface
+	if err := c.tcp.init(c, addrport); err != nil {
+		c.log.Println("Failed to start TCP interface:", err)
+		panic(err)
+	}
 }
 
 func (c *Core) DEBUG_getGlobalTCPAddr() *net.TCPAddr {

--- a/src/yggdrasil/udp.go
+++ b/src/yggdrasil/udp.go
@@ -65,18 +65,19 @@ type udpKeys struct {
 	sig sigPubKey
 }
 
-func (iface *udpInterface) init(core *Core, addr string) {
+func (iface *udpInterface) init(core *Core, addr string) (err error) {
 	iface.core = core
 	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
-		panic(err)
+		return
 	}
 	iface.sock, err = net.ListenUDP("udp", udpAddr)
 	if err != nil {
-		panic(err)
+		return
 	}
 	iface.conns = make(map[connAddr]*connInfo)
 	go iface.reader()
+	return
 }
 
 func (iface *udpInterface) sendKeys(addr connAddr) {

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -123,7 +123,8 @@ func doGenconf() string {
 var pprof = flag.Bool("pprof", false, "Run pprof, see http://localhost:6060/debug/pprof/")
 var genconf = flag.Bool("genconf", false, "print a new config to stdout")
 var useconf = flag.Bool("useconf", false, "read config from stdin")
-var normaliseconf = flag.Bool("normaliseconf", false, "use in combination with -useconf, outputs your configuration normalised")
+var useconffile = flag.String("useconffile", "", "read config from specified file path")
+var normaliseconf = flag.Bool("normaliseconf", false, "use in combination with either -useconf or -useconffile, outputs your configuration normalised")
 var autoconf = flag.Bool("autoconf", false, "automatic mode (dynamic IP, peer with IPv6 neighbors)")
 
 func main() {
@@ -132,10 +133,14 @@ func main() {
 	switch {
 	case *autoconf:
 		cfg = generateConfig(true)
-	case *useconf:
+	case *useconffile != "" || *useconf:
 		var config []byte
 		var err error
-		config, err = ioutil.ReadAll(os.Stdin)
+		if *useconffile != "" {
+			config, err = ioutil.ReadFile(*useconffile)
+		} else {
+			config, err = ioutil.ReadAll(os.Stdin)
+		}
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
When loading a config file through hjson, convert it to json and then load the json into the config struct. This correctly allows missing values to take on the defaults normally associated with genconf.