### PR TITLE
Admin "dot" style changes

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -605,7 +605,7 @@ func (a *admin) getResponse_dot() []byte {
 			}
 			newInfo.name = "?"
 			newInfo.key = key
-			newInfo.options = "style=filled"
+			newInfo.options = "style=dashed"
 			infos[key] = newInfo
 		}
 	}

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -568,21 +568,25 @@ func (a *admin) getResponse_dot() []byte {
 	}
 	infos := make(map[string]nodeInfo)
 	// First fill the tree with all known nodes, no parents
-	addInfo := func(nodes []admin_nodeInfo, options string) {
+	addInfo := func(nodes []admin_nodeInfo, options string, tag string) {
 		for _, node := range nodes {
 			n := node.asMap()
 			info := nodeInfo{
-				name:    n["ip"].(string),
 				key:     n["coords"].(string),
 				options: options,
+			}
+			if len(tag) > 0 {
+				info.name = fmt.Sprintf("%s\n%s", n["ip"].(string), tag)
+			} else {
+				info.name = n["ip"].(string)
 			}
 			infos[info.key] = info
 		}
 	}
-	addInfo(sessions, "fillcolor=\"#acf3fd\" style=filled") // blue
-	addInfo(dht, "fillcolor=\"#ffffff\" style=filled") // white
-	addInfo(peers, "fillcolor=\"#ffffb5\" style=filled") // yellow
-	addInfo(append([]admin_nodeInfo(nil), *self), "fillcolor=\"#a5ff8a\" style=filled") // green
+	addInfo(dht, "fillcolor=\"#ffffff\" style=filled", "Known in DHT") // white
+	addInfo(sessions, "fillcolor=\"#acf3fd\" style=filled", "Open session") // blue
+	addInfo(peers, "fillcolor=\"#ffffb5\" style=filled", "Connected peer") // yellow
+	addInfo(append([]admin_nodeInfo(nil), *self), "fillcolor=\"#a5ff8a\" style=filled", "This node") // green
 	// Get coords as a slice of strings, FIXME? this looks very fragile
 	coordSlice := func(coords string) []string {
 		tmp := strings.Replace(coords, "[", "", -1)

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -579,10 +579,10 @@ func (a *admin) getResponse_dot() []byte {
 			infos[info.key] = info
 		}
 	}
-	addInfo(sessions, "fillcolor=indianred style=filled")
-	addInfo(dht, "fillcolor=lightblue style=filled")
-	addInfo(peers, "fillcolor=palegreen style=filled")
-	addInfo(append([]admin_nodeInfo(nil), *self), "")
+	addInfo(sessions, "fillcolor=\"#acf3fd\" style=filled") // blue
+	addInfo(dht, "fillcolor=\"#ffffff\" style=filled") // white
+	addInfo(peers, "fillcolor=\"#ffffb5\" style=filled") // yellow
+	addInfo(append([]admin_nodeInfo(nil), *self), "fillcolor=\"#a5ff8a\" style=filled") // green
 	// Get coords as a slice of strings, FIXME? this looks very fragile
 	coordSlice := func(coords string) []string {
 		tmp := strings.Replace(coords, "[", "", -1)


### PR DESCRIPTION
The dot graph is a little bland. It shows you the nodes you know about, but says nothing about why you know them.

This change styles nodes differently based on why we know them. Currently they're colored as follows: nodes that we only know about because we have an active session are red, nodes we have in the DHT are blue, peers are green, the self node is white, and anything missing but inferred (`?`) is shaded.

I have no idea if that's something we want. If it is, then I have no idea if these color choices are appropriate (we should make sure that the text is easy to read, including for people with abnormal color vision, and maybe introduce a shape difference too).