### PR TITLE
Use new switchMsg format

### DIFF
--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -162,7 +162,9 @@ func testPaths(store map[[32]byte]*Node) bool {
 			for here := source; here != dest; {
 				temp++
 				if temp > 4096 {
-					panic("Loop?")
+					fmt.Println("Loop?")
+					time.Sleep(time.Second)
+					return false
 				}
 				nextPort := here.core.DEBUG_switchLookup(coords)
 				// First check if "here" is accepting packets from the previous node
@@ -195,7 +197,7 @@ func testPaths(store map[[32]byte]*Node) bool {
 						source.index, source.core.DEBUG_getLocator(),
 						here.index, here.core.DEBUG_getLocator(),
 						dest.index, dest.core.DEBUG_getLocator())
-					here.core.DEBUG_getSwitchTable().DEBUG_dumpTable()
+					//here.core.DEBUG_getSwitchTable().DEBUG_dumpTable()
 				}
 				if here != source {
 					// This is sufficient to check for routing loops or blackholes

--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -160,17 +160,11 @@ func testPaths(store map[[32]byte]*Node) bool {
 			ttl := ^uint64(0)
 			oldTTL := ttl
 			for here := source; here != dest; {
-				if ttl == 0 {
-					fmt.Println("Drop:", source.index, here.index, dest.index, oldTTL)
-					return false
-				}
 				temp++
 				if temp > 4096 {
 					panic("Loop?")
 				}
-				oldTTL = ttl
-				nextPort, newTTL := here.core.DEBUG_switchLookup(coords, ttl)
-				ttl = newTTL
+				nextPort := here.core.DEBUG_switchLookup(coords)
 				// First check if "here" is accepting packets from the previous node
 				// TODO explain how this works
 				ports := here.core.DEBUG_getPeers().DEBUG_getPorts()
@@ -208,7 +202,7 @@ func testPaths(store map[[32]byte]*Node) bool {
 					//break
 				}
 				if here == next {
-					fmt.Println("Drop2:", source.index, here.index, dest.index, oldTTL)
+					fmt.Println("Drop:", source.index, here.index, dest.index, oldTTL)
 					return false
 				}
 				here = next
@@ -231,7 +225,7 @@ func stressTest(store map[[32]byte]*Node) {
 	start := time.Now()
 	for _, source := range store {
 		for _, coords := range dests {
-			source.core.DEBUG_switchLookup(coords, ^uint64(0))
+			source.core.DEBUG_switchLookup(coords)
 			lookups++
 		}
 	}

--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -207,6 +207,10 @@ func testPaths(store map[[32]byte]*Node) bool {
 					// This is sufficient to check for routing loops or blackholes
 					//break
 				}
+				if here == next {
+					fmt.Println("Drop2:", source.index, here.index, dest.index, oldTTL)
+					return false
+				}
 				here = next
 			}
 		}

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -103,11 +103,6 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 		return err
 	}
 
-	if err := c.switchTable.start(); err != nil {
-		c.log.Println("Failed to start switch table ticker")
-		return err
-	}
-
 	if err := c.admin.start(); err != nil {
 		c.log.Println("Failed to start admin socket")
 		return err

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -36,7 +36,6 @@ func (c *Core) Init() {
 	spub, spriv := newSigKeys()
 	c.init(bpub, bpriv, spub, spriv)
 	c.router.start()
-	c.switchTable.start()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -310,9 +309,6 @@ func (c *Core) DEBUG_init(bpub []byte,
 		panic(err)
 	}
 
-	if err := c.switchTable.start(); err != nil {
-		panic(err)
-	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -126,8 +126,8 @@ func (l *switchLocator) DEBUG_getCoords() []byte {
 	return l.getCoords()
 }
 
-func (c *Core) DEBUG_switchLookup(dest []byte, ttl uint64) (switchPort, uint64) {
-	return c.switchTable.lookup(dest, ttl)
+func (c *Core) DEBUG_switchLookup(dest []byte) switchPort {
+	return c.switchTable.lookup(dest)
 }
 
 /*

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -453,16 +453,16 @@ func (c *Core) DEBUG_addAllowedEncryptionPublicKey(boxStr string) {
 
 func DEBUG_simLinkPeers(p, q *peer) {
 	// Sets q.out() to point to p and starts p.linkLoop()
-	plinkIn := make(chan []byte, 1)
-	qlinkIn := make(chan []byte, 1)
+	p.linkIn, q.linkIn = make(chan []byte, 32), make(chan []byte, 32)
+	p.linkOut, q.linkOut = q.linkIn, p.linkIn
 	p.out = func(bs []byte) {
-		go q.handlePacket(bs, qlinkIn)
+		go q.handlePacket(bs)
 	}
 	q.out = func(bs []byte) {
-		go p.handlePacket(bs, plinkIn)
+		go p.handlePacket(bs)
 	}
-	go p.linkLoop(plinkIn)
-	go q.linkLoop(qlinkIn)
+	go p.linkLoop()
+	go q.linkLoop()
 }
 
 func (c *Core) DEBUG_simFixMTU() {

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -326,7 +326,6 @@ func (t *dht) sendReq(req *dhtReq, dest *dhtInfo) {
 	shared := t.core.sessions.getSharedKey(&t.core.boxPriv, &dest.key)
 	payload, nonce := boxSeal(shared, bs, nil)
 	p := wire_protoTrafficPacket{
-		TTL:     ^uint64(0),
 		Coords:  dest.coords,
 		ToKey:   dest.key,
 		FromKey: t.core.boxPub,
@@ -352,7 +351,6 @@ func (t *dht) sendRes(res *dhtRes, req *dhtReq) {
 	shared := t.core.sessions.getSharedKey(&t.core.boxPriv, &req.Key)
 	payload, nonce := boxSeal(shared, bs, nil)
 	p := wire_protoTrafficPacket{
-		TTL:     ^uint64(0),
 		Coords:  req.Coords,
 		ToKey:   req.Key,
 		FromKey: t.core.boxPub,

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -81,7 +81,7 @@ type dht struct {
 func (t *dht) init(c *Core) {
 	t.core = c
 	t.nodeID = *t.core.GetNodeID()
-	t.peers = make(chan *dhtInfo, 1)
+	t.peers = make(chan *dhtInfo, 1024)
 	t.reqs = make(map[boxPubKey]map[NodeID]time.Time)
 }
 

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -520,9 +520,15 @@ func dht_firstCloserThanThird(first *NodeID,
 
 func (t *dht) reset() {
 	// This is mostly so bootstrapping will reset to resend coords into the network
+	t.offset = 0
+	t.rumorMill = nil // reset mill
 	for _, b := range t.buckets_hidden {
 		b.peers = b.peers[:0]
+		for _, info := range b.other {
+			// Add other nodes to the rumor mill so they'll be pinged soon
+			// This will hopefully tell them our coords and re-learn theirs quickly if they haven't changed
+			t.addToMill(info, info.getNodeID())
+		}
 		b.other = b.other[:0]
 	}
-	t.offset = 0
 }

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -281,7 +281,6 @@ func (p *peer) handleSwitchMsg(packet []byte) {
 	}
 	//p.core.log.Println("Decoded msg:", msg, "; bytes:", packet)
 	if len(msg.Hops) < 1 {
-		panic("FIXME testing")
 		p.core.peers.removePeer(p.port)
 	}
 	var loc switchLocator
@@ -293,7 +292,6 @@ func (p *peer) handleSwitchMsg(packet []byte) {
 		loc.coords = append(loc.coords, hop.Port)
 		bs := getBytesForSig(&hop.Next, &sigMsg)
 		if !p.core.sigs.check(&prevKey, &hop.Sig, bs) {
-			panic("FIXME testing")
 			p.core.peers.removePeer(p.port)
 		}
 		prevKey = hop.Next

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -204,14 +204,11 @@ func (p *peer) handleTraffic(packet []byte, pTypeLen int) {
 		// Drop traffic until the peer manages to send us at least one good switchMsg
 		return
 	}
-	_, ttlLen := wire_decode_uint64(packet[pTypeLen:])
-	ttlEnd := pTypeLen + ttlLen
-	coords, coordLen := wire_decode_coords(packet[ttlEnd:])
-	coordEnd := ttlEnd + coordLen
-	if coordEnd == len(packet) {
+	coords, coordLen := wire_decode_coords(packet[pTypeLen:])
+	if coordLen >= len(packet) {
 		return
 	} // No payload
-	toPort, _ := p.core.switchTable.lookup(coords, 0)
+	toPort := p.core.switchTable.lookup(coords)
 	if toPort == p.port {
 		return
 	}

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -319,7 +319,6 @@ func (p *peer) handleSwitchMsg(packet []byte) {
 		panic("FIXME testing")
 		return
 	}
-	var info switchMessage
 	var loc switchLocator
 	prevKey := msg.Root
 	for idx, hop := range msg.Hops {
@@ -335,7 +334,7 @@ func (p *peer) handleSwitchMsg(packet []byte) {
 		}
 		prevKey = hop.Next
 	}
-	p.core.switchTable.handleMsg(&msg, &info, p.port)
+	p.core.switchTable.handleMsg(&msg, p.port)
 	// Pass a mesage to the dht informing it that this peer (still) exists
 	loc.coords = loc.coords[:len(loc.coords)-1]
 	dinfo := dhtInfo{

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -150,6 +150,9 @@ func (ps *peers) removePeer(port switchPort) {
 	if port == 0 {
 		return
 	} // Can't remove self peer
+	ps.core.router.doAdmin(func() {
+		ps.core.switchTable.removePeer(port)
+	})
 	ps.mutex.Lock()
 	oldPorts := ps.getPorts()
 	p, isIn := oldPorts[port]
@@ -160,8 +163,11 @@ func (ps *peers) removePeer(port switchPort) {
 	delete(newPorts, port)
 	ps.putPorts(newPorts)
 	ps.mutex.Unlock()
-	if isIn && p.close != nil {
-		p.close()
+	if isIn {
+		if p.close != nil {
+			p.close()
+		}
+		close(p.linkIn)
 	}
 }
 

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -287,7 +287,9 @@ func (p *peer) sendSwitchMsg() {
 
 func (p *peer) handleSwitchMsg(packet []byte) {
 	var msg switchMsg
-	msg.decode(packet)
+	if !msg.decode(packet) {
+		return
+	}
 	//p.core.log.Println("Decoded msg:", msg, "; bytes:", packet)
 	if len(msg.Hops) < 1 {
 		panic("FIXME testing")

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -347,11 +347,9 @@ func (p *peer) handleSwitchMsg(packet []byte) {
 }
 
 func getBytesForSig(next *sigPubKey, loc *switchLocator) []byte {
-	//bs, err := wire_encode_locator(loc)
-	//if err != nil { panic(err) }
 	bs := append([]byte(nil), next[:]...)
-	bs = append(bs, wire_encode_locator(loc)...)
-	//bs := wire_encode_locator(loc)
-	//bs = append(next[:], bs...)
+	bs = append(bs, loc.root[:]...)
+	bs = append(bs, wire_encode_uint64(wire_intToUint(loc.tstamp))...)
+	bs = append(bs, wire_encode_coords(loc.getCoords())...)
 	return bs
 }

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -55,7 +55,7 @@ func (r *router) init(core *Core) {
 		}
 	}
 	r.in = in
-	r.out = func(packet []byte) { p.handlePacket(packet, nil) } // The caller is responsible for go-ing if it needs to not block
+	r.out = func(packet []byte) { p.handlePacket(packet) } // The caller is responsible for go-ing if it needs to not block
 	recv := make(chan []byte, 32)
 	send := make(chan []byte, 32)
 	r.recv = recv

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -93,6 +93,7 @@ func (r *router) mainLoop() {
 				// Any periodic maintenance stuff goes here
 				r.core.switchTable.doMaintenance()
 				r.core.dht.doMaintenance()
+				//r.core.peers.fixSwitchAfterPeerDisconnect() // FIXME makes sure dht peers get added quickly
 				util_getBytes() // To slowly drain things
 			}
 		case f := <-r.admin:

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -93,7 +93,7 @@ func (r *router) mainLoop() {
 				// Any periodic maintenance stuff goes here
 				r.core.switchTable.doMaintenance()
 				r.core.dht.doMaintenance()
-				//r.core.peers.fixSwitchAfterPeerDisconnect() // FIXME makes sure dht peers get added quickly
+				//r.core.peers.sendSwitchMsgs() // FIXME debugging
 				util_getBytes() // To slowly drain things
 			}
 		case f := <-r.admin:

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -91,6 +91,7 @@ func (r *router) mainLoop() {
 		case <-ticker.C:
 			{
 				// Any periodic maintenance stuff goes here
+				r.core.switchTable.doMaintenance()
 				r.core.dht.doMaintenance()
 				util_getBytes() // To slowly drain things
 			}

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -107,7 +107,10 @@ func (s *searches) doSearchStep(sinfo *searchInfo) {
 		// Send to the next search target
 		var next *dhtInfo
 		next, sinfo.toVisit = sinfo.toVisit[0], sinfo.toVisit[1:]
+		var oldPings int
+		oldPings, next.pings = next.pings, 0
 		s.core.dht.ping(next, &sinfo.dest)
+		next.pings = oldPings // Don't evict a node for searching with it too much
 		sinfo.visited[*next.getNodeID()] = true
 	}
 }

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -255,7 +255,6 @@ func (ss *sessions) sendPingPong(sinfo *sessionInfo, isPong bool) {
 	shared := ss.getSharedKey(&ss.core.boxPriv, &sinfo.theirPermPub)
 	payload, nonce := boxSeal(shared, bs, nil)
 	p := wire_protoTrafficPacket{
-		TTL:     ^uint64(0),
 		Coords:  sinfo.coords,
 		ToKey:   sinfo.theirPermPub,
 		FromKey: ss.core.boxPub,
@@ -383,7 +382,6 @@ func (sinfo *sessionInfo) doSend(bs []byte) {
 	payload, nonce := boxSeal(&sinfo.sharedSesKey, bs, &sinfo.myNonce)
 	defer util_putBytes(payload)
 	p := wire_trafficPacket{
-		TTL:     ^uint64(0),
 		Coords:  sinfo.coords,
 		Handle:  sinfo.theirHandle,
 		Nonce:   *nonce,

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -113,18 +113,10 @@ type peerInfo struct {
 	key       sigPubKey     // ID of this peer
 	locator   switchLocator // Should be able to respond with signatures upon request
 	degree    uint64        // Self-reported degree
-	coords    []switchPort  // Coords of this peer (taken from coords of the sent locator)
 	time      time.Time     // Time this node was last seen
 	firstSeen time.Time
 	port      switchPort // Interface number of this peer
-	seq       uint64     // Seq number we last saw this peer advertise
-	smsg      switchMsg  // The wire switchMsg used
-}
-
-type switchMessage struct {
-	from    sigPubKey     // key of the sender
-	locator switchLocator // Locator advertised for the receiver, not the sender's loc!
-	seq     uint64
+	msg       switchMsg  // The wire switchMsg used
 }
 
 type switchPort uint64
@@ -144,7 +136,6 @@ type switchData struct {
 	locator switchLocator
 	seq     uint64 // Sequence number, reported to peers, so they know about changes
 	peers   map[switchPort]peerInfo
-	sigs    []sigInfo
 	msg     *switchMsg
 }
 
@@ -224,7 +215,6 @@ func (t *switchTable) cleanRoot() {
 			}
 		}
 		t.data.locator = switchLocator{root: t.key, tstamp: now.Unix()}
-		t.data.sigs = nil
 		t.core.peers.sendSwitchMsgs()
 	}
 }
@@ -242,15 +232,6 @@ func (t *switchTable) cleanDropped() {
 			delete(t.drop, root)
 		}
 	}
-}
-
-func (t *switchTable) createMessage(port switchPort) (*switchMessage, []sigInfo) {
-	t.mutex.RLock()
-	defer t.mutex.RUnlock()
-	msg := switchMessage{from: t.key, locator: t.data.locator.clone()}
-	msg.locator.coords = append(msg.locator.coords, port)
-	msg.seq = t.data.seq
-	return &msg, t.data.sigs
 }
 
 type switchMsg struct {
@@ -271,7 +252,7 @@ func (t *switchTable) getMsg() *switchMsg {
 	if t.parent == 0 {
 		return &switchMsg{Root: t.key, TStamp: t.data.locator.tstamp}
 	} else if parent, isIn := t.data.peers[t.parent]; isIn {
-		msg := parent.smsg
+		msg := parent.msg
 		msg.Hops = append([]switchMsgHop(nil), msg.Hops...)
 		return &msg
 	} else {
@@ -279,47 +260,34 @@ func (t *switchTable) getMsg() *switchMsg {
 	}
 }
 
-func (t *switchTable) handleMsg(smsg *switchMsg, xmsg *switchMessage, fromPort switchPort) {
+func (t *switchTable) handleMsg(msg *switchMsg, fromPort switchPort) {
 	// TODO directly use a switchMsg instead of switchMessage + sigs
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	now := time.Now()
-
-	//*
-	var msg switchMessage
-	var sigs []sigInfo
-	msg.locator.root = smsg.Root
-	msg.locator.tstamp = smsg.TStamp
-	msg.from = smsg.Root
-	prevKey := msg.from
-	for _, hop := range smsg.Hops {
+	// Set up the sender peerInfo
+	var sender peerInfo
+	sender.locator.root = msg.Root
+	sender.locator.tstamp = msg.TStamp
+	prevKey := msg.Root
+	for _, hop := range msg.Hops {
 		// Build locator and signatures
 		var sig sigInfo
 		sig.next = hop.Next
 		sig.sig = hop.Sig
-		sigs = append(sigs, sig)
-		msg.locator.coords = append(msg.locator.coords, hop.Port)
-		msg.from = prevKey
+		sender.locator.coords = append(sender.locator.coords, hop.Port)
+		sender.key = prevKey
 		prevKey = hop.Next
 	}
-	msg.seq = uint64(now.Unix())
-	//*/
-
-	if len(msg.locator.coords) == 0 {
-		return
-	} // Should always have >=1 links
+	sender.msg = *msg
 	oldSender, isIn := t.data.peers[fromPort]
 	if !isIn {
 		oldSender.firstSeen = now
 	}
-	sender := peerInfo{key: msg.from,
-		locator:   msg.locator,
-		coords:    msg.locator.coords[:len(msg.locator.coords)-1],
-		time:      now,
-		firstSeen: oldSender.firstSeen,
-		port:      fromPort,
-		seq:       msg.seq,
-		smsg:      *smsg}
+	sender.firstSeen = oldSender.firstSeen
+	sender.port = fromPort
+	sender.time = now
+	// Decide what to do
 	equiv := func(x *switchLocator, y *switchLocator) bool {
 		if x.root != y.root {
 			return false
@@ -335,7 +303,7 @@ func (t *switchTable) handleMsg(smsg *switchMsg, xmsg *switchMessage, fromPort s
 		return true
 	}
 	doUpdate := false
-	if !equiv(&msg.locator, &oldSender.locator) {
+	if !equiv(&sender.locator, &oldSender.locator) {
 		doUpdate = true
 		//sender.firstSeen = now // TODO? uncomment to prevent flapping?
 	}
@@ -344,12 +312,12 @@ func (t *switchTable) handleMsg(smsg *switchMsg, xmsg *switchMessage, fromPort s
 	oldParent, isIn := t.data.peers[t.parent]
 	noParent := !isIn
 	noLoop := func() bool {
-		for idx := 0; idx < len(sigs)-1; idx++ {
-			if sigs[idx].next == t.core.sigPub {
+		for idx := 0; idx < len(msg.Hops)-1; idx++ {
+			if msg.Hops[idx].Next == t.core.sigPub {
 				return false
 			}
 		}
-		if msg.locator.root == t.core.sigPub {
+		if sender.locator.root == t.core.sigPub {
 			return false
 		}
 		return true
@@ -358,30 +326,30 @@ func (t *switchTable) handleMsg(smsg *switchMsg, xmsg *switchMessage, fromPort s
 	pTime := oldParent.time.Sub(oldParent.firstSeen) + switch_timeout
 	// Really want to compare sLen/sTime and pLen/pTime
 	// Cross multiplied to avoid divide-by-zero
-	cost := len(msg.locator.coords) * int(pTime.Seconds())
+	cost := len(sender.locator.coords) * int(pTime.Seconds())
 	pCost := len(t.data.locator.coords) * int(sTime.Seconds())
-	dropTstamp, isIn := t.drop[msg.locator.root]
+	dropTstamp, isIn := t.drop[sender.locator.root]
 	// Here be dragons
 	switch {
 	case !noLoop: // do nothing
-	case isIn && dropTstamp >= msg.locator.tstamp: // do nothing
-	case firstIsBetter(&msg.locator.root, &t.data.locator.root):
+	case isIn && dropTstamp >= sender.locator.tstamp: // do nothing
+	case firstIsBetter(&sender.locator.root, &t.data.locator.root):
 		updateRoot = true
-	case t.data.locator.root != msg.locator.root: // do nothing
-	case t.data.locator.tstamp > msg.locator.tstamp: // do nothing
+	case t.data.locator.root != sender.locator.root: // do nothing
+	case t.data.locator.tstamp > sender.locator.tstamp: // do nothing
 	case noParent:
 		updateRoot = true
 	case cost < pCost:
 		updateRoot = true
 	case sender.port != t.parent: // do nothing
-	case !equiv(&msg.locator, &t.data.locator):
+	case !equiv(&sender.locator, &t.data.locator):
 		updateRoot = true
 	case now.Sub(t.time) < switch_throttle: // do nothing
-	case msg.locator.tstamp > t.data.locator.tstamp:
+	case sender.locator.tstamp > t.data.locator.tstamp:
 		updateRoot = true
 	}
 	if updateRoot {
-		if !equiv(&msg.locator, &t.data.locator) {
+		if !equiv(&sender.locator, &t.data.locator) {
 			doUpdate = true
 			t.data.seq++
 			select {
@@ -391,12 +359,11 @@ func (t *switchTable) handleMsg(smsg *switchMsg, xmsg *switchMessage, fromPort s
 			//t.core.log.Println("Switch update:", msg.locator.root, msg.locator.tstamp, msg.locator.coords)
 			//fmt.Println("Switch update:", msg.Locator.Root, msg.Locator.Tstamp, msg.Locator.Coords)
 		}
-		if t.data.locator.tstamp != msg.locator.tstamp {
+		if t.data.locator.tstamp != sender.locator.tstamp {
 			t.time = now
 		}
-		t.data.locator = msg.locator
+		t.data.locator = sender.locator
 		t.parent = sender.port
-		t.data.sigs = sigs
 		//t.core.log.Println("Switch update:", msg.Locator.Root, msg.Locator.Tstamp, msg.Locator.Coords)
 		t.core.peers.sendSwitchMsgs()
 	}

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -230,7 +230,7 @@ func (t *switchTable) cleanRoot() {
 func (t *switchTable) removePeer(port switchPort) {
 	delete(t.data.peers, port)
 	t.updater.Store(&sync.Once{})
-	t.core.peers.fixSwitchAfterPeerDisconnect()
+	// TODO if parent, find a new peer to use as parent instead
 }
 
 func (t *switchTable) cleanDropped() {
@@ -287,6 +287,7 @@ func (t *switchTable) handleMessage(msg *switchMessage, fromPort switchPort, sig
 	doUpdate := false
 	if !equiv(&msg.locator, &oldSender.locator) {
 		doUpdate = true
+		//sender.firstSeen = now // TODO? uncomment to prevent flapping?
 	}
 	t.data.peers[fromPort] = sender
 	updateRoot := false

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -181,7 +181,6 @@ func (t *switchTable) doMaintenance() {
 	t.mutex.Lock()         // Write lock
 	defer t.mutex.Unlock() // Release lock when we're done
 	t.cleanRoot()
-	t.cleanPeers()
 	t.cleanDropped()
 }
 
@@ -227,19 +226,9 @@ func (t *switchTable) cleanRoot() {
 	}
 }
 
-func (t *switchTable) cleanPeers() {
-	now := time.Now()
-	changed := false
-	for idx, info := range t.data.peers {
-		if info.port != switchPort(0) && now.Sub(info.time) > 6*time.Second /*switch_timeout*/ {
-			//fmt.Println("peer timed out", t.key, info.locator)
-			delete(t.data.peers, idx)
-			changed = true
-		}
-	}
-	if changed {
-		t.updater.Store(&sync.Once{})
-	}
+func (t *switchTable) removePeer(port switchPort) {
+	delete(t.data.peers, port)
+	t.updater.Store(&sync.Once{})
 }
 
 func (t *switchTable) cleanDropped() {

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -418,6 +418,9 @@ func (t *switchTable) lookup(dest []byte, ttl uint64) (switchPort, uint64) {
 	table := t.table.Load().(lookupTable)
 	myDist := table.self.dist(dest) //getDist(table.self.coords)
 	if !(uint64(myDist) < ttl) {
+		//return 0, 0
+	}
+	if myDist == 0 {
 		return 0, 0
 	}
 	// cost is in units of (expected distance) + (expected queue size), where expected distance is used as an approximation of the minimum backpressure gradient needed for packets to flow
@@ -441,7 +444,7 @@ func (t *switchTable) lookup(dest []byte, ttl uint64) (switchPort, uint64) {
 	}
 	//t.core.log.Println("DEBUG: sending to", best, "bandwidth", getBandwidth(best))
 	//t.core.log.Println("DEBUG: sending to", best, "cost", bestCost)
-	return best, uint64(myDist)
+	return best, ttl //uint64(myDist)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -170,26 +170,13 @@ func (t *switchTable) init(core *Core, key sigPubKey) {
 	t.drop = make(map[sigPubKey]int64)
 }
 
-func (t *switchTable) start() error {
-	doTicker := func() {
-		ticker := time.NewTicker(time.Second)
-		defer ticker.Stop()
-		for {
-			<-ticker.C
-			t.Tick()
-		}
-	}
-	go doTicker()
-	return nil
-}
-
 func (t *switchTable) getLocator() switchLocator {
 	t.mutex.RLock()
 	defer t.mutex.RUnlock()
 	return t.data.locator.clone()
 }
 
-func (t *switchTable) Tick() {
+func (t *switchTable) doMaintenance() {
 	// Periodic maintenance work to keep things internally consistent
 	t.mutex.Lock()         // Write lock
 	defer t.mutex.Unlock() // Release lock when we're done

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -9,7 +9,7 @@ package yggdrasil
 // TODO document/comment everything in a lot more detail
 
 // TODO? use a pre-computed lookup table (python version had this)
-//  A little annoying to do with constant changes from bandwidth estimates
+//  A little annoying to do with constant changes from backpressure
 
 import "time"
 import "sort"

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -279,7 +279,6 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 	defer func() {
 		// Put all of our cleanup here...
 		p.core.peers.removePeer(p.port)
-		close(p.linkIn)
 	}()
 	them, _, _ := net.SplitHostPort(sock.RemoteAddr().String())
 	themNodeID := getNodeID(&info.box)

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -209,7 +209,6 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 	// Note that multiple connections to the same node are allowed
 	//  E.g. over different interfaces
 	p := iface.core.peers.newPeer(&info.box, &info.sig)
-	p.linkIn = make(chan []byte, 1)
 	p.linkOut = make(chan []byte, 1)
 	in := func(bs []byte) {
 		p.handlePacket(bs)

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -170,17 +170,6 @@ func (m *switchMsg) decode(bs []byte) bool {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Format used to check signatures only, so no need to also support decoding
-// TODO something else for signatures
-func wire_encode_locator(loc *switchLocator) []byte {
-	coords := wire_encode_coords(loc.getCoords())
-	var bs []byte
-	bs = append(bs, loc.root[:]...)
-	bs = append(bs, wire_encode_uint64(wire_intToUint(loc.tstamp))...)
-	bs = append(bs, coords...)
-	return bs
-}
-
 func wire_chop_slice(toSlice []byte, fromSlice *[]byte) bool {
 	if len(*fromSlice) < len(toSlice) {
 		return false

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -115,18 +115,6 @@ func wire_decode_coords(packet []byte) ([]byte, int) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-type switchMsg struct {
-	Root   sigPubKey
-	TStamp int64
-	Hops   []switchMsgHop
-}
-
-type switchMsgHop struct {
-	Port switchPort
-	Next sigPubKey
-	Sig  sigBytes
-}
-
 func (m *switchMsg) encode() []byte {
 	bs := wire_encode_uint64(wire_SwitchMsg)
 	bs = append(bs, m.Root[:]...)

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -192,7 +192,6 @@ func wire_chop_uint64(toUInt64 *uint64, fromSlice *[]byte) bool {
 // Wire traffic packets
 
 type wire_trafficPacket struct {
-	TTL     uint64
 	Coords  []byte
 	Handle  handle
 	Nonce   boxNonce
@@ -203,7 +202,6 @@ type wire_trafficPacket struct {
 func (p *wire_trafficPacket) encode() []byte {
 	bs := util_getBytes()
 	bs = wire_put_uint64(wire_Traffic, bs)
-	bs = wire_put_uint64(p.TTL, bs)
 	bs = wire_put_coords(p.Coords, bs)
 	bs = append(bs, p.Handle[:]...)
 	bs = append(bs, p.Nonce[:]...)
@@ -219,8 +217,6 @@ func (p *wire_trafficPacket) decode(bs []byte) bool {
 		return false
 	case pType != wire_Traffic:
 		return false
-	case !wire_chop_uint64(&p.TTL, &bs):
-		return false
 	case !wire_chop_coords(&p.Coords, &bs):
 		return false
 	case !wire_chop_slice(p.Handle[:], &bs):
@@ -233,7 +229,6 @@ func (p *wire_trafficPacket) decode(bs []byte) bool {
 }
 
 type wire_protoTrafficPacket struct {
-	TTL     uint64
 	Coords  []byte
 	ToKey   boxPubKey
 	FromKey boxPubKey
@@ -244,7 +239,6 @@ type wire_protoTrafficPacket struct {
 func (p *wire_protoTrafficPacket) encode() []byte {
 	coords := wire_encode_coords(p.Coords)
 	bs := wire_encode_uint64(wire_ProtocolTraffic)
-	bs = append(bs, wire_encode_uint64(p.TTL)...)
 	bs = append(bs, coords...)
 	bs = append(bs, p.ToKey[:]...)
 	bs = append(bs, p.FromKey[:]...)
@@ -259,8 +253,6 @@ func (p *wire_protoTrafficPacket) decode(bs []byte) bool {
 	case !wire_chop_uint64(&pType, &bs):
 		return false
 	case pType != wire_ProtocolTraffic:
-		return false
-	case !wire_chop_uint64(&p.TTL, &bs):
 		return false
 	case !wire_chop_coords(&p.Coords, &bs):
 		return false

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -13,9 +13,6 @@ const (
 	wire_ProtocolTraffic            // protocol traffic, pub keys for crypto
 	wire_LinkProtocolTraffic        // link proto traffic, pub keys for crypto
 	wire_SwitchMsg                  // inside link protocol traffic header
-	wire_SwitchAnnounce             // inside protocol traffic header
-	wire_SwitchHopRequest           // inside protocol traffic header
-	wire_SwitchHop                  // inside protocol traffic header
 	wire_SessionPing                // inside protocol traffic header
 	wire_SessionPong                // inside protocol traffic header
 	wire_DHTLookupRequest           // inside protocol traffic header
@@ -173,136 +170,8 @@ func (m *switchMsg) decode(bs []byte) bool {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Announces that we can send parts of a Message with a particular seq
-type msgAnnounce struct {
-	Root   sigPubKey
-	Tstamp int64
-	Seq    uint64
-	Len    uint64
-	//Deg uint64
-	Rseq uint64
-}
-
-func (m *msgAnnounce) encode() []byte {
-	bs := wire_encode_uint64(wire_SwitchAnnounce)
-	bs = append(bs, m.Root[:]...)
-	bs = append(bs, wire_encode_uint64(wire_intToUint(m.Tstamp))...)
-	bs = append(bs, wire_encode_uint64(m.Seq)...)
-	bs = append(bs, wire_encode_uint64(m.Len)...)
-	bs = append(bs, wire_encode_uint64(m.Rseq)...)
-	return bs
-}
-
-func (m *msgAnnounce) decode(bs []byte) bool {
-	var pType uint64
-	var tstamp uint64
-	switch {
-	case !wire_chop_uint64(&pType, &bs):
-		return false
-	case pType != wire_SwitchAnnounce:
-		return false
-	case !wire_chop_slice(m.Root[:], &bs):
-		return false
-	case !wire_chop_uint64(&tstamp, &bs):
-		return false
-	case !wire_chop_uint64(&m.Seq, &bs):
-		return false
-	case !wire_chop_uint64(&m.Len, &bs):
-		return false
-	case !wire_chop_uint64(&m.Rseq, &bs):
-		return false
-	}
-	m.Tstamp = wire_intFromUint(tstamp)
-	return true
-}
-
-type msgHopReq struct {
-	Root   sigPubKey
-	Tstamp int64
-	Seq    uint64
-	Hop    uint64
-}
-
-func (m *msgHopReq) encode() []byte {
-	bs := wire_encode_uint64(wire_SwitchHopRequest)
-	bs = append(bs, m.Root[:]...)
-	bs = append(bs, wire_encode_uint64(wire_intToUint(m.Tstamp))...)
-	bs = append(bs, wire_encode_uint64(m.Seq)...)
-	bs = append(bs, wire_encode_uint64(m.Hop)...)
-	return bs
-}
-
-func (m *msgHopReq) decode(bs []byte) bool {
-	var pType uint64
-	var tstamp uint64
-	switch {
-	case !wire_chop_uint64(&pType, &bs):
-		return false
-	case pType != wire_SwitchHopRequest:
-		return false
-	case !wire_chop_slice(m.Root[:], &bs):
-		return false
-	case !wire_chop_uint64(&tstamp, &bs):
-		return false
-	case !wire_chop_uint64(&m.Seq, &bs):
-		return false
-	case !wire_chop_uint64(&m.Hop, &bs):
-		return false
-	}
-	m.Tstamp = wire_intFromUint(tstamp)
-	return true
-}
-
-type msgHop struct {
-	Root   sigPubKey
-	Tstamp int64
-	Seq    uint64
-	Hop    uint64
-	Port   switchPort
-	Next   sigPubKey
-	Sig    sigBytes
-}
-
-func (m *msgHop) encode() []byte {
-	bs := wire_encode_uint64(wire_SwitchHop)
-	bs = append(bs, m.Root[:]...)
-	bs = append(bs, wire_encode_uint64(wire_intToUint(m.Tstamp))...)
-	bs = append(bs, wire_encode_uint64(m.Seq)...)
-	bs = append(bs, wire_encode_uint64(m.Hop)...)
-	bs = append(bs, wire_encode_uint64(uint64(m.Port))...)
-	bs = append(bs, m.Next[:]...)
-	bs = append(bs, m.Sig[:]...)
-	return bs
-}
-
-func (m *msgHop) decode(bs []byte) bool {
-	var pType uint64
-	var tstamp uint64
-	switch {
-	case !wire_chop_uint64(&pType, &bs):
-		return false
-	case pType != wire_SwitchHop:
-		return false
-	case !wire_chop_slice(m.Root[:], &bs):
-		return false
-	case !wire_chop_uint64(&tstamp, &bs):
-		return false
-	case !wire_chop_uint64(&m.Seq, &bs):
-		return false
-	case !wire_chop_uint64(&m.Hop, &bs):
-		return false
-	case !wire_chop_uint64((*uint64)(&m.Port), &bs):
-		return false
-	case !wire_chop_slice(m.Next[:], &bs):
-		return false
-	case !wire_chop_slice(m.Sig[:], &bs):
-		return false
-	}
-	m.Tstamp = wire_intFromUint(tstamp)
-	return true
-}
-
 // Format used to check signatures only, so no need to also support decoding
+// TODO something else for signatures
 func wire_encode_locator(loc *switchLocator) []byte {
 	coords := wire_encode_coords(loc.getCoords())
 	var bs []byte


### PR DESCRIPTION
Note that this PR is *not* backwards compatible, so it's requested for `develop`, and shouldn't hit `master` until the v0.2 release.

This is a whole mess of changes related to using a new switchMsg format.

Previously, we had 3 packet types related to the switch / spanning tree. There were announcements, hop requests, and hop responses. The announcements listed some basic info about a node's coords (including a sequence number and the number of hops to the root), and the node's peers would send hop requests and get back hop responses until they had all the information they needed. `wire_LinkProtocolTraffic` packets bypass the LIFO queue in `tcp.go`, to make sure they aren't dropped due to congestion, and to avoid races with later traffic packets.

That made sense when we wanted to send tiny UDP packets. After deprecating the old udp implementation, it no longer makes sense to keep the 3 kinds of messages. Instead, there's 1 `switchMsg`, which contains all the information. Instead of being sent periodically, a node sends one to their peers immediately in response to a locator change (either new root, new coords, or a new timestamp from the root).

Related changes include:
1. Peers immediately find a new parent if their current parent goes offline, when possible.
2. Some reworking of how peers are added to the DHT, to deal with not constantly getting spammed with traffic from peers.
3. Some DHT tuning. The part that periodically does a lookup of a bucket and pings the best node that's older than 1 minute now uses a variable threshold per node. This is used to ping new nodes frequently, and gradually throttle back to the old 1 minute cooldown. It should help nodes bootstrap faster. The rate at which it throttles back hasn't been tuned, so it may need further study.
4. `wire_Traffic` and `wire_ProtocolTraffic` packets have had their `TTL` fields removed--packets are no longer mutated during forwarding. This is because ordered reliable transport eliminates the race condition that previously would lead to routing loops. It should still be possible for a packet to follow a loop *once* if there are nodes in the loop that are updating coords while the packet is in flight.
5. Since there's no longer idle traffic for each peer, `tcp.go` sends an empty message through the TCP stream after 4 seconds without sending any other traffic. The read side of the stream continues to time out after 6 seconds of inactivity, as before. Both values are subject to tuning.