### PR TITLE
Enable multicast on interfaces that come up after startup

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -175,7 +175,7 @@ func (a *admin) init(c *Core, listenaddr string) {
 	})
 	a.addHandler("getMulticastInterfaces", []string{}, func(in admin_info) (admin_info, error) {
 		var intfs []string
-		for _, v := range a.core.multicast.interfaces {
+		for _, v := range a.core.multicast.interfaces() {
 			intfs = append(intfs, v.Name)
 		}
 		return admin_info{"multicast_interfaces": intfs}, nil


### PR DESCRIPTION
Replaces `m.interfaces` with `m.interfaces()` that builds the list of multicast-allowed interfaces on-the-fly. This allows multicast to work on interfaces that come up after yggdrasil has already started.

I believe this was how it worked when the code was in `yggdrasil.go`, but I didn't notice the change until I started re-running some old tests with netns while working on another PR.