### PR TITLE
Use "localhost:9001" for the default admin socket

### DIFF
--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -48,7 +48,7 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 		r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
 		cfg.Listen = fmt.Sprintf("[::]:%d", r1.Intn(65534-32768)+32768)
 	}
-	cfg.AdminListen = "[::1]:9001"
+	cfg.AdminListen = "localhost:9001"
 	cfg.EncryptionPublicKey = hex.EncodeToString(bpub[:])
 	cfg.EncryptionPrivateKey = hex.EncodeToString(bpriv[:])
 	cfg.SigningPublicKey = hex.EncodeToString(spub[:])


### PR DESCRIPTION
Plays nicer on platforms where `localhost` doesn't resolve to `[::1]`.