### PR TITLE
Peer authentication improvements

### DIFF
--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -54,10 +54,12 @@ func linkNodes(m, n *Node) {
 	// Create peers
 	// Buffering reduces packet loss in the sim
 	//  This slightly speeds up testing (fewer delays before retrying a ping)
+	pLinkPub, pLinkPriv := m.core.DEBUG_newBoxKeys()
+	qLinkPub, qLinkPriv := m.core.DEBUG_newBoxKeys()
 	p := m.core.DEBUG_getPeers().DEBUG_newPeer(n.core.DEBUG_getEncryptionPublicKey(),
-		n.core.DEBUG_getSigningPublicKey())
+		n.core.DEBUG_getSigningPublicKey(), *m.core.DEBUG_getSharedKey(pLinkPriv, qLinkPub))
 	q := n.core.DEBUG_getPeers().DEBUG_newPeer(m.core.DEBUG_getEncryptionPublicKey(),
-		m.core.DEBUG_getSigningPublicKey())
+		m.core.DEBUG_getSigningPublicKey(), *n.core.DEBUG_getSharedKey(qLinkPriv, pLinkPub))
 	DEBUG_simLinkPeers(p, q)
 	return
 }

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -64,11 +64,10 @@ func (c *Core) DEBUG_getPeers() *peers {
 	return &c.peers
 }
 
-func (ps *peers) DEBUG_newPeer(box boxPubKey,
-	sig sigPubKey) *peer {
+func (ps *peers) DEBUG_newPeer(box boxPubKey, sig sigPubKey, link boxSharedKey) *peer {
 	//in <-chan []byte,
 	//out chan<- []byte) *peer {
-	return ps.newPeer(&box, &sig) //, in, out)
+	return ps.newPeer(&box, &sig, &link) //, in, out)
 }
 
 /*
@@ -273,6 +272,10 @@ func (c *Core) DEBUG_stopTun() {
 
 func (c *Core) DEBUG_newBoxKeys() (*boxPubKey, *boxPrivKey) {
 	return newBoxKeys()
+}
+
+func (c *Core) DEBUG_getSharedKey(myPrivKey *boxPrivKey, othersPubKey *boxPubKey) *boxSharedKey {
+	return getSharedKey(myPrivKey, othersPubKey)
 }
 
 func (c *Core) DEBUG_newSigKeys() (*sigPubKey, *sigPrivKey) {

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -297,6 +297,13 @@ func (p *peer) handleSwitchMsg(packet []byte) {
 		prevKey = hop.Next
 	}
 	p.core.switchTable.handleMsg(&msg, p.port)
+	if !p.core.switchTable.checkRoot(&msg) {
+		// Bad switch message
+		// Stop forwarding traffic from it
+		// Stop refreshing it in the DHT
+		p.dinfo = nil
+		return
+	}
 	// Pass a mesage to the dht informing it that this peer (still) exists
 	loc.coords = loc.coords[:len(loc.coords)-1]
 	dinfo := dhtInfo{

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -76,17 +76,18 @@ type peer struct {
 	bytesSent  uint64 // To track bandwidth usage for getPeers
 	bytesRecvd uint64 // To track bandwidth usage for getPeers
 	// BUG: sync/atomic, 32 bit platforms need the above to be the first element
-	core      *Core
-	port      switchPort
-	box       boxPubKey
-	sig       sigPubKey
-	shared    boxSharedKey
-	firstSeen time.Time       // To track uptime for getPeers
-	linkOut   (chan []byte)   // used for protocol traffic (to bypass queues)
-	doSend    (chan struct{}) // tell the linkLoop to send a switchMsg
-	dinfo     *dhtInfo        // used to keep the DHT working
-	out       func([]byte)    // Set up by whatever created the peers struct, used to send packets to other nodes
-	close     func()          // Called when a peer is removed, to close the underlying connection, or via admin api
+	core       *Core
+	port       switchPort
+	box        boxPubKey
+	sig        sigPubKey
+	shared     boxSharedKey
+	linkShared boxSharedKey
+	firstSeen  time.Time       // To track uptime for getPeers
+	linkOut    (chan []byte)   // used for protocol traffic (to bypass queues)
+	doSend     (chan struct{}) // tell the linkLoop to send a switchMsg
+	dinfo      *dhtInfo        // used to keep the DHT working
+	out        func([]byte)    // Set up by whatever created the peers struct, used to send packets to other nodes
+	close      func()          // Called when a peer is removed, to close the underlying connection, or via admin api
 }
 
 func (p *peer) getQueueSize() int64 {
@@ -97,14 +98,15 @@ func (p *peer) updateQueueSize(delta int64) {
 	atomic.AddInt64(&p.queueSize, delta)
 }
 
-func (ps *peers) newPeer(box *boxPubKey, sig *sigPubKey) *peer {
+func (ps *peers) newPeer(box *boxPubKey, sig *sigPubKey, linkShared *boxSharedKey) *peer {
 	now := time.Now()
 	p := peer{box: *box,
-		sig:       *sig,
-		shared:    *getSharedKey(&ps.core.boxPriv, box),
-		firstSeen: now,
-		doSend:    make(chan struct{}, 1),
-		core:      ps.core}
+		sig:        *sig,
+		shared:     *getSharedKey(&ps.core.boxPriv, box),
+		linkShared: *linkShared,
+		firstSeen:  now,
+		doSend:     make(chan struct{}, 1),
+		core:       ps.core}
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()
 	oldPorts := ps.getPorts()
@@ -228,7 +230,13 @@ func (p *peer) sendPacket(packet []byte) {
 }
 
 func (p *peer) sendLinkPacket(packet []byte) {
-	bs, nonce := boxSeal(&p.shared, packet, nil)
+	innerPayload, innerNonce := boxSeal(&p.linkShared, packet, nil)
+	innerLinkPacket := wire_linkProtoTrafficPacket{
+		Nonce:   *innerNonce,
+		Payload: innerPayload,
+	}
+	outerPayload := innerLinkPacket.encode()
+	bs, nonce := boxSeal(&p.shared, outerPayload, nil)
 	linkPacket := wire_linkProtoTrafficPacket{
 		Nonce:   *nonce,
 		Payload: bs,
@@ -242,7 +250,15 @@ func (p *peer) handleLinkTraffic(bs []byte) {
 	if !packet.decode(bs) {
 		return
 	}
-	payload, isOK := boxOpen(&p.shared, packet.Payload, &packet.Nonce)
+	outerPayload, isOK := boxOpen(&p.shared, packet.Payload, &packet.Nonce)
+	if !isOK {
+		return
+	}
+	innerPacket := wire_linkProtoTrafficPacket{}
+	if !innerPacket.decode(outerPayload) {
+		return
+	}
+	payload, isOK := boxOpen(&p.linkShared, innerPacket.Payload, &innerPacket.Nonce)
 	if !isOK {
 		return
 	}

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -43,8 +43,8 @@ type router struct {
 func (r *router) init(core *Core) {
 	r.core = core
 	r.addr = *address_addrForNodeID(&r.core.dht.nodeID)
-	in := make(chan []byte, 32)                               // TODO something better than this...
-	p := r.core.peers.newPeer(&r.core.boxPub, &r.core.sigPub) //, out, in)
+	in := make(chan []byte, 32) // TODO something better than this...
+	p := r.core.peers.newPeer(&r.core.boxPub, &r.core.sigPub, &boxSharedKey{})
 	p.out = func(packet []byte) {
 		// This is to make very sure it never blocks
 		select {


### PR DESCRIPTION
Fixes #50 to the extent that I think it's fixable / our problem. It's already possible to only accept connections from addresses if they're link-local IPv6 or using a key that was added to a user-configured list via config file or the admin API. This PR tries to fix some loose ends related to cases where a peer could lie about keys, replay legitimate traffic, and get a partly-working connection.

Two somewhat related changes:
1. We don't add a peer to our dht or accept traffic from them if we've either never gotten a `switchMsg` with the current root or our last `switchMsg` from them was bad (old timestamp / worse root). We can possibly relax this behavior somewhat and allow old timestamped messages, but that should only be an issue for peers with latency > root timestamp update interval.
2. Link protocol traffic now has two crypto layers. The outer crypto layer is the same as before. The inner crypto layer uses ephemeral keys that are generated on the fly and exchanged during the connection setup. This should prevent replay attacks where a malicious node monitors a peer connection and tries to replay it to trigger the addition of a new peer. The inner layer should prevent replays from working (the victim node's ephemeral keys won't match those of the recorded traffic, so it will fail to decrypt the inner layer of the link protocol traffic), which, when combined with fix 1 above, prevents replayed traffic from affecting routing.

There's some duplicate code involved in the second change, so we can probably re-factor / rewrite things a bit and make that look nicer, but the ugliness is already limited to only a few functions.

An attacker can still set up a connection to waste resources, so we should probably add some timeout after which we close a connection that hasn't gotten any valid link traffic. That part is at least backwards compatible, so it's less urgent to figure out.

The remaining attack vector, that I know of, consists of injecting traffic into a legitimate TCP stream. This *should* break the alignment and padding of messages in the stream, so I would expect nodes to close the connection as soon as they receive any traffic after the injected message.