### PR TITLE
Add version information to connection setup

### DIFF
--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -354,29 +354,7 @@ func (iface *tcpInterface) reader(sock net.Conn, in func([]byte)) {
 ////////////////////////////////////////////////////////////////////////////////
 
 // Magic bytes to check
-var tcp_key = [...]byte{'k', 'e', 'y', 's'}
 var tcp_msg = [...]byte{0xde, 0xad, 0xb1, 0x75} // "dead bits"
-
-func tcp_chop_keys(box *boxPubKey, sig *sigPubKey, link *boxPubKey, bs *[]byte) bool {
-	// This one is pretty simple: we know how long the message should be
-	// So don't call this with a message that's too short
-	if len(*bs) < len(tcp_key)+2*len(*box)+len(*sig) {
-		return false
-	}
-	for idx := range tcp_key {
-		if (*bs)[idx] != tcp_key[idx] {
-			return false
-		}
-	}
-	(*bs) = (*bs)[len(tcp_key):]
-	copy(box[:], *bs)
-	(*bs) = (*bs)[len(box):]
-	copy(sig[:], *bs)
-	(*bs) = (*bs)[len(sig):]
-	copy(link[:], *bs)
-	(*bs) = (*bs)[len(sig):]
-	return true
-}
 
 func tcp_chop_msg(bs *[]byte) ([]byte, bool, error) {
 	// Returns msg, ok, err

--- a/src/yggdrasil/version.go
+++ b/src/yggdrasil/version.go
@@ -1,0 +1,70 @@
+package yggdrasil
+
+// This file contains the version metadata struct
+// Used in the inital connection setup and key exchange
+// Some of this could arguably go in wire.go instead
+
+type version_metadata struct {
+	meta [4]byte
+	ver  uint64 // 1 byte in this version
+	// Everything after this point potentially depends on the version number, and is subject to change in future versions
+	minorVer uint64 // 1 byte in this version
+	box      boxPubKey
+	sig      sigPubKey
+	link     boxPubKey
+}
+
+func version_getBaseMetadata() version_metadata {
+	return version_metadata{
+		meta:     [4]byte{'m', 'e', 't', 'a'},
+		ver:      0,
+		minorVer: 2,
+	}
+}
+
+func version_getMetaLength() (mlen int) {
+	mlen += 4            // meta
+	mlen += 1            // ver
+	mlen += 1            // minorVer
+	mlen += boxPubKeyLen // box
+	mlen += sigPubKeyLen // sig
+	mlen += boxPubKeyLen // link
+	return
+}
+
+func (m *version_metadata) encode() []byte {
+	bs := make([]byte, 0, version_getMetaLength())
+	bs = append(bs, m.meta[:]...)
+	bs = append(bs, wire_encode_uint64(m.ver)...)
+	bs = append(bs, wire_encode_uint64(m.minorVer)...)
+	bs = append(bs, m.box[:]...)
+	bs = append(bs, m.sig[:]...)
+	bs = append(bs, m.link[:]...)
+	if len(bs) != version_getMetaLength() {
+		panic("Inconsistent metadata length")
+	}
+	return bs
+}
+
+func (m *version_metadata) decode(bs []byte) bool {
+	switch {
+	case !wire_chop_slice(m.meta[:], &bs):
+		return false
+	case !wire_chop_uint64(&m.ver, &bs):
+		return false
+	case !wire_chop_uint64(&m.minorVer, &bs):
+		return false
+	case !wire_chop_slice(m.box[:], &bs):
+		return false
+	case !wire_chop_slice(m.sig[:], &bs):
+		return false
+	case !wire_chop_slice(m.link[:], &bs):
+		return false
+	}
+	return true
+}
+
+func (m *version_metadata) check() bool {
+	base := version_getBaseMetadata()
+	return base.meta == m.meta && base.ver == m.ver && base.minorVer == m.minorVer
+}

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -66,23 +66,14 @@ func wire_decode_uint64(bs []byte) (uint64, int) {
 }
 
 func wire_intToUint(i int64) uint64 {
-	var u uint64
-	if i < 0 {
-		u = uint64(-i) << 1
-		u |= 0x01 // sign bit
-	} else {
-		u = uint64(i) << 1
-	}
-	return u
+	// Non-negative integers mapped to even integers: 0 -> 0, 1 -> 2, etc.
+	// Negative integres mapped to odd integes: -1 -> 1, -2 -> 3, etc.
+	// This means the least significant bit is a sign bit.
+	return ((uint64(-(i+1))<<1)|0x01)*(uint64(i)>>63) + (uint64(i)<<1)*(^uint64(i)>>63)
 }
 
 func wire_intFromUint(u uint64) int64 {
-	var i int64
-	i = int64(u >> 1)
-	if u&0x01 != 0 {
-		i *= -1
-	}
-	return i
+	return int64(u&0x01)*(-int64(u>>1)-1) + int64(^u&0x01)*int64(u>>1)
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #42 to the extent that I think we can/should address it for now. Things are not forwards/backwards compatible, but this should catch incompatible versions at connection setup time, close the connection, and print a print (or spam, if reconnection attempts are made) a notification to the logs that newer version was seen.

The first 4 bytes ('meta' header) and first uint64 (major version number) are meant to be kept in the same format across version changes. The rest of the metadata (minor version, keys) can be changed in future versions, or change to signal that something in the wire packet formats have changed. We would probably want to remove the minor version number field for the stable 1.0+ releases, if/when that happens.

There's also a minor bugfix to wire signed int formats (the previous implementation had negative zeros and no way to represent the negative integer with the representation of all `1` bits).