### PR TITLE
Fix launchd script path and amend debian control file

### DIFF
--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -34,7 +34,7 @@ mkdir -p /tmp/$PKGNAME/usr/bin/
 mkdir -p /tmp/$PKGNAME/etc/systemd/system/
 
 cat > /tmp/$PKGNAME/debian/changelog << EOF
-Please see https://github.com/Arceliar/yggdrasil-go/
+Please see https://github.com/yggdrasil-network/yggdrasil-go/
 EOF
 echo 9 > /tmp/$PKGNAME/debian/compat
 cat > /tmp/$PKGNAME/debian/control << EOF
@@ -43,15 +43,16 @@ Version: $PKGVERSION
 Section: contrib/net
 Priority: extra
 Architecture: $PKGARCH
+Replaces: yggdrasil yggdrasil-develop
 Maintainer: Neil Alexander <neilalexander@users.noreply.github.com>
 Description: Debian yggdrasil package
  Binary yggdrasil package for Debian and Ubuntu
 EOF
 cat > /tmp/$PKGNAME/debian/copyright << EOF
-Please see https://github.com/Arceliar/yggdrasil-go/
+Please see https://github.com/yggdrasil-network/yggdrasil-go/
 EOF
 cat > /tmp/$PKGNAME/debian/docs << EOF
-Please see https://github.com/Arceliar/yggdrasil-go/
+Please see https://github.com/yggdrasil-network/yggdrasil-go/
 EOF
 cat > /tmp/$PKGNAME/debian/install << EOF
 usr/bin/yggdrasil usr/bin

--- a/contrib/macos/yggdrasil.plist
+++ b/contrib/macos/yggdrasil.plist
@@ -8,7 +8,7 @@
     <array>
       <string>sh</string>
       <string>-c</string>
-      <string>/usr/bin/yggdrasil -useconf &lt; /etc/yggdrasil.conf</string>
+      <string>/usr/local/bin/yggdrasil -useconf &lt; /etc/yggdrasil.conf</string>
     </array>
     <key>KeepAlive</key>
     <true/>


### PR DESCRIPTION
Makes the launchd file for macOS refer to `/usr/local/bin` instead of `/usr/bin`, since `/usr/bin` is protected by System Integrity Protection and can't be written to/installed in very easily.

Also amends the Debian control file to include a `Replaces:` statement so that `yggdrasil` and `yggdrasil-develop` can be installed on top of one another. Also fixes the URLs in some of the metadata files to point to the org repository.