### PR TITLE
Address prefix change

### DIFF
--- a/src/yggdrasil/address.go
+++ b/src/yggdrasil/address.go
@@ -19,17 +19,18 @@ func (a *address) isValid() bool {
 			return false
 		}
 	}
-	return (*a)[len(address_prefix)-1]&0x80 == 0
+	return true
 }
 
 // isValid returns true if a prefix falls within the range usable by the network.
 func (s *subnet) isValid() bool {
-	for idx := range address_prefix {
+	l := len(address_prefix)
+	for idx := range address_prefix[:l-1] {
 		if (*s)[idx] != address_prefix[idx] {
 			return false
 		}
 	}
-	return (*s)[len(address_prefix)-1]&0x80 != 0
+	return (*s)[l-1] == address_prefix[l-1]|0x01
 }
 
 // address_addrForNodeID takes a *NodeID as an argument and returns an *address.
@@ -83,7 +84,7 @@ func address_subnetForNodeID(nid *NodeID) *subnet {
 	addr := *address_addrForNodeID(nid)
 	var snet subnet
 	copy(snet[:], addr[:])
-	snet[len(address_prefix)-1] |= 0x80
+	snet[len(address_prefix)-1] |= 0x01
 	return &snet
 }
 

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -406,7 +406,7 @@ func (a *admin) startTunWithMTU(ifname string, iftapmode bool, ifmtu int) error 
 	_ = a.core.tun.close()
 	// Then reconfigure and start it
 	addr := a.core.router.addr
-	straddr := fmt.Sprintf("%s/%v", net.IP(addr[:]).String(), 8*len(address_prefix))
+	straddr := fmt.Sprintf("%s/%v", net.IP(addr[:]).String(), 8*len(address_prefix)-1)
 	if ifname != "none" {
 		err := a.core.tun.setup(ifname, iftapmode, straddr, ifmtu)
 		if err != nil {

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -117,7 +117,7 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 	}
 
 	ip := net.IP(c.router.addr[:]).String()
-	if err := c.tun.start(nc.IfName, nc.IfTAPMode, fmt.Sprintf("%s/8", ip), nc.IfMTU); err != nil {
+	if err := c.tun.start(nc.IfName, nc.IfTAPMode, fmt.Sprintf("%s/%d", ip, 8*len(address_prefix)-1), nc.IfMTU); err != nil {
 		c.log.Println("Failed to start TUN/TAP")
 		return err
 	}

--- a/src/yggdrasil/icmpv6.go
+++ b/src/yggdrasil/icmpv6.go
@@ -252,7 +252,7 @@ func (i *icmpv6) handle_ndp(in []byte) ([]byte, error) {
 	case source.isValid():
 	case snet.isValid():
 	default:
-		return nil, errors.New("Not an NDP for fd00::/8")
+		return nil, errors.New("Not an NDP for 0200::/7")
 	}
 
 	// Create our NDP message body response

--- a/src/yggdrasil/tun_darwin.go
+++ b/src/yggdrasil/tun_darwin.go
@@ -87,7 +87,7 @@ func (tun *tunDevice) setupAddress(addr string) error {
 
 	ar.ifra_prefixmask.sin6_len = uint8(unsafe.Sizeof(ar.ifra_prefixmask))
 	b := make([]byte, 16)
-	binary.LittleEndian.PutUint16(b, uint16(0xFF00))
+	binary.LittleEndian.PutUint16(b, uint16(0xFE00))
 	ar.ifra_prefixmask.sin6_addr[0] = uint16(binary.BigEndian.Uint16(b))
 
 	ar.ifra_addr.sin6_len = uint8(unsafe.Sizeof(ar.ifra_addr))


### PR DESCRIPTION
Previously: used `fd00::/8`, with `fd00::/9` for nodes and `fd80::/9` for `/64` subnets.
Now: uses `0200::/7`, with `0200::/8` for nodes and `0300::/8` for subnets, to avoid conflicts for people already using ULA in their networks. The `0200::/7` range was reserved in [rfc1888](https://tools.ietf.org/html/rfc1888) and deprecated in [rfc4048](https://tools.ietf.org/html/rfc4048), and appears to have not been reassigned for any purpose yet, so we think it's safe to squat here for now.

We can always change the address range later. NodeIDs are used internally, so only the edges of the network need to update for new addressing schemes to work.

Tested on linux, and I think I've updated the required parts for macos. I think other platforms *should* work, but testing would be good. The main issue would be that we've switched from a `/8` to a `/7` and need to make sure the correct prefix length is set, otherwise `/64` ranges will be unreachable.

Marked breaking because any services running on top of it will be broken by the change, at least until addresses are updated to use the new range.