### PR TITLE
Bugfixes

### DIFF
--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -10,7 +10,7 @@ package yggdrasil
 
 import _ "golang.org/x/net/ipv6" // TODO put this somewhere better
 
-import "golang.org/x/net/proxy"
+//import "golang.org/x/net/proxy"
 
 import "fmt"
 import "net"
@@ -353,6 +353,7 @@ func (c *Core) DEBUG_addPeer(addr string) {
 	}
 }
 
+/*
 func (c *Core) DEBUG_addSOCKSConn(socksaddr, peeraddr string) {
 	go func() {
 		dialer, err := proxy.SOCKS5("tcp", socksaddr, nil, proxy.Direct)
@@ -370,6 +371,7 @@ func (c *Core) DEBUG_addSOCKSConn(socksaddr, peeraddr string) {
 		}
 	}()
 }
+*/
 
 //*
 func (c *Core) DEBUG_setupAndStartGlobalTCPInterface(addrport string) {
@@ -384,7 +386,7 @@ func (c *Core) DEBUG_getGlobalTCPAddr() *net.TCPAddr {
 }
 
 func (c *Core) DEBUG_addTCPConn(saddr string) {
-	c.tcp.call(saddr)
+	c.tcp.call(saddr, nil)
 }
 
 //*/

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -126,8 +126,10 @@ func (t *dht) handleReq(req *dhtReq) {
 		key:    req.Key,
 		coords: req.Coords,
 	}
-	t.insertIfNew(&info, false) // This seems DoSable (we just trust their coords...)
-	//if req.dest != t.nodeID { t.ping(&info, info.getNodeID()) } // Or spam...
+	// For bootstrapping to work, we need to add these nodes to the table
+	// Using insertIfNew, they can lie about coords, but searches will route around them
+	// Using the mill would mean trying to block off the mill becomes an attack vector
+	t.insertIfNew(&info, false)
 }
 
 // Reads a lookup response, checks that we had sent a matching request, and processes the response info.
@@ -142,6 +144,7 @@ func (t *dht) handleRes(res *dhtRes) {
 	if !isIn {
 		return
 	}
+	delete(reqs, res.Dest)
 	now := time.Now()
 	rinfo := dhtInfo{
 		key:           res.Key,


### PR DESCRIPTION
Fixes two bugs (and some debug code used by the sim).

1. `dht.handleRes` now cleans up the old request info immediately. This prevents nodes from spamming responses that would then be processed until the maintenance cycle cleans up the old request for having timed out.
2. When the switch receives a message from a node, and that message advertises a different root or coordinates than before, the firstSeen time of that node gets set to now (i.e. we reset the uptime to 0). If the node happens to be our parent, then we possibly replace them as the parent immediately instead of using their new coords and replacing them the next time another node advertises to us. This prevents malicious parent nodes from repeatedly advertising different coords (in case they have 2 non-looping routes to the tree), which would cause downstream coord oscillations for us and all our children. Now we'll switch to any other non-looping path, if possible, unless all the viable alternatives have also reset recently. Our coord change is immediately sent to our peers, which could cause our children to switch to a new parent, which could in turn cause us to switch over to being their child node, so it *should* prevent forced oscillations from constantly flooding updates as long as there's at least 1 path of non-malicious nodes to the root.

For the second item, the case where all paths have malicious nodes needs some kind of throttling, such that the worst case scenario is that the isolated honest nodes are updating coords too quickly to converge, but not arbitrarily fast (to not waste bandwidth/power). Ideally, they should begin ignoring the flappy peers, and split the network to find  a root from within the stable region. I'm not sure how to do that (it seems like it would need a lot of fine tuning), so I'm not attempting it for now.