### PR TITLE
Fix typo for big-endian BOM

### DIFF
--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -117,7 +117,7 @@ func main() {
 		// of it - remove it and decode back down into UTF-8. This is necessary
 		// because hjson doesn't know what to do with UTF-16 and will panic
 		if bytes.Compare(config[0:2], []byte{0xFF, 0xFE}) == 0 ||
-			bytes.Compare(config[0:2], []byte{0xFF, 0xFF}) == 0 {
+			bytes.Compare(config[0:2], []byte{0xFE, 0xFF}) == 0 {
 			utf := unicode.UTF16(unicode.BigEndian, unicode.UseBOM)
 			decoder := utf.NewDecoder()
 			config, err = decoder.Bytes(config)


### PR DESCRIPTION
This was a typo that would have affected detecting a BOM for big-endian UTF-16.

This didn't affect Windows as it seems to rather tightly stick to little-endian.

Thanks @cathugger for pointing this out!