### PR TITLE
Update build script

### DIFF
--- a/build
+++ b/build
@@ -20,6 +20,6 @@ for file in *.go ; do
     go build -ldflags="-s -w" -v $file
   fi
   if [ $UPX ]; then
-    upx --brute ${file/.go/}
+    upx --brute ${file%.go}
   fi
 done

--- a/build
+++ b/build
@@ -1,11 +1,25 @@
 #!/bin/sh
+while getopts ud option
+do
+  case "${option}"
+  in
+  u) UPX=true;;
+  d) DEBUG=true;;
+  esac
+done
 export GOPATH=$PWD
 echo "Downloading..."
 go get -d -v
 go get -d -v yggdrasil
 for file in *.go ; do
   echo "Building: $file"
-  go build $@ $file
-  #go build -ldflags="-s -w" -v $file
-  #upx --brute ${file/.go/}
+  #go build $@ $file
+  if [ $DEBUG ]; then
+    go build -tags debug -v $file
+  else
+    go build -ldflags="-s -w" -v $file
+  fi
+  if [ $UPX ]; then
+    upx --brute ${file/.go/}
+  fi
 done


### PR DESCRIPTION
These updates cause the build script to strip the binary by default, unless producing a debug build.

This also adds two flags to `build`:
- `-d` for debug builds (doesn't strip and adds `-tags debug`)
- `-u` for UPX packing, if available on the system