### PR TITLE
Sesson cleanup

### DIFF
--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -101,6 +101,8 @@ func (r *router) mainLoop() {
 				// Any periodic maintenance stuff goes here
 				r.core.switchTable.doMaintenance()
 				r.core.dht.doMaintenance()
+				r.core.sessions.cleanup()
+				r.core.sigs.cleanup()
 				util_getBytes() // To slowly drain things
 			}
 		case f := <-r.admin:


### PR DESCRIPTION
Currently, when creating a new session, we first loop over all existing sessions and clean up any timed-out ones. This is probably bad if there's a lot of open sessions and large numbers are created/destroyed.

This change removes the cleanup from createSession, and instead runs cleanup periodically (once per minute, which is also the time between session timeouts). It does something similar with cached checked signatures, which were using a similar logic (but at least had a timeout between cleanup attempts before).