### PR TITLE
More tcp fine tuning

### DIFF
--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -242,7 +242,7 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 	in := func(bs []byte) {
 		p.handlePacket(bs)
 	}
-	out := make(chan []byte, 1)
+	out := make(chan []byte, 1024) // Should be effectively infinite, but gets fed into finite LIFO stack
 	defer close(out)
 	go func() {
 		var shadow int64
@@ -296,6 +296,7 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 				select {
 				case msg := <-p.linkOut:
 					send <- msg
+					continue
 				default:
 				}
 				// Then block until we send or receive something

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -249,6 +250,10 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 		var stack [][]byte
 		put := func(msg []byte) {
 			stack = append(stack, msg)
+			sort.SliceStable(stack, func(i, j int) bool {
+				// Sort in reverse order, with smallest messages at the end
+				return len(stack[i]) >= len(stack[j])
+			})
 			for len(stack) > 32 {
 				util_putBytes(stack[0])
 				stack = stack[1:]


### PR DESCRIPTION
This needs further testing before merging. Some of the improvements are unexpected,

Does 2 related things:
1. Moves the tcp writes to a separate goroutine from the one that manages the LIFO stack, and adjust channel buffer sizes. Using a separate goroutine for the stack manager means we can continue to read from the outgoing channel and append to the stack while a tcp write is blocked. The large buffer size of the out channel is to give the go runtime the freedom to schedule things how it wants without forcing a context switch due to the channel send.
2. After a packet is added to the outgoing stack, we do a sort.SliceStable by message size. This is one of those things that I tried just for the sake of trying, but it seems to help. I think I maybe understand why: most congestion comes from TCP streams, and those tend to send many packets of the same size. The stable sort preserves the relative order of packets in a stream in that case, so the usual benefits of the LIFO order are mostly intact. However, sorting by size means that small packets are prioritized, which helps UDP traffic or TCP streams that spend most of their time idle (hopefully that includes VoIP, games, or other latency sensitive applications).

Tests, to be repeated when the network has other sources of congestion, in case the behavior is different for some reason (since I don't understand why it does some of what it does, it's hard to predict what the effects would be if the congestion is elsewhere):

I have a connection A->B->C->...->X, where A is my computer and X is a minecraft server. While playing, I run iperf to have B send to A and congest the link (B is A's only peer). Previously, the game would stay connected, but my subjective experience was that it was unplayable under congestion--mobs warp around, punching dirt cause the block to disappear a noticeable time before the collectible/inventory dirt block spawns, and then there's another delay before it gets picked up). After these changes, there's a noticeable delay between punching a block and the item spawn, but it's not painfully obvious when I'm not trying to look for it. Mob movements aren't completely smooth, but they don't teleport around like they did before. There was one instance where a region of the map didn't seem to load properly, but I've had trouble reproducing it (it loads a little slower than I'd like in general, but I'm not sure if that's a ygg issue or normal behavior for minecraft these days--it's been a while).

Another subjective test: starting a vpn and making a test call with skype. Previously, this caused some static noises and speed warping throughout the whole call. Now it causes some noise when the TCP stream first starts in the background, and some (less severe) speed warping throughout--I might not have noticed it if I hadn't heard the same recording before.

For reasons I don't understand, throughput over iperf is more stable and a little higher on average.