### PR TITLE
Local backpressure improvements

### DIFF
--- a/misc/run-schannel-netns
+++ b/misc/run-schannel-netns
@@ -51,12 +51,12 @@ ip netns exec node4 ip link set lo up
 ip netns exec node5 ip link set lo up
 ip netns exec node6 ip link set lo up
 
-ip netns exec node1 ./run --autoconf --pprof &> /dev/null &
-ip netns exec node2 ./run --autoconf --pprof &> /dev/null &
-ip netns exec node3 ./run --autoconf --pprof &> /dev/null &
-ip netns exec node4 ./run --autoconf --pprof &> /dev/null &
-ip netns exec node5 ./run --autoconf --pprof &> /dev/null &
-ip netns exec node6 ./run --autoconf --pprof &> /dev/null &
+ip netns exec node1 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
+ip netns exec node2 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
+ip netns exec node3 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
+ip netns exec node4 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
+ip netns exec node5 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
+ip netns exec node6 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
 
 echo "Started, to continue you should (possibly w/ sudo):"
 echo "kill" $(jobs -p)

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -101,6 +101,11 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 		return err
 	}
 
+	if err := c.switchTable.start(); err != nil {
+		c.log.Println("Failed to start switch")
+		return err
+	}
+
 	if err := c.router.start(); err != nil {
 		c.log.Println("Failed to start router")
 		return err

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -49,6 +49,7 @@ func (c *Core) Init() {
 	bpub, bpriv := newBoxKeys()
 	spub, spriv := newSigKeys()
 	c.init(bpub, bpriv, spub, spriv)
+	c.switchTable.start()
 	c.router.start()
 }
 

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -481,13 +481,17 @@ func DEBUG_simLinkPeers(p, q *peer) {
 		}
 	}()
 	p.out = func(bs []byte) {
+		p.core.switchTable.idleIn <- p.port
 		go q.handlePacket(bs)
 	}
 	q.out = func(bs []byte) {
+		q.core.switchTable.idleIn <- q.port
 		go p.handlePacket(bs)
 	}
 	go p.linkLoop()
 	go q.linkLoop()
+	p.core.switchTable.idleIn <- p.port
+	q.core.switchTable.idleIn <- q.port
 }
 
 func (c *Core) DEBUG_simFixMTU() {

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -74,9 +74,8 @@ func (ps *peers) putPorts(ports map[switchPort]*peer) {
 	ps.ports.Store(ports)
 }
 
-// Information known about a peer, including thier box/sig keys, precomputed shared keys (static and ephemeral), a handler for their outgoing traffic, and queue sizes for local backpressure.
+// Information known about a peer, including thier box/sig keys, precomputed shared keys (static and ephemeral) and a handler for their outgoing traffic
 type peer struct {
-	queueSize  int64  // used to track local backpressure
 	bytesSent  uint64 // To track bandwidth usage for getPeers
 	bytesRecvd uint64 // To track bandwidth usage for getPeers
 	// BUG: sync/atomic, 32 bit platforms need the above to be the first element
@@ -92,16 +91,6 @@ type peer struct {
 	dinfo      *dhtInfo        // used to keep the DHT working
 	out        func([]byte)    // Set up by whatever created the peers struct, used to send packets to other nodes
 	close      func()          // Called when a peer is removed, to close the underlying connection, or via admin api
-}
-
-// Size of the queue of packets to be sent to the node.
-func (p *peer) getQueueSize() int64 {
-	return atomic.LoadInt64(&p.queueSize)
-}
-
-// Used to increment or decrement the queue.
-func (p *peer) updateQueueSize(delta int64) {
-	atomic.AddInt64(&p.queueSize, delta)
 }
 
 // Creates a new peer with the specified box, sig, and linkShared keys, using the lowest unocupied port number.

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -229,19 +229,7 @@ func (p *peer) handleTraffic(packet []byte, pTypeLen int) {
 		// Drop traffic until the peer manages to send us at least one good switchMsg
 		return
 	}
-	coords, coordLen := wire_decode_coords(packet[pTypeLen:])
-	if coordLen >= len(packet) {
-		return
-	} // No payload
-	toPort := p.core.switchTable.lookup(coords)
-	if toPort == p.port {
-		return
-	}
-	to := p.core.peers.getPorts()[toPort]
-	if to == nil {
-		return
-	}
-	to.sendPacket(packet)
+	p.core.switchTable.packetIn <- packet
 }
 
 // This just calls p.out(packet) for now.

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -624,8 +624,10 @@ func (t *switchTable) handleIdle(port switchPort, stacks map[string][][]byte) bo
 	var bestSize int
 	for streamID, packets := range stacks {
 		// Filter over the streams that this node is closer to
+		// Keep the one with the smallest queue
 		packet := packets[len(packets)-1]
-		if (bestSize == 0 || len(packets) < bestSize) && t.portIsCloser(packet, port) {
+		coords := switch_getPacketCoords(packet)
+		if (bestSize == 0 || len(packets) < bestSize) && t.portIsCloser(coords, port) {
 			best = streamID
 			bestSize = len(packets)
 		}

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -586,32 +586,6 @@ func (t *switchTable) handleIn(packet []byte, idle map[switchPort]struct{}) bool
 	}
 }
 
-/*
-FIXME for some reason the new version is a *lot* slower than this one was
-It seems to be from the switchLocator.dist(coords) calls
-
-// Handles incoming idle notifications
-// Loops over packets and sends the newest one that's OK for this peer to send
-// Returns true if the peer is no longer idle, false if it should be added to the idle list
-func (t *switchTable) handleIdle(port switchPort, packets *[][]byte) bool {
-	to := t.core.peers.getPorts()[port]
-	if to == nil {
-		return true
-	}
-	for idx := len(*packets) - 1; idx >= 0; idx-- {
-		packet := (*packets)[idx]
-		_, pTypeLen := wire_decode_uint64(packet)
-		coords, _ := wire_decode_coords(packet[pTypeLen:])
-		if t.portIsCloser(coords, port) {
-			to.sendPacket(packet)
-			*packets = append((*packets)[:idx], (*packets)[idx+1:]...)
-			return true
-		}
-	}
-	return false
-}
-*/
-
 // Handles incoming idle notifications
 // Loops over packets and sends the newest one that's OK for this peer to send
 // Returns true if the peer is no longer idle, false if it should be added to the idle list

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -242,7 +242,7 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 	in := func(bs []byte) {
 		p.handlePacket(bs)
 	}
-	out := make(chan []byte, 1)
+	out := make(chan []byte, 1024) // Should be effectively infinite, but gets fed into finite LIFO stack
 	defer close(out)
 	go func() {
 		var shadow int64
@@ -296,6 +296,7 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 				select {
 				case msg := <-p.linkOut:
 					send <- msg
+					continue
 				default:
 				}
 				// Then block until we send or receive something

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -249,6 +250,10 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 		var stack [][]byte
 		put := func(msg []byte) {
 			stack = append(stack, msg)
+			sort.SliceStable(stack, func(i, j int) bool {
+				// Sort in reverse order, with smallest messages at the end
+				return len(stack[i]) >= len(stack[j])
+			})
 			for len(stack) > 32 {
 				util_putBytes(stack[0])
 				stack = stack[1:]


### PR DESCRIPTION
These changes give a more realistic implementation of backpressure using only local information.

Switch lookup logic has been moved to a dedicated switch worker goroutine, which does basically 2 things:
1. When a packet comes in, it checks all idle peers, and sends the packet to the one that's the best next hop, if a valid next hop exists. If no next hop exists, the packet is buffered, with overflowing buffers dropping in FIFO order.
2. When a connection to a peer notifies the switch that it's idle (i.e. able to send something), the worker loops over the buffers and finds the smallest non-empty buffer for which the peer is a valid next hop, and sends a packet from the buffer (FIFO). If it can't find a packet, it adds the link to the idle set (to be used by 1).

Separate buffers are maintained for each session (`coords` + `handle`) or protocol traffic pairing (`coords` + `toKey` + `fromKey`). Since the smallest non-empty buffer is used in 2, my *hope* is that it will tend to send traffic from mostly-idle connections first, to give latency-sensitive small traffic streams a higher priority than bulk data transfers. Separate buffers per session means that different nodes no longer interfere with eachother, outside of the TCP socket buffers, so a simple FIFO buffer can be used, which improves throughput. The down side is that there's multiple traffic sources in the same session (e.g. a connection to a VPN with both TCP and UDP streams in it), then the TCP tends to cause that whole session to bufferbloat. Switching back to LIFO would be a possible workaround for that, but I'd like to look for alternatives first.

The changes generally work, but more testing is needed to see if there are additional performance implications that I haven't noticed yet.