### PR TITLE
More backpressure tuning

### DIFF
--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -600,7 +600,7 @@ type switch_buffer struct {
 // Clean up old packets from buffers, to help keep latency within some reasonable bound
 func (t *switchTable) cleanBuffer(b *switch_buffer) {
 	// TODO sane maximum buffer size, or else CoDel-like maximum time
-	for len(b.packets) > 32 || (len(b.packets) > 0 && t.selfIsClosest(switch_getPacketCoords(b.packets[0].bytes))) {
+	for len(b.packets) > 1024 || (len(b.packets) > 0 && t.selfIsClosest(switch_getPacketCoords(b.packets[0].bytes))) {
 		util_putBytes(b.packets[0].bytes)
 		b.packets = b.packets[1:]
 	}

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -609,7 +609,6 @@ func (t *switchTable) cleanBuffer(b *switch_buffer) {
 	const timeout = 25 * time.Millisecond
 	now := time.Now()
 	for len(b.packets) > 0 && (dropAll || len(b.packets) > 32 || (len(b.packets) > 1 && now.Sub(b.packets[0].time) > timeout)) {
-		t.core.log.Println("DEBUG:", len(b.packets), now.Sub(b.packets[0].time))
 		util_putBytes(b.packets[0].bytes)
 		b.packets = b.packets[1:]
 	}

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -589,7 +589,6 @@ func (t *switchTable) handleIn(packet []byte, idle map[switchPort]struct{}) bool
 // Info about a buffered packet
 type switch_packetInfo struct {
 	bytes []byte
-	//time  time.Time // Timestamp of when the packet arrived
 }
 
 // Used to keep track of buffered packets
@@ -600,7 +599,7 @@ type switch_buffer struct {
 
 // Clean up old packets from buffers, to help keep latency within some reasonable bound
 func (t *switchTable) cleanBuffer(b *switch_buffer) {
-  // TODO sane maximum buffer size, or else CoDel-like maximum time
+	// TODO sane maximum buffer size, or else CoDel-like maximum time
 	for len(b.packets) > 32 || (len(b.packets) > 0 && t.selfIsClosest(switch_getPacketCoords(b.packets[0].bytes))) {
 		util_putBytes(b.packets[0].bytes)
 		b.packets = b.packets[1:]
@@ -634,12 +633,10 @@ func (t *switchTable) handleIdle(port switchPort, buffs map[string]switch_buffer
 		}
 	}
 	if bestSize != 0 {
-    t.core.log.Println("DEBUG:", []byte(best), bestSize)
 		buf := buffs[best]
 		var packet switch_packetInfo
 		// TODO decide if this should be LIFO or FIFO
 		packet, buf.packets = buf.packets[0], buf.packets[1:]
-		//buf.count-- // Force flooding connections to eventually yield
 		if len(buf.packets) == 0 {
 			delete(buffs, best)
 		} else {
@@ -676,7 +673,7 @@ func (t *switchTable) doWorker() {
 				streamID := switch_getPacketStreamID(packet)
 				buf := buffs[streamID]
 				t.cleanBuffer(&buf)
-				pinfo := switch_packetInfo{packet/*, time.Now()*/}
+				pinfo := switch_packetInfo{packet}
 				buf.packets = append(buf.packets, pinfo)
 				buf.count++
 				buffs[streamID] = buf


### PR DESCRIPTION
Needs testing, but this tries to tune the local backpressure stuff a little better.

The changes are:
1. Remove the 25 ms time for packets to sit in the queue.
2. Limit the maximum number of queues to 32, to prevent possible OOM DoS attacks, since 1 means queues are not guaranteed to empty eventually (without this, a node could use random coordinates to create an arbitrary number of queues with 1 packet each, and those packets would never be dropped due to timeout).
3. Limit the maximum queue size to ~~32~~ 1024, to prevent OOM DoS (combined with the above, and the fact that there's a maximum packet size enforced in tcp.go, this limits total memory usage to ~~`32*32*(65535+2048) = 69204992 bytes`~~ `32*1024*(65535+2048) = 2214559744 bytes` in backpressure related buffers. These numbers can be tuned later, the important thing is to have some kind of maximum. This is intentionally a stupidly large value, since I have no sense for what actually makes sense.
4. If we no longer have any peer that would be a valid next hop to some destination, then immediately drop all packets from that queue. Required due to 1, in case peers and/or coords change after a queue has already been created.
5. Removed the `buf.count--` when sending a packet. This means that, until a queue is completely drained, the count will keep rising. Since low-count queues are given a higher priority, this makes sure that bulk transfers really get out of the way (previously, they tended to drain the queue and reset the counter a little too easily, which caused them to sometimes beat lower bandwidth / more latency sensitive traffic).