### PR TITLE
Limit backpressure resource consumption

### DIFF
--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -631,8 +631,12 @@ func (b *switch_buffers) cleanup(t *switchTable) {
 			packet, buf.packets = buf.packets[0], buf.packets[1:]
 			buf.size -= uint64(len(packet.bytes))
 			b.size -= uint64(len(packet.bytes))
+			util_putBytes(packet.bytes)
 			if len(buf.packets) == 0 {
 				delete(b.bufs, streamID)
+			} else {
+				// Need to update the map, since buf was retrieved by value
+				b.bufs[streamID] = buf
 			}
 			break
 		}
@@ -672,6 +676,7 @@ func (t *switchTable) handleIdle(port switchPort, bufs *switch_buffers) bool {
 		if len(buf.packets) == 0 {
 			delete(bufs.bufs, best)
 		} else {
+			// Need to update the map, since buf was retrieved by value
 			bufs.bufs[best] = buf
 		}
 		to.sendPacket(packet.bytes)

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -12,6 +12,7 @@ package yggdrasil
 //  A little annoying to do with constant changes from backpressure
 
 import (
+	"math/rand"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -624,7 +625,13 @@ func (b *switch_buffers) cleanup(t *switchTable) {
 	const maxSize = 4 * 1048576 // Maximum 4 MB
 	for b.size > maxSize {
 		// Drop a random queue
-		for streamID := range b.bufs {
+		target := rand.Uint64() % b.size
+		var size uint64 // running total
+		for streamID, buf := range b.bufs {
+			size += buf.size
+			if size < target {
+				continue
+			}
 			remove(streamID)
 			break
 		}


### PR DESCRIPTION
Previously, we kept an arbitrary amount of information in the backpressure buffers, but removed anything older than 25 ms. That time is both arbitrary and needs work tuning.

This patch set changes the following:
1. Track queue sizes in terms of bytes instead of number of packets.
2. Limit the total size of all queues to 4 MB. If the queue sizes get larger than this limit, the first packet from a random queue is dropped, with odds based on relative queue sizes, until the total drops below 4 MB. The 4 MB threshold is arbitrary, but I think it's a reasonable size for now. We could either make this configurable, or adjusted at runtime based on e.g. number of peers, at some later point.
3. When deciding which queue to send from, select the one that maximizes `<age of oldest packet>/<size of queue>`. Previously, it always sent from the smallest queue. This change continues to prioritize small streams of traffic, but prevents high bandwidth queues from blocking completely.