### PR TITLE
Fallback to TCP when parsing AdminListen

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -245,7 +245,8 @@ func (a *admin) listen() {
 		case "tcp":
 			a.listener, err = net.Listen("tcp", u.Host)
 		default:
-			err = errors.New(fmt.Sprint("protocol not supported: ", u.Scheme))
+			// err = errors.New(fmt.Sprint("protocol not supported: ", u.Scheme))
+			a.listener, err = net.Listen("tcp", a.listenaddr)
 		}
 	} else {
 		a.listener, err = net.Listen("tcp", a.listenaddr)


### PR DESCRIPTION
This falls back to trying TCP in the event of `AdminListen` scheme parsing failing - i.e. `localhost:9001` will detect `localhost` as the scheme and fail. This might break some old configs or expected behaviour if changed, so falling back to TCP is better than failing altogether.