### PR TITLE
Cap MTU on Linux in TAP mode

### DIFF
--- a/src/yggdrasil/tun_linux.go
+++ b/src/yggdrasil/tun_linux.go
@@ -37,6 +37,10 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 			tun.mtu = 65535-tun_ETHER_HEADER_LENGTH
 		}
 	}
+	// Friendly output
+	tun.core.log.Printf("Interface name: %s", tun.iface.Name())
+	tun.core.log.Printf("Interface IPv6: %s", addr)
+	tun.core.log.Printf("Interface MTU: %d", tun.mtu)
 	return tun.setupAddress(addr)
 }
 

--- a/src/yggdrasil/tun_linux.go
+++ b/src/yggdrasil/tun_linux.go
@@ -29,6 +29,14 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 	}
 	tun.iface = iface
 	tun.mtu = getSupportedMTU(mtu)
+	// The following check is specific to Linux, as the TAP driver only supports
+	// an MTU of 65535-14 to make room for the ethernet headers. This makes sure
+	// that the MTU gets rounded down to 65521 instead of causing a panic.
+	if iftapmode {
+		if tun.mtu > 65535-tun_ETHER_HEADER_LENGTH {
+			tun.mtu = 65535-tun_ETHER_HEADER_LENGTH
+		}
+	}
 	return tun.setupAddress(addr)
 }
 

--- a/src/yggdrasil/tun_windows.go
+++ b/src/yggdrasil/tun_windows.go
@@ -57,6 +57,10 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 	if err != nil {
 		panic(err)
 	}
+	// Friendly output
+	tun.core.log.Printf("Interface name: %s", tun.iface.Name())
+	tun.core.log.Printf("Interface IPv6: %s", addr)
+	tun.core.log.Printf("Interface MTU: %d", tun.mtu)
 	return tun.setupAddress(addr)
 }
 


### PR DESCRIPTION
On Linux, the maximum MTU ordinarily is 65535 for TUN devices, but it appears that TAP devices also account for the 14 byte ethernet header, making 65521 the maximum MTU for TAP.

Beforehand, if you had the `IfMTU` setting as higher than 65521 and enabled `IfTAPMode`, Yggdrasil would panic at startup with an `invalid argument` error.

This patch caps the TAP MTU to 65521 so that it starts correctly. It does not affect TUN.