### PR TITLE
Sort dotgraph links by integer value

### DIFF
--- a/src/yggdrasil/tun_linux.go
+++ b/src/yggdrasil/tun_linux.go
@@ -34,7 +34,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 	// that the MTU gets rounded down to 65521 instead of causing a panic.
 	if iftapmode {
 		if tun.mtu > 65535-tun_ETHER_HEADER_LENGTH {
-			tun.mtu = 65535-tun_ETHER_HEADER_LENGTH
+			tun.mtu = 65535 - tun_ETHER_HEADER_LENGTH
 		}
 	}
 	// Friendly output


### PR DESCRIPTION
Previously, when running dot over the api, links were sorted by destination node coords, with the coords already in a string format. Now they're sorted by the integer value of the last hop in the coords, so `10` is added to the graph after `2`. This leads to a better layout in the resulting image if you run `yggdrasilctl dot | dot -Tsvg -o network.svg` or similar.