### PR TITLE
StreamID changes

### DIFF
--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -529,24 +529,13 @@ func switch_getPacketCoords(packet []byte) []byte {
 }
 
 // Returns a unique string for each stream of traffic
-// Equal to type+coords+handle for traffic packets
-// Equal to type+coords+toKey+fromKey for protocol traffic packets
+// Equal to coords
+// The sender may append arbitrary info to the end of coords (as long as it's begins with a 0x00) to designate separate traffic streams
+// Currently, it's the IPv6 next header type and the first 2 uint16 of the next header
+// This is equivalent to the TCP/UDP protocol numbers and the source / dest ports
+// TODO figure out if something else would make more sense (other transport protocols?)
 func switch_getPacketStreamID(packet []byte) string {
-	pType, pTypeLen := wire_decode_uint64(packet)
-	_, coordLen := wire_decode_coords(packet[pTypeLen:])
-	end := pTypeLen + coordLen
-	switch {
-	case pType == wire_Traffic:
-		end += handleLen // handle
-	case pType == wire_ProtocolTraffic:
-		end += 2 * boxPubKeyLen
-	default:
-		end = 0
-	}
-	if end > len(packet) {
-		end = len(packet)
-	}
-	return string(packet[:end])
+	return string(switch_getPacketCoords(packet))
 }
 
 // Handle an incoming packet


### PR DESCRIPTION
Packets in the switch are tagged with a stream id, which determines which queue they end up in.

Previously, this was some combination of packet type, coords, and handle (for session traffic) or keys (for protocol traffic). Now it's just equal to the coords.

Meanwhile, in the session worker that encrypts outgoing packets, coords are appended with `0x00` (to make sure they always get routed to the destination node's self peer -- aka the router), followed by some arbitrary data to put different streams of traffic into different queues. Currently, this is the IPv6 header's next header field (typically this indicates a TCP or UDP header is next), followed by the first two uint16 from the next header (source and destination port for TCP and UDP), with all of these things being converted to a uint64 and then stored in uint64 wire format (VLQ format).

The main effect should be that multiple streams of traffic between a pair of nodes should end up in different queues, so they'll be throttled independent of each other by the switch layer.