### PR TITLE
Make TCP read timeouts configurable.

### DIFF
--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -5,6 +5,7 @@ type NodeConfig struct {
 	Listen                      string   `comment:"Listen address for peer connections. Default is to listen for all\nTCP connections over IPv4 and IPv6 with a random port."`
 	AdminListen                 string   `comment:"Listen address for admin connections Default is to listen for local\nconnections either on TCP/9001 or a UNIX socket depending on your\nplatform. Use this value for yggdrasilctl -endpoint=X."`
 	Peers                       []string `comment:"List of connection strings for static peers in URI format, i.e.\ntcp://a.b.c.d:e or socks://a.b.c.d:e/f.g.h.i:j"`
+	ReadTimeout                 int32    `comment:"Read timeout for connections, specified in milliseconds. If less than 6000 and not negative, 6000 (the default) is used. If negative, reads won't time out."`
 	AllowedEncryptionPublicKeys []string `comment:"List of peer encryption public keys to allow or incoming TCP\nconnections from. If left empty/undefined then all connections\nwill be allowed by default."`
 	EncryptionPublicKey         string   `comment:"Your public encryption key. Your peers may ask you for this to put\ninto their AllowedEncryptionPublicKeys configuration."`
 	EncryptionPrivateKey        string   `comment:"Your private encryption key. DO NOT share this with anyone!"`

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -97,7 +97,7 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 	c.init(&boxPub, &boxPriv, &sigPub, &sigPriv)
 	c.admin.init(c, nc.AdminListen)
 
-	if err := c.tcp.init(c, nc.Listen); err != nil {
+	if err := c.tcp.init(c, nc.Listen, nc.ReadTimeout); err != nil {
 		c.log.Println("Failed to start TCP interface")
 		return err
 	}

--- a/src/yggdrasil/tun_linux.go
+++ b/src/yggdrasil/tun_linux.go
@@ -34,7 +34,7 @@ func (tun *tunDevice) setup(ifname string, iftapmode bool, addr string, mtu int)
 	// that the MTU gets rounded down to 65521 instead of causing a panic.
 	if iftapmode {
 		if tun.mtu > 65535-tun_ETHER_HEADER_LENGTH {
-			tun.mtu = 65535-tun_ETHER_HEADER_LENGTH
+			tun.mtu = 65535 - tun_ETHER_HEADER_LENGTH
 		}
 	}
 	// Friendly output


### PR DESCRIPTION
This should be helpful on high-latency networks, like Tor or I2P.
Also gofmt.