### PR TITLE
Whitepaper

### DIFF
--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -427,7 +427,7 @@ func (c *Core) DEBUG_addSOCKSConn(socksaddr, peeraddr string) {
 
 //*
 func (c *Core) DEBUG_setupAndStartGlobalTCPInterface(addrport string) {
-	if err := c.tcp.init(c, addrport); err != nil {
+	if err := c.tcp.init(c, addrport, 0); err != nil {
 		c.log.Println("Failed to start TCP interface:", err)
 		panic(err)
 	}


### PR DESCRIPTION
Updates whitepaper to make it a little more readable. This mostly uses info from the old version of the about page on the .io site. There's more to do, but at least now the paper shouldn't be completely useless (and the info it does have should reasonably well reflect the current state of things).

Also fixes a compile error with debug builds.