### PR TITLE
Fix bug in admin dot graph

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -656,6 +656,16 @@ func (a *admin) getResponse_dot() []byte {
 			newInfo.name = "?"
 			newInfo.key = key
 			newInfo.options = "fontname=\"sans serif\" style=dashed color=\"#999999\" fontcolor=\"#999999\""
+
+			coordsSplit := coordSlice(newInfo.key)
+			if len(coordsSplit) != 0 {
+				portStr := coordsSplit[len(coordsSplit)-1]
+				portUint, err := strconv.ParseUint(portStr, 10, 64)
+				if err == nil {
+					newInfo.port = switchPort(portUint)
+				}
+			}
+
 			infos[key] = newInfo
 		}
 	}


### PR DESCRIPTION
This fixes a stupid bug I introduced in an earlier patch. In the dot graph, links to unknown (`?`) nodes were keeping a default (0) value for the port number attached to the link. This patch sets labels on these links to the correct values.