### PR TITLE
Support adding peers on specific interfaces

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -113,18 +113,22 @@ func (a *admin) init(c *Core, listenaddr string) {
 		return admin_info{"sessions": sessions}, nil
 	})
 	a.addHandler("addPeer", []string{"uri", "[interface]"}, func(in admin_info) (admin_info, error) {
-		if a.addPeer(in["uri"].(string), in["interface"].(string)) == nil {
+		// Set sane defaults
+		intf := ""
+		// Has interface been specified?
+		if itf, ok := in["interface"]; ok {
+			intf = itf.(string)
+		}
+		if a.addPeer(in["uri"].(string), intf) == nil {
 			return admin_info{
 				"added": []string{
 					in["uri"].(string),
-					in["interface"].(string),
 				},
 			}, nil
 		} else {
 			return admin_info{
 				"not_added": []string{
 					in["uri"].(string),
-					in["interface"].(string),
 				},
 			}, errors.New("Failed to add peer")
 		}

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -510,6 +510,8 @@ func (a *admin) getData_getSwitchPeers() []admin_nodeInfo {
 			{"ip", net.IP(addr[:]).String()},
 			{"coords", fmt.Sprint(coords)},
 			{"port", elem.port},
+			{"bytes_sent", atomic.LoadUint64(&peer.bytesSent)},
+			{"bytes_recvd", atomic.LoadUint64(&peer.bytesRecvd)},
 		}
 		peerInfos = append(peerInfos, info)
 	}

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -395,7 +395,11 @@ func (a *admin) addPeer(addr string) error {
 	if err == nil {
 		switch strings.ToLower(u.Scheme) {
 		case "tcp":
-			a.core.tcp.connect(u.Host)
+			if len(u.Path) > 1 {
+				a.core.tcp.connect(u.Host, u.Path[1:])
+			} else {
+				a.core.tcp.connect(u.Host, "")
+			}
 		case "socks":
 			a.core.tcp.connectSOCKS(u.Host, u.Path[1:])
 		default:
@@ -407,7 +411,7 @@ func (a *admin) addPeer(addr string) error {
 		if strings.HasPrefix(addr, "tcp:") {
 			addr = addr[4:]
 		}
-		a.core.tcp.connect(addr)
+		a.core.tcp.connect(addr, "")
 		return nil
 	}
 	return nil

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -112,17 +112,19 @@ func (a *admin) init(c *Core, listenaddr string) {
 		}
 		return admin_info{"sessions": sessions}, nil
 	})
-	a.addHandler("addPeer", []string{"uri"}, func(in admin_info) (admin_info, error) {
-		if a.addPeer(in["uri"].(string)) == nil {
+	a.addHandler("addPeer", []string{"uri", "[interface]"}, func(in admin_info) (admin_info, error) {
+		if a.addPeer(in["uri"].(string), in["interface"].(string)) == nil {
 			return admin_info{
 				"added": []string{
 					in["uri"].(string),
+					in["interface"].(string),
 				},
 			}, nil
 		} else {
 			return admin_info{
 				"not_added": []string{
 					in["uri"].(string),
+					in["interface"].(string),
 				},
 			}, errors.New("Failed to add peer")
 		}
@@ -390,16 +392,12 @@ func (a *admin) printInfos(infos []admin_nodeInfo) string {
 }
 
 // addPeer triggers a connection attempt to a node.
-func (a *admin) addPeer(addr string) error {
+func (a *admin) addPeer(addr string, sintf string) error {
 	u, err := url.Parse(addr)
 	if err == nil {
 		switch strings.ToLower(u.Scheme) {
 		case "tcp":
-			if len(u.Path) > 1 {
-				a.core.tcp.connect(u.Host, u.Path[1:])
-			} else {
-				a.core.tcp.connect(u.Host, "")
-			}
+			a.core.tcp.connect(u.Host, sintf)
 		case "socks":
 			a.core.tcp.connectSOCKS(u.Host, u.Path[1:])
 		default:

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -2,19 +2,20 @@ package config
 
 // NodeConfig defines all configuration values needed to run a signle yggdrasil node
 type NodeConfig struct {
-	Listen                      string   `comment:"Listen address for peer connections. Default is to listen for all\nTCP connections over IPv4 and IPv6 with a random port."`
-	AdminListen                 string   `comment:"Listen address for admin connections Default is to listen for local\nconnections either on TCP/9001 or a UNIX socket depending on your\nplatform. Use this value for yggdrasilctl -endpoint=X."`
-	Peers                       []string `comment:"List of connection strings for static peers in URI format, i.e.\ntcp://a.b.c.d:e or socks://a.b.c.d:e/f.g.h.i:j"`
-	ReadTimeout                 int32    `comment:"Read timeout for connections, specified in milliseconds. If less than 6000 and not negative, 6000 (the default) is used. If negative, reads won't time out."`
-	AllowedEncryptionPublicKeys []string `comment:"List of peer encryption public keys to allow or incoming TCP\nconnections from. If left empty/undefined then all connections\nwill be allowed by default."`
-	EncryptionPublicKey         string   `comment:"Your public encryption key. Your peers may ask you for this to put\ninto their AllowedEncryptionPublicKeys configuration."`
-	EncryptionPrivateKey        string   `comment:"Your private encryption key. DO NOT share this with anyone!"`
-	SigningPublicKey            string   `comment:"Your public signing key. You should not ordinarily need to share\nthis with anyone."`
-	SigningPrivateKey           string   `comment:"Your private signing key. DO NOT share this with anyone!"`
-	MulticastInterfaces         []string `comment:"Regular expressions for which interfaces multicast peer discovery\nshould be enabled on. If none specified, multicast peer discovery is\ndisabled. The default value is .* which uses all interfaces."`
-	IfName                      string   `comment:"Local network interface name for TUN/TAP adapter, or \"auto\" to select\nan interface automatically, or \"none\" to run without TUN/TAP."`
-	IfTAPMode                   bool     `comment:"Set local network interface to TAP mode rather than TUN mode if\nsupported by your platform - option will be ignored if not."`
-	IfMTU                       int      `comment:"Maximux Transmission Unit (MTU) size for your local TUN/TAP interface.\nDefault is the largest supported size for your platform. The lowest\npossible value is 1280."`
+	Listen                      string              `comment:"Listen address for peer connections. Default is to listen for all\nTCP connections over IPv4 and IPv6 with a random port."`
+	AdminListen                 string              `comment:"Listen address for admin connections Default is to listen for local\nconnections either on TCP/9001 or a UNIX socket depending on your\nplatform. Use this value for yggdrasilctl -endpoint=X."`
+	Peers                       []string            `comment:"List of connection strings for static peers in URI format, i.e.\ntcp://a.b.c.d:e or socks://a.b.c.d:e/f.g.h.i:j"`
+	InterfacePeers              map[string][]string `comment:"List of connection strings for static peers in URI format, arranged\nby source interface, i.e. { \"eth0\": [ tcp://a.b.c.d:e ] }"`
+	ReadTimeout                 int32               `comment:"Read timeout for connections, specified in milliseconds. If less\nthan 6000 and not negative, 6000 (the default) is used. If negative,\nreads won't time out."`
+	AllowedEncryptionPublicKeys []string            `comment:"List of peer encryption public keys to allow or incoming TCP\nconnections from. If left empty/undefined then all connections\nwill be allowed by default."`
+	EncryptionPublicKey         string              `comment:"Your public encryption key. Your peers may ask you for this to put\ninto their AllowedEncryptionPublicKeys configuration."`
+	EncryptionPrivateKey        string              `comment:"Your private encryption key. DO NOT share this with anyone!"`
+	SigningPublicKey            string              `comment:"Your public signing key. You should not ordinarily need to share\nthis with anyone."`
+	SigningPrivateKey           string              `comment:"Your private signing key. DO NOT share this with anyone!"`
+	MulticastInterfaces         []string            `comment:"Regular expressions for which interfaces multicast peer discovery\nshould be enabled on. If none specified, multicast peer discovery is\ndisabled. The default value is .* which uses all interfaces."`
+	IfName                      string              `comment:"Local network interface name for TUN/TAP adapter, or \"auto\" to select\nan interface automatically, or \"none\" to run without TUN/TAP."`
+	IfTAPMode                   bool                `comment:"Set local network interface to TAP mode rather than TUN mode if\nsupported by your platform - option will be ignored if not."`
+	IfMTU                       int                 `comment:"Maximux Transmission Unit (MTU) size for your local TUN/TAP interface.\nDefault is the largest supported size for your platform. The lowest\npossible value is 1280."`
 	//Net                         NetConfig `comment:"Extended options for connecting to peers over other networks."`
 }
 

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -4,8 +4,8 @@ package config
 type NodeConfig struct {
 	Listen                      string              `comment:"Listen address for peer connections. Default is to listen for all\nTCP connections over IPv4 and IPv6 with a random port."`
 	AdminListen                 string              `comment:"Listen address for admin connections Default is to listen for local\nconnections either on TCP/9001 or a UNIX socket depending on your\nplatform. Use this value for yggdrasilctl -endpoint=X."`
-	Peers                       []string            `comment:"List of connection strings for static peers in URI format, i.e.\ntcp://a.b.c.d:e or socks://a.b.c.d:e/f.g.h.i:j"`
-	InterfacePeers              map[string][]string `comment:"List of connection strings for static peers in URI format, arranged\nby source interface, i.e. { \"eth0\": [ tcp://a.b.c.d:e ] }"`
+	Peers                       []string            `comment:"List of connection strings for static peers in URI format, i.e.\ntcp://a.b.c.d:e or socks://a.b.c.d:e/f.g.h.i:j."`
+	InterfacePeers              map[string][]string `comment:"List of connection strings for static peers in URI format, arranged\nby source interface, i.e. { \"eth0\": [ tcp://a.b.c.d:e ] }. Note that\nSOCKS peerings will NOT be affected by this option and should go in\nthe \"Peers\" section instead."`
 	ReadTimeout                 int32               `comment:"Read timeout for connections, specified in milliseconds. If less\nthan 6000 and not negative, 6000 (the default) is used. If negative,\nreads won't time out."`
 	AllowedEncryptionPublicKeys []string            `comment:"List of peer encryption public keys to allow or incoming TCP\nconnections from. If left empty/undefined then all connections\nwill be allowed by default."`
 	EncryptionPublicKey         string              `comment:"Your public encryption key. Your peers may ask you for this to put\ninto their AllowedEncryptionPublicKeys configuration."`

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -182,8 +182,8 @@ func (c *Core) SetLogger(log *log.Logger) {
 
 // Adds a peer. This should be specified in the peer URI format, i.e.
 // tcp://a.b.c.d:e, udp://a.b.c.d:e, socks://a.b.c.d:e/f.g.h.i:j
-func (c *Core) AddPeer(addr string) error {
-	return c.admin.addPeer(addr)
+func (c *Core) AddPeer(addr string, sintf string) error {
+	return c.admin.addPeer(addr, sintf)
 }
 
 // Adds an expression to select multicast interfaces for peer discovery. This

--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -153,6 +153,6 @@ func (m *multicast) listen() {
 		}
 		addr.Zone = from.Zone
 		saddr := addr.String()
-		m.core.tcp.connect(saddr)
+		m.core.tcp.connect(saddr, "")
 	}
 }

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -138,6 +138,9 @@ func (iface *tcpInterface) call(saddr string, socksaddr *string, sintf string) {
 		var conn net.Conn
 		var err error
 		if socksaddr != nil {
+			if sintf != "" {
+				return
+			}
 			var dialer proxy.Dialer
 			dialer, err = proxy.SOCKS5("tcp", *socksaddr, nil, proxy.Direct)
 			if err != nil {
@@ -159,6 +162,9 @@ func (iface *tcpInterface) call(saddr string, socksaddr *string, sintf string) {
 			if sintf != "" {
 				ief, err := net.InterfaceByName(sintf)
 				if err == nil {
+					if ief.Flags & net.FlagUp == 0 {
+				    return
+					}
 					addrs, err := ief.Addrs()
 					if err == nil {
 						dst, err := net.ResolveTCPAddr("tcp", saddr)
@@ -175,10 +181,10 @@ func (iface *tcpInterface) call(saddr string, socksaddr *string, sintf string) {
 									IP:   src,
 									Port: 0,
 								}
+								break
 							}
 						}
 						if dialer.LocalAddr == nil {
-							iface.core.log.Println("No valid source address found for interface", sintf)
 							return
 						}
 					}

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -112,7 +112,10 @@ func (iface *tcpInterface) listener() {
 // This all happens in a separate goroutine that it spawns.
 func (iface *tcpInterface) call(saddr string, socksaddr *string, sintf string) {
 	go func() {
-		callname := fmt.Sprintf("%s/%s", saddr, sintf)
+		callname := saddr
+		if sintf != "" {
+			callname = fmt.Sprintf("%s/%s", saddr, sintf)
+		}
 		quit := false
 		iface.mutex.Lock()
 		if _, isIn := iface.calls[callname]; isIn {

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -60,6 +60,7 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 	cfg.SigningPublicKey = hex.EncodeToString(spub[:])
 	cfg.SigningPrivateKey = hex.EncodeToString(spriv[:])
 	cfg.Peers = []string{}
+	cfg.InterfacePeers = map[string][]string{}
 	cfg.AllowedEncryptionPublicKeys = []string{}
 	cfg.MulticastInterfaces = []string{".*"}
 	cfg.IfName = defaults.GetDefaults().DefaultIfName
@@ -231,13 +232,19 @@ func main() {
 	// configure them. The loop ensures that disconnected peers will eventually
 	// be reconnected with.
 	go func() {
-		if len(cfg.Peers) == 0 {
+		if len(cfg.Peers) == 0 && len(cfg.InterfacePeers) == 0 {
 			return
 		}
 		for {
-			for _, p := range cfg.Peers {
-				n.core.AddPeer(p)
+			for _, peer := range cfg.Peers {
+				n.core.AddPeer(peer, "")
 				time.Sleep(time.Second)
+			}
+			for intf, intfpeers := range cfg.InterfacePeers {
+				for _, peer := range intfpeers {
+					n.core.AddPeer(peer, intf)
+					time.Sleep(time.Second)
+				}
 			}
 			time.Sleep(time.Minute)
 		}


### PR DESCRIPTION
This adds support for a new configuration option `InterfacePeers` (in addition to `Peers`, not replacing). It allows adding a peering specifically on a given interface, and to create redundant peerings over redundant network links.

It scans the interface for the first unicast address that matches the protocol (IPv4 vs. IPv6) and then uses that as the source address for the TCP dial.

The changes to the configuration look like this:
```
  # List of connection strings for static peers in URI format, arranged
  # by source interface, i.e. { "eth0": [ tcp://a.b.c.d:e ] }
  InterfacePeers: {
    "en0": [ "tcp://172.22.97.1:5190" ]
    "en1": [ "tcp://172.22.97.1:5190" ]
  }
```
This will have no effect on SOCKS5 peers, which will continue to use the standard default source address. 

It also adds the optional `interface=` option to `addPeers` on the admin socket, and adds `bytes_sent` and `bytes_recvd` to `getSwitchPeers`. (Currently multiple connections to the same node show in `getSwitchPeers` but not `getPeers`).