### PR TITLE
Ignore peer in InterfacePeers when source interface not found

### DIFF
--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -161,7 +161,9 @@ func (iface *tcpInterface) call(saddr string, socksaddr *string, sintf string) {
 			dialer := net.Dialer{}
 			if sintf != "" {
 				ief, err := net.InterfaceByName(sintf)
-				if err == nil {
+				if err != nil {
+					return
+				} else {
 					if ief.Flags & net.FlagUp == 0 {
 				    return
 					}


### PR DESCRIPTION
This fixes a bug where an `InterfacePeers` entry with a source interface that doesn't exist doesn't get ignored properly.