### PR TITLE
Add freebsd service script into contrib

### DIFF
--- a/contrib/freebsd/yggdrasil
+++ b/contrib/freebsd/yggdrasil
@@ -1,0 +1,72 @@
+#!/bin/sh
+#
+# Put the yggdrasil and yggdrasilctl binaries into /usr/local/bin
+# Then copy this script into /etc/rc.d/yggdrasil
+# Finally, run:
+#   1. chmod +x /etc/rc.d/yggdrasil /usr/local/bin/{yggdrasil,yggdrasilctl}
+#   2. echo "yggdrasil_enable=yes" >> /etc/rc.d
+#   3. service yggdrasil start
+#
+# PROVIDE: yggdrasil
+# REQUIRE: networking
+# KEYWORD:
+
+. /etc/rc.subr
+
+name="yggdrasil"
+rcvar="yggdrasil_enable"
+
+start_cmd="${name}_start"
+stop_cmd="${name}_stop"
+
+pidfile="/var/run/yggdrasil/${name}.pid"
+command="/usr/sbin/daemon"
+command_args="-P ${pidfile} -r -f ${yggdrasil_command}"
+
+yggdrasil_start()
+{
+	test ! -x /usr/local/bin/yggdrasil && (
+		logger -s -t yggdrasil "Warning: /usr/local/bin/yggdrasil is missing or not executable"
+		logger -s -t yggdrasil "Copy the yggdrasil binary into /usr/local/bin and then chmod +x /usr/local/bin/yggdrasil"
+		return 1
+	)
+
+	test ! -f /etc/yggdrasil.conf && (
+		logger -s -t yggdrasil "Generating new configuration file into /etc/yggdrasil.conf"
+		/usr/local/bin/yggdrasil -genconf > /etc/yggdrasil.conf
+	)
+
+	tap_path="$(cat /etc/yggdrasil.conf | egrep -o '/dev/tap[0-9]{1,2}$')"
+	tap_name="$(echo -n ${tap_path} | tr -d '/dev/')"
+
+	/sbin/ifconfig ${tap_name} >/dev/null 2>&1 || (
+		logger -s -t yggdrasil "Creating ${tap_name} adapter"
+		/sbin/ifconfig ${tap_name} create || logger -s -t yggdrasil "Failed to create ${tap_name} adapter"
+	)
+
+	test ! -d /var/run/yggdrasil && mkdir -p /var/run/yggdrasil
+
+	logger -s -t yggdrasil "Starting yggdrasil"
+	${command} ${command_args} /usr/local/bin/yggdrasil -useconffile /etc/yggdrasil.conf \
+		1>/var/log/yggdrasil.stdout.log \
+		2>/var/log/yggdrasil.stderr.log &
+}
+
+yggdrasil_stop()
+{
+	logger -s -t yggdrasil "Stopping yggdrasil"
+	test -f /var/run/yggdrasil/${name}.pid && kill -TERM $(cat /var/run/yggdrasil/${name}.pid)
+
+	tap_path="$(cat /etc/yggdrasil.conf | grep /dev/tap | egrep -o '/dev/.*$')"
+        tap_name="$(echo -n ${tap_path} | tr -d '/dev/')"
+
+	/sbin/ifconfig ${tap_name} >/dev/null 2>&1 && (
+		logger -s -t yggdrasil "Destroying ${tap_name} adapter"
+		/sbin/ifconfig ${tap_name} destroy || logger -s -t yggdrasil "Failed to destroy ${tap_name} adapter"
+	)
+}
+
+load_rc_config $name
+: ${yggdrasil_enable:=no}
+
+run_rc_command "$1"


### PR DESCRIPTION
This adds a FreeBSD service file for rc.d into the `contrib` folder. 

The script assumes that `yggdrasil` and `yggdrasilctl` binaries are in `/usr/local/bin` and have been made executable. It will generate fresh configuration into `/etc/yggdrasil.conf` if it does not exist already, and it will create and destroy the `/dev/tapX` device as defined in the config if appropriate.

Steps to use:

1. Install the service file into `/etc/rc.d/yggdrasil`
2. Enable the service by putting `yggdrasil_enable=yes` into `/etc/rc.conf`
3. Start the service with `service yggdrasil start`

Tested with FreeBSD 11.2-RELEASE.