### PR TITLE
Add session firewall

### DIFF
--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -16,6 +16,7 @@ type NodeConfig struct {
 	IfName                      string              `comment:"Local network interface name for TUN/TAP adapter, or \"auto\" to select\nan interface automatically, or \"none\" to run without TUN/TAP."`
 	IfTAPMode                   bool                `comment:"Set local network interface to TAP mode rather than TUN mode if\nsupported by your platform - option will be ignored if not."`
 	IfMTU                       int                 `comment:"Maximux Transmission Unit (MTU) size for your local TUN/TAP interface.\nDefault is the largest supported size for your platform. The lowest\npossible value is 1280."`
+	SessionFirewall             SessionFirewall     `comment:"The session firewall controls who can send/receive network traffic\nto/from. This is useful if you want to protect this node without\nresorting to using a real firewall. This does not affect traffic\nbeing routed via this node to somewhere else."`
 	//Net                         NetConfig `comment:"Extended options for connecting to peers over other networks."`
 }
 
@@ -23,4 +24,12 @@ type NodeConfig struct {
 type NetConfig struct {
 	Tor TorConfig `comment:"Experimental options for configuring peerings over Tor."`
 	I2P I2PConfig `comment:"Experimental options for configuring peerings over I2P."`
+}
+
+type SessionFirewall struct {
+	Enable                        bool     `comment:"Enable or disable the session firewall. If disabled, network traffic\nfrom any node will be allowed. If enabled, the below rules apply."`
+	AllowFromDirect               bool     `comment:"Allow network traffic from directly connected peers."`
+	AllowFromRemote               bool     `comment:"Allow network traffic from remote nodes on the network that you are\nnot directly peered with."`
+	WhitelistEncryptionPublicKeys []string `comment:"List of public keys from which network traffic is always accepted,\nregardless of AllowFromDirect or AllowFromRemote."`
+	BlacklistEncryptionPublicKeys []string `comment:"List of public keys from which network traffic is always rejected,\nregardless of the whitelist, AllowFromDirect or AllowFromRemote."`
 }

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -30,6 +30,7 @@ type SessionFirewall struct {
 	Enable                        bool     `comment:"Enable or disable the session firewall. If disabled, network traffic\nfrom any node will be allowed. If enabled, the below rules apply."`
 	AllowFromDirect               bool     `comment:"Allow network traffic from directly connected peers."`
 	AllowFromRemote               bool     `comment:"Allow network traffic from remote nodes on the network that you are\nnot directly peered with."`
+	AlwaysAllowOutbound           bool     `comment:"Allow outbound network traffic regardless of AllowFromDirect or\nAllowFromRemote. This does allow a remote node to send unsolicited\ntraffic back to you for the length of the session."`
 	WhitelistEncryptionPublicKeys []string `comment:"List of public keys from which network traffic is always accepted,\nregardless of AllowFromDirect or AllowFromRemote."`
 	BlacklistEncryptionPublicKeys []string `comment:"List of public keys from which network traffic is always rejected,\nregardless of the whitelist, AllowFromDirect or AllowFromRemote."`
 }

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -16,7 +16,7 @@ type NodeConfig struct {
 	IfName                      string              `comment:"Local network interface name for TUN/TAP adapter, or \"auto\" to select\nan interface automatically, or \"none\" to run without TUN/TAP."`
 	IfTAPMode                   bool                `comment:"Set local network interface to TAP mode rather than TUN mode if\nsupported by your platform - option will be ignored if not."`
 	IfMTU                       int                 `comment:"Maximux Transmission Unit (MTU) size for your local TUN/TAP interface.\nDefault is the largest supported size for your platform. The lowest\npossible value is 1280."`
-	SessionFirewall             SessionFirewall     `comment:"The session firewall controls who can send/receive network traffic\nto/from. This is useful if you want to protect this node without\nresorting to using a real firewall. This does not affect traffic\nbeing routed via this node to somewhere else."`
+	SessionFirewall             SessionFirewall     `comment:"The session firewall controls who can send/receive network traffic\nto/from. This is useful if you want to protect this node without\nresorting to using a real firewall. This does not affect traffic\nbeing routed via this node to somewhere else. Rules are prioritised as\nfollows: whitelist, blacklist, always allow outgoing, direct, remote."`
 	//Net                         NetConfig `comment:"Extended options for connecting to peers over other networks."`
 }
 

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -108,7 +108,11 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 	}
 
 	c.sessions.setSessionFirewallState(nc.SessionFirewall.Enable)
-	c.sessions.setSessionFirewallDefaults(nc.SessionFirewall.AllowFromDirect, nc.SessionFirewall.AllowFromRemote)
+	c.sessions.setSessionFirewallDefaults(
+		nc.SessionFirewall.AllowFromDirect,
+		nc.SessionFirewall.AllowFromRemote,
+		nc.SessionFirewall.AlwaysAllowOutbound,
+	)
 	c.sessions.setSessionFirewallWhitelist(nc.SessionFirewall.WhitelistEncryptionPublicKeys)
 	c.sessions.setSessionFirewallBlacklist(nc.SessionFirewall.BlacklistEncryptionPublicKeys)
 

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -107,6 +107,11 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 		return err
 	}
 
+	c.sessions.setSessionFirewallState(nc.SessionFirewall.Enable)
+	c.sessions.setSessionFirewallDefaults(nc.SessionFirewall.AllowFromDirect, nc.SessionFirewall.AllowFromRemote)
+	c.sessions.setSessionFirewallWhitelist(nc.SessionFirewall.WhitelistEncryptionPublicKeys)
+	c.sessions.setSessionFirewallBlacklist(nc.SessionFirewall.BlacklistEncryptionPublicKeys)
+
 	if err := c.router.start(); err != nil {
 		c.log.Println("Failed to start router")
 		return err

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -17,7 +17,7 @@ import (
 type peers struct {
 	core                        *Core
 	mutex                       sync.Mutex   // Synchronize writes to atomic
-	ports                       atomic.Value //map[Port]*peer, use CoW semantics
+	ports                       atomic.Value //map[switchPort]*peer, use CoW semantics
 	authMutex                   sync.RWMutex
 	allowedEncryptionPublicKeys map[boxPubKey]struct{}
 }

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -184,6 +184,10 @@ func (s *searches) checkDHTRes(info *searchInfo, res *dhtRes) bool {
 	sinfo, isIn := s.core.sessions.getByTheirPerm(&res.Key)
 	if !isIn {
 		sinfo = s.core.sessions.createSession(&res.Key)
+		if sinfo == nil {
+			// nil if the DHT search finished but the session wasn't allowed
+			return true
+		}
 		_, isIn := s.core.sessions.getByTheirPerm(&res.Key)
 		if !isIn {
 			panic("This should never happen")

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -390,7 +390,7 @@ func (ss *sessions) handlePing(ping *sessionPing) {
 	// Get the corresponding session (or create a new session)
 	sinfo, isIn := ss.getByTheirPerm(&ping.SendPermPub)
 	// Check the session firewall
-	if ss.sessionFirewallEnabled {
+	if !isIn && ss.sessionFirewallEnabled {
 		if !ss.isSessionAllowed(&ping.SendPermPub) {
 			return
 		}

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -164,7 +164,7 @@ func (iface *tcpInterface) call(saddr string, socksaddr *string, sintf string) {
 				if err != nil {
 					return
 				} else {
-					if ief.Flags & net.FlagUp == 0 {
+					if ief.Flags&net.FlagUp == 0 {
 						return
 					}
 					addrs, err := ief.Addrs()

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -66,6 +66,9 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 	cfg.IfName = defaults.GetDefaults().DefaultIfName
 	cfg.IfMTU = defaults.GetDefaults().DefaultIfMTU
 	cfg.IfTAPMode = defaults.GetDefaults().DefaultIfTAPMode
+	cfg.SessionFirewall.Enable = false
+	cfg.SessionFirewall.AllowFromDirect = true
+	cfg.SessionFirewall.AllowFromRemote = true
 
 	return &cfg
 }


### PR DESCRIPTION
The session firewall is designed to control who you can exchange session traffic with. It lets you limit it based on whether the peer is direct, remote, listed in a whitelist or listed in a blacklist. It defaults to being disabled (that is, allowing all session traffic to pass).

The only thing I'm not particularly satisfied with is that currently this works by simply ignoring the session ping, so the session never actually gets created at all, whereas setting `IfName` to `none` allows the session to open anyway and sets an MTU of 0 whilst still preventing traffic flow. I am not sure which behaviour is better.

It adds the new default config:
```
  # The session firewall controls who can send/receive network traffic
  # to/from. This is useful if you want to protect this node without
  # resorting to using a real firewall. This does not affect traffic
  # being routed via this node to somewhere else.
  SessionFirewall:
  { 
    # Enable or disable the session firewall. If disabled, network traffic  
    # from any node will be allowed. If enabled, the below rules apply. 
    Enable: false
 
    # Allow network traffic from directly connected peers. 
    AllowFromDirect: true
 
    # Allow network traffic from remote nodes on the network that you are  
    # not directly peered with. 
    AllowFromRemote: true

    # Allow outbound network traffic regardless of AllowFromDirect or  
    # AllowFromRemote. This does allow a remote node to send unsolicited  
    # traffic back to you for the length of the session. 
    AlwaysAllowOutbound: false
 
    # List of public keys from which network traffic is always accepted,  
    # regardless of AllowFromDirect or AllowFromRemote. 
    WhitelistEncryptionPublicKeys: []
 
    # List of public keys from which network traffic is always rejected,  
    # regardless of the whitelist, AllowFromDirect or AllowFromRemote. 
    BlacklistEncryptionPublicKeys: []
  }
```