### PR TITLE
Fix a concurrent map read-write when removing peers

### DIFF
--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -127,7 +127,7 @@ func (ps *peers) removePeer(port switchPort) {
 		return
 	} // Can't remove self peer
 	ps.core.router.doAdmin(func() {
-		ps.core.switchTable.unlockedRemovePeer(port)
+		ps.core.switchTable.forgetPeer(port)
 	})
 	ps.mutex.Lock()
 	oldPorts := ps.getPorts()

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -242,7 +242,9 @@ func (t *switchTable) cleanRoot() {
 // Removes a peer.
 // Must be called by the router mainLoop goroutine, e.g. call router.doAdmin with a lambda that calls this.
 // If the removed peer was this node's parent, it immediately tries to find a new parent.
-func (t *switchTable) unlockedRemovePeer(port switchPort) {
+func (t *switchTable) forgetPeer(port switchPort) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
 	delete(t.data.peers, port)
 	t.updater.Store(&sync.Once{})
 	if port != t.parent {


### PR DESCRIPTION
With any luck, this will fix the bug that @MakeItGreatAgain reported with crashing under load when goroutines are running across CPU cores.

https://ban.ai/~jhj/misc/yggdrasil-crash-0928.txt