### PR TITLE
Tunnel traffic using crypto-key routing

### DIFF
--- a/src/yggdrasil/ckr.go
+++ b/src/yggdrasil/ckr.go
@@ -28,6 +28,7 @@ type cryptokey_route struct {
 	destination []byte
 }
 
+// Initialise crypto-key routing. This must be done before any other CKR calls.
 func (c *cryptokey) init(core *Core) {
 	c.core = core
 	c.ipv4routes = make([]cryptokey_route, 0)
@@ -38,14 +39,19 @@ func (c *cryptokey) init(core *Core) {
 	c.ipv6sources = make([]net.IPNet, 0)
 }
 
+// Enable or disable crypto-key routing.
 func (c *cryptokey) setEnabled(enabled bool) {
 	c.enabled = enabled
 }
 
+// Check if crypto-key routing is enabled.
 func (c *cryptokey) isEnabled() bool {
 	return c.enabled
 }
 
+// Check whether the given address (with the address length specified in bytes)
+// matches either the current node's address, the node's routed subnet or the
+// list of subnets specified in IPv4Sources/IPv6Sources.
 func (c *cryptokey) isValidSource(addr address, addrlen int) bool {
 	ip := net.IP(addr[:addrlen])
 
@@ -86,6 +92,8 @@ func (c *cryptokey) isValidSource(addr address, addrlen int) bool {
 	return false
 }
 
+// Adds a source subnet, which allows traffic with these source addresses to
+// be tunnelled using crypto-key routing.
 func (c *cryptokey) addSourceSubnet(cidr string) error {
 	// Is the CIDR we've been given valid?
 	_, ipnet, err := net.ParseCIDR(cidr)
@@ -121,6 +129,8 @@ func (c *cryptokey) addSourceSubnet(cidr string) error {
 	return nil
 }
 
+// Adds a destination route for the given CIDR to be tunnelled to the node
+// with the given BoxPubKey.
 func (c *cryptokey) addRoute(cidr string, dest string) error {
 	// Is the CIDR we've been given valid?
 	ipaddr, ipnet, err := net.ParseCIDR(cidr)
@@ -190,6 +200,9 @@ func (c *cryptokey) addRoute(cidr string, dest string) error {
 	return errors.New("Unspecified error")
 }
 
+// Looks up the most specific route for the given address (with the address
+// length specified in bytes) from the crypto-key routing table. An error is
+// returned if the address is not suitable or no route was found.
 func (c *cryptokey) getPublicKeyForAddress(addr address, addrlen int) (boxPubKey, error) {
 	// Check if the address is a valid Yggdrasil address - if so it
 	// is exempt from all CKR checking

--- a/src/yggdrasil/ckr.go
+++ b/src/yggdrasil/ckr.go
@@ -1,0 +1,104 @@
+package yggdrasil
+
+import (
+	"encoding/hex"
+	"errors"
+	"net"
+	"sort"
+)
+
+// This module implements crypto-key routing, similar to Wireguard, where we
+// allow traffic for non-Yggdrasil ranges to be routed over Yggdrasil.
+
+type cryptokey struct {
+	core       *Core
+	enabled    bool
+	ipv4routes []cryptokey_route
+	ipv6routes []cryptokey_route
+}
+
+type cryptokey_route struct {
+	subnet      net.IPNet
+	destination []byte
+}
+
+func (c *cryptokey) init(core *Core) {
+	c.core = core
+	c.ipv4routes = make([]cryptokey_route, 0)
+	c.ipv6routes = make([]cryptokey_route, 0)
+}
+
+func (c *cryptokey) isEnabled() bool {
+	return c.enabled
+}
+
+func (c *cryptokey) addRoute(cidr string, dest string) error {
+	// Is the CIDR we've been given valid?
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return err
+	}
+
+	// Get the prefix length and size
+	prefixlen, prefixsize := ipnet.Mask.Size()
+
+	// Check if the prefix is IPv4 or IPv6
+	if prefixsize == net.IPv6len*8 {
+		// IPv6
+		for _, route := range c.ipv6routes {
+			// Do we already have a route for this subnet?
+			routeprefixlen, _ := route.subnet.Mask.Size()
+			if route.subnet.IP.Equal(ipnet.IP) && routeprefixlen == prefixlen {
+				return errors.New("IPv6 route already exists")
+			}
+		}
+		// Decode the public key
+		if boxPubKey, err := hex.DecodeString(dest); err != nil {
+			return err
+		} else {
+			// Add the new crypto-key route
+			c.ipv6routes = append(c.ipv6routes, cryptokey_route{
+				subnet:      *ipnet,
+				destination: boxPubKey,
+			})
+			// Sort so most specific routes are first
+			sort.Slice(c.ipv6routes, func(i, j int) bool {
+				im, _ := c.ipv6routes[i].subnet.Mask.Size()
+				jm, _ := c.ipv6routes[j].subnet.Mask.Size()
+				return im > jm
+			})
+			return nil
+		}
+	} else if prefixsize == net.IPv4len*8 {
+		// IPv4
+		return errors.New("IPv4 not supported at this time")
+	}
+	return errors.New("Unspecified error")
+}
+
+func (c *cryptokey) getPublicKeyForAddress(addr string) (boxPubKey, error) {
+	ipaddr := net.ParseIP(addr)
+
+	if ipaddr.To4() == nil {
+		// IPv6
+		for _, route := range c.ipv6routes {
+			if route.subnet.Contains(ipaddr) {
+				var box boxPubKey
+				copy(box[:boxPubKeyLen], route.destination)
+				return box, nil
+			}
+		}
+	} else {
+		// IPv4
+		return boxPubKey{}, errors.New("IPv4 not supported at this time")
+		/*
+			    for _, route := range c.ipv4routes {
+						if route.subnet.Contains(ipaddr) {
+							return route.destination, nil
+						}
+					}
+		*/
+	}
+
+	return boxPubKey{}, errors.New("No route")
+}

--- a/src/yggdrasil/ckr.go
+++ b/src/yggdrasil/ckr.go
@@ -1,6 +1,7 @@
 package yggdrasil
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -49,15 +50,12 @@ func (c *cryptokey) isValidSource(addr address) bool {
 	ip := net.IP(addr[:])
 
 	// Does this match our node's address?
-	if addr == c.core.router.addr {
+	if bytes.Equal(addr[:16], c.core.router.addr[:16]) {
 		return true
 	}
 
 	// Does this match our node's subnet?
-	var subnet net.IPNet
-	copy(subnet.IP, c.core.router.subnet[:])
-	copy(subnet.Mask, net.CIDRMask(64, 128))
-	if subnet.Contains(ip) {
+	if bytes.Equal(addr[:8], c.core.router.subnet[:8]) {
 		return true
 	}
 

--- a/src/yggdrasil/ckr.go
+++ b/src/yggdrasil/ckr.go
@@ -99,7 +99,7 @@ func (c *cryptokey) getPublicKeyForAddress(addr address) (boxPubKey, error) {
 	// Check if the address is a valid Yggdrasil address - if so it
 	// is exempt from all CKR checking
 	if addr.isValid() {
-		return
+		return boxPubKey{}, errors.New("Cannot look up CKR for Yggdrasil addresses")
 	}
 
 	// Check if there's a cache entry for this addr

--- a/src/yggdrasil/ckr.go
+++ b/src/yggdrasil/ckr.go
@@ -96,6 +96,12 @@ func (c *cryptokey) addRoute(cidr string, dest string) error {
 }
 
 func (c *cryptokey) getPublicKeyForAddress(addr address) (boxPubKey, error) {
+	// Check if the address is a valid Yggdrasil address - if so it
+	// is exempt from all CKR checking
+	if addr.isValid() {
+		return
+	}
+
 	// Check if there's a cache entry for this addr
 	if route, ok := c.ipv6cache[addr]; ok {
 		var box boxPubKey

--- a/src/yggdrasil/ckr.go
+++ b/src/yggdrasil/ckr.go
@@ -16,6 +16,8 @@ type cryptokey struct {
 	enabled    bool
 	ipv4routes []cryptokey_route
 	ipv6routes []cryptokey_route
+	ipv4cache  map[address]cryptokey_route
+	ipv6cache  map[address]cryptokey_route
 }
 
 type cryptokey_route struct {
@@ -27,6 +29,8 @@ func (c *cryptokey) init(core *Core) {
 	c.core = core
 	c.ipv4routes = make([]cryptokey_route, 0)
 	c.ipv6routes = make([]cryptokey_route, 0)
+	c.ipv4cache = make(map[address]cryptokey_route, 0)
+	c.ipv6cache = make(map[address]cryptokey_route, 0)
 }
 
 func (c *cryptokey) isEnabled() bool {
@@ -68,12 +72,20 @@ func (c *cryptokey) addRoute(cidr string, dest string) error {
 				subnet:      *ipnet,
 				destination: boxPubKey,
 			})
+
 			// Sort so most specific routes are first
 			sort.Slice(c.ipv6routes, func(i, j int) bool {
 				im, _ := c.ipv6routes[i].subnet.Mask.Size()
 				jm, _ := c.ipv6routes[j].subnet.Mask.Size()
 				return im > jm
 			})
+
+			// Clear the cache as this route might change future routing
+			// Setting an empty slice keeps the memory whereas nil invokes GC
+			for k := range c.ipv6cache {
+				delete(c.ipv6cache, k)
+			}
+
 			return nil
 		}
 	} else if prefixsize == net.IPv4len*8 {
@@ -83,28 +95,39 @@ func (c *cryptokey) addRoute(cidr string, dest string) error {
 	return errors.New("Unspecified error")
 }
 
-func (c *cryptokey) getPublicKeyForAddress(addr string) (boxPubKey, error) {
-	ipaddr := net.ParseIP(addr)
+func (c *cryptokey) getPublicKeyForAddress(addr address) (boxPubKey, error) {
+	// Check if there's a cache entry for this addr
+	if route, ok := c.ipv6cache[addr]; ok {
+		var box boxPubKey
+		copy(box[:boxPubKeyLen], route.destination)
+		return box, nil
+	}
 
-	if ipaddr.To4() == nil {
-		// IPv6
+	// No cache was found - start by converting the address into a net.IP
+	ip := make(net.IP, 16)
+	copy(ip[:16], addr[:])
+
+	// Check whether it's an IPv4 or an IPv6 address
+	if ip.To4() == nil {
+		// Check if we have a route. At this point c.ipv6routes should be
+		// pre-sorted so that the most specific routes are first
 		for _, route := range c.ipv6routes {
-			if route.subnet.Contains(ipaddr) {
+			// Does this subnet match the given IP?
+			if route.subnet.Contains(ip) {
+				// Cache the entry for future packets to get a faster lookup
+				c.ipv6cache[addr] = route
+
+				// Return the boxPubKey
 				var box boxPubKey
 				copy(box[:boxPubKeyLen], route.destination)
 				return box, nil
 			}
 		}
 	} else {
-		// IPv4
+		// IPv4 isn't supported yet
 		return boxPubKey{}, errors.New("IPv4 not supported at this time")
-		/*
-			    for _, route := range c.ipv4routes {
-						if route.subnet.Contains(ipaddr) {
-							return route.destination, nil
-						}
-					}
-		*/
 	}
-	return boxPubKey{}, errors.New(fmt.Sprintf("No route to %s", addr))
+
+	// No route was found if we got to this point
+	return boxPubKey{}, errors.New(fmt.Sprintf("No route to %s", ip.String()))
 }

--- a/src/yggdrasil/ckr.go
+++ b/src/yggdrasil/ckr.go
@@ -86,6 +86,7 @@ func (c *cryptokey) addSourceSubnet(cidr string) error {
 
 	// Add the source subnet
 	c.ipv6sources = append(c.ipv6sources, *ipnet)
+	c.core.log.Println("Added CKR source subnet", cidr)
 	return nil
 }
 
@@ -138,6 +139,7 @@ func (c *cryptokey) addRoute(cidr string, dest string) error {
 				delete(c.ipv6cache, k)
 			}
 
+			c.core.log.Println("Added CKR destination subnet", cidr)
 			return nil
 		}
 	} else if prefixsize == net.IPv4len*8 {

--- a/src/yggdrasil/ckr.go
+++ b/src/yggdrasil/ckr.go
@@ -58,9 +58,11 @@ func (c *cryptokey) isValidSource(addr address) bool {
 	}
 
 	// Does it match a configured CKR source?
-	for _, subnet := range c.ipv6sources {
-		if subnet.Contains(ip) {
-			return true
+	if c.isEnabled() {
+		for _, subnet := range c.ipv6sources {
+			if subnet.Contains(ip) {
+				return true
+			}
 		}
 	}
 

--- a/src/yggdrasil/ckr.go
+++ b/src/yggdrasil/ckr.go
@@ -37,6 +37,10 @@ func (c *cryptokey) init(core *Core) {
 	c.ipv6sources = make([]net.IPNet, 0)
 }
 
+func (c *cryptokey) setEnabled(enabled bool) {
+	c.enabled = enabled
+}
+
 func (c *cryptokey) isEnabled() bool {
 	return c.enabled
 }

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -4,8 +4,8 @@ package config
 type NodeConfig struct {
 	Listen                      string              `comment:"Listen address for peer connections. Default is to listen for all\nTCP connections over IPv4 and IPv6 with a random port."`
 	AdminListen                 string              `comment:"Listen address for admin connections Default is to listen for local\nconnections either on TCP/9001 or a UNIX socket depending on your\nplatform. Use this value for yggdrasilctl -endpoint=X."`
-	Peers                       []string            `comment:"List of connection strings for static peers in URI format, i.e.\ntcp://a.b.c.d:e or socks://a.b.c.d:e/f.g.h.i:j."`
-	InterfacePeers              map[string][]string `comment:"List of connection strings for static peers in URI format, arranged\nby source interface, i.e. { \"eth0\": [ tcp://a.b.c.d:e ] }. Note that\nSOCKS peerings will NOT be affected by this option and should go in\nthe \"Peers\" section instead."`
+	Peers                       []string            `comment:"List of connection strings for static peers in URI format, e.g.\ntcp://a.b.c.d:e or socks://a.b.c.d:e/f.g.h.i:j."`
+	InterfacePeers              map[string][]string `comment:"List of connection strings for static peers in URI format, arranged\nby source interface, e.g. { \"eth0\": [ tcp://a.b.c.d:e ] }. Note that\nSOCKS peerings will NOT be affected by this option and should go in\nthe \"Peers\" section instead."`
 	ReadTimeout                 int32               `comment:"Read timeout for connections, specified in milliseconds. If less\nthan 6000 and not negative, 6000 (the default) is used. If negative,\nreads won't time out."`
 	AllowedEncryptionPublicKeys []string            `comment:"List of peer encryption public keys to allow or incoming TCP\nconnections from. If left empty/undefined then all connections\nwill be allowed by default."`
 	EncryptionPublicKey         string              `comment:"Your public encryption key. Your peers may ask you for this to put\ninto their AllowedEncryptionPublicKeys configuration."`
@@ -17,7 +17,7 @@ type NodeConfig struct {
 	IfTAPMode                   bool                `comment:"Set local network interface to TAP mode rather than TUN mode if\nsupported by your platform - option will be ignored if not."`
 	IfMTU                       int                 `comment:"Maximux Transmission Unit (MTU) size for your local TUN/TAP interface.\nDefault is the largest supported size for your platform. The lowest\npossible value is 1280."`
 	SessionFirewall             SessionFirewall     `comment:"The session firewall controls who can send/receive network traffic\nto/from. This is useful if you want to protect this node without\nresorting to using a real firewall. This does not affect traffic\nbeing routed via this node to somewhere else. Rules are prioritised as\nfollows: blacklist, whitelist, always allow outgoing, direct, remote."`
-	TunnelRouting               TunnelRouting       `comment:"Allow tunneling non-Yggdrasil traffic over Yggdrasil."`
+	TunnelRouting               TunnelRouting       `comment:"Allow tunneling non-Yggdrasil traffic over Yggdrasil. This effectively\nallows you to use Yggdrasil to route to, or to bridge other networks,\nsimilar to a VPN tunnel. Tunnelling works between any two nodes and\ndoes not require them to be directly peered."`
 	//Net                         NetConfig `comment:"Extended options for connecting to peers over other networks."`
 }
 
@@ -39,9 +39,9 @@ type SessionFirewall struct {
 
 // TunnelRouting contains the crypto-key routing tables for tunneling
 type TunnelRouting struct {
-	Enable           bool              `comment:"Enable or disable tunneling."`
-	IPv6Destinations map[string]string `comment:"IPv6 subnets, mapped to the EncryptionPublicKey to which they should\nbe routed to."`
-	IPv6Sources      []string          `comment:"Optional IPv6 subnets which are allowed to be used as source addresses\nin addition to this node's Yggdrasil address/subnet."`
-	IPv4Destinations map[string]string `comment:"IPv4 subnets, mapped to the EncryptionPublicKey to which they should\nbe routed to."`
-	IPv4Sources      []string          `comment:"Optional IPv4 subnets which are allowed to be used as source addresses."`
+	Enable           bool              `comment:"Enable or disable tunnel routing."`
+	IPv6Destinations map[string]string `comment:"IPv6 CIDR subnets, mapped to the EncryptionPublicKey to which they\nshould be routed, e.g. { \"aaaa:bbbb:cccc::/e\": \"boxpubkey\", ... }"`
+	IPv6Sources      []string          `comment:"Optional IPv6 source subnets which are allowed to be tunnelled in\naddition to this node's Yggdrasil address/subnet. If not\nspecified, only traffic originating from this node's Yggdrasil\naddress or subnet will be tunnelled."`
+	IPv4Destinations map[string]string `comment:"IPv4 CIDR subnets, mapped to the EncryptionPublicKey to which they\nshould be routed, e.g. { \"a.b.c.d/e\": \"boxpubkey\", ... }"`
+	IPv4Sources      []string          `comment:"IPv4 source subnets which are allowed to be tunnelled. Unlike for\nIPv6, this option is required for bridging IPv4 traffic. Only\ntraffic with a source matching these subnets will be tunnelled."`
 }

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -39,7 +39,7 @@ type SessionFirewall struct {
 
 // TunnelRouting contains the crypto-key routing tables for tunneling
 type TunnelRouting struct {
-	Enable      bool              `comment:"Enable or disable tunneling."`
-	IPv6Routes  map[string]string `comment:"IPv6 subnets, mapped to the public keys to which they should be routed."`
-	IPv6Sources []string          `comment:"Allow source addresses in these subnets."`
+	Enable           bool              `comment:"Enable or disable tunneling."`
+	IPv6Destinations map[string]string `comment:"IPv6 subnets, mapped to the EncryptionPublicKey to which they should\nbe routed to."`
+	IPv6Sources      []string          `comment:"Optional IPv6 subnets which are allowed to be used as source addresses\nin addition to this node's Yggdrasil address/subnet."`
 }

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -39,6 +39,7 @@ type SessionFirewall struct {
 
 // TunnelRouting contains the crypto-key routing tables for tunneling
 type TunnelRouting struct {
-	Enable     bool              `comment:"Enable or disable tunneling."`
-	IPv6Routes map[string]string `comment:"IPv6 subnets, mapped to the public keys to which they should be routed."`
+	Enable      bool              `comment:"Enable or disable tunneling."`
+	IPv6Routes  map[string]string `comment:"IPv6 subnets, mapped to the public keys to which they should be routed."`
+	IPv6Sources []string          `comment:"Allow source addresses in these subnets."`
 }

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -42,4 +42,6 @@ type TunnelRouting struct {
 	Enable           bool              `comment:"Enable or disable tunneling."`
 	IPv6Destinations map[string]string `comment:"IPv6 subnets, mapped to the EncryptionPublicKey to which they should\nbe routed to."`
 	IPv6Sources      []string          `comment:"Optional IPv6 subnets which are allowed to be used as source addresses\nin addition to this node's Yggdrasil address/subnet."`
+	IPv4Destinations map[string]string `comment:"IPv4 subnets, mapped to the EncryptionPublicKey to which they should\nbe routed to."`
+	IPv4Sources      []string          `comment:"Optional IPv4 subnets which are allowed to be used as source addresses."`
 }

--- a/src/yggdrasil/config/config.go
+++ b/src/yggdrasil/config/config.go
@@ -17,6 +17,7 @@ type NodeConfig struct {
 	IfTAPMode                   bool                `comment:"Set local network interface to TAP mode rather than TUN mode if\nsupported by your platform - option will be ignored if not."`
 	IfMTU                       int                 `comment:"Maximux Transmission Unit (MTU) size for your local TUN/TAP interface.\nDefault is the largest supported size for your platform. The lowest\npossible value is 1280."`
 	SessionFirewall             SessionFirewall     `comment:"The session firewall controls who can send/receive network traffic\nto/from. This is useful if you want to protect this node without\nresorting to using a real firewall. This does not affect traffic\nbeing routed via this node to somewhere else. Rules are prioritised as\nfollows: blacklist, whitelist, always allow outgoing, direct, remote."`
+	TunnelRouting               TunnelRouting       `comment:"Allow tunneling non-Yggdrasil traffic over Yggdrasil."`
 	//Net                         NetConfig `comment:"Extended options for connecting to peers over other networks."`
 }
 
@@ -26,6 +27,7 @@ type NetConfig struct {
 	I2P I2PConfig `comment:"Experimental options for configuring peerings over I2P."`
 }
 
+// SessionFirewall controls the session firewall configuration
 type SessionFirewall struct {
 	Enable                        bool     `comment:"Enable or disable the session firewall. If disabled, network traffic\nfrom any node will be allowed. If enabled, the below rules apply."`
 	AllowFromDirect               bool     `comment:"Allow network traffic from directly connected peers."`
@@ -33,4 +35,10 @@ type SessionFirewall struct {
 	AlwaysAllowOutbound           bool     `comment:"Allow outbound network traffic regardless of AllowFromDirect or\nAllowFromRemote. This does allow a remote node to send unsolicited\ntraffic back to you for the length of the session."`
 	WhitelistEncryptionPublicKeys []string `comment:"List of public keys from which network traffic is always accepted,\nregardless of AllowFromDirect or AllowFromRemote."`
 	BlacklistEncryptionPublicKeys []string `comment:"List of public keys from which network traffic is always rejected,\nregardless of the whitelist, AllowFromDirect or AllowFromRemote."`
+}
+
+// TunnelRouting contains the crypto-key routing tables for tunneling
+type TunnelRouting struct {
+	Enable     bool              `comment:"Enable or disable tunneling."`
+	IPv6Routes map[string]string `comment:"IPv6 subnets, mapped to the public keys to which they should be routed."`
 }

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -122,7 +122,7 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 	}
 
 	if nc.TunnelRouting.Enable {
-		for ipv6, pubkey := range nc.TunnelRouting.IPv6Routes {
+		for ipv6, pubkey := range nc.TunnelRouting.IPv6Destinations {
 			if err := c.router.cryptokey.addRoute(ipv6, pubkey); err != nil {
 				panic(err)
 			}

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -122,6 +122,7 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 	}
 
 	if nc.TunnelRouting.Enable {
+		c.log.Println("Crypto-key routing enabled")
 		for ipv6, pubkey := range nc.TunnelRouting.IPv6Destinations {
 			if err := c.router.cryptokey.addRoute(ipv6, pubkey); err != nil {
 				panic(err)

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -121,7 +121,8 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 		return err
 	}
 
-	if nc.TunnelRouting.Enable {
+	c.router.cryptokey.setEnabled(nc.TunnelRouting.Enable)
+	if c.router.cryptokey.isEnabled() {
 		c.log.Println("Crypto-key routing enabled")
 		for ipv6, pubkey := range nc.TunnelRouting.IPv6Destinations {
 			if err := c.router.cryptokey.addRoute(ipv6, pubkey); err != nil {

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -134,6 +134,16 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 				panic(err)
 			}
 		}
+		for ipv4, pubkey := range nc.TunnelRouting.IPv4Destinations {
+			if err := c.router.cryptokey.addRoute(ipv4, pubkey); err != nil {
+				panic(err)
+			}
+		}
+		for _, source := range nc.TunnelRouting.IPv4Sources {
+			if c.router.cryptokey.addSourceSubnet(source); err != nil {
+				panic(err)
+			}
+		}
 	}
 
 	if err := c.admin.start(); err != nil {

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -121,6 +121,14 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 		return err
 	}
 
+	if nc.TunnelRouting.Enable {
+		for ipv6, pubkey := range nc.TunnelRouting.IPv6Routes {
+			if err := c.router.cryptokey.addRoute(ipv6, pubkey); err != nil {
+				panic(err)
+			}
+		}
+	}
+
 	if err := c.admin.start(); err != nil {
 		c.log.Println("Failed to start admin socket")
 		return err

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -127,6 +127,11 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 				panic(err)
 			}
 		}
+		for _, source := range nc.TunnelRouting.IPv6Sources {
+			if c.router.cryptokey.addSourceSubnet(source); err != nil {
+				panic(err)
+			}
+		}
 	}
 
 	if err := c.admin.start(); err != nil {

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -259,6 +259,12 @@ func (r *router) recvPacket(bs []byte, sinfo *sessionInfo) {
 		util_putBytes(bs)
 		return
 	}
+	var dest address
+	copy(dest[:], bs[24:])
+	if !r.cryptokey.isValidSource(dest) {
+		util_putBytes(bs)
+		return
+	}
 	var source address
 	copy(source[:], bs[8:])
 	var snet subnet

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -140,6 +140,7 @@ func (r *router) sendPacket(bs []byte) {
 		copy(sourceAddr[:addrlen], bs[12:])
 		copy(dest[:addrlen], bs[16:])
 	} else {
+		// Unknown address length
 		return
 	}
 	if !r.cryptokey.isValidSource(sourceAddr, addrlen) {
@@ -287,6 +288,7 @@ func (r *router) recvPacket(bs []byte, sinfo *sessionInfo) {
 		copy(sourceAddr[:addrlen], bs[12:])
 		copy(dest[:addrlen], bs[16:])
 	} else {
+		// Unknown address length
 		return
 	}
 	if !r.cryptokey.isValidSource(dest, addrlen) {

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -134,7 +134,7 @@ func (r *router) sendPacket(bs []byte) {
 	copy(dest[:], bs[24:])
 	copy(snet[:], bs[24:])
 	if !dest.isValid() && !snet.isValid() {
-		if key, err := r.cryptokey.getPublicKeyForAddress(dest); err == nil {
+		if key, err := r.cryptokey.getPublicKeyForAddress(dest, 16); err == nil {
 			addr := *address_addrForNodeID(getNodeID(&key))
 			copy(dest[:], addr[:])
 			copy(snet[:], addr[:])
@@ -273,7 +273,7 @@ func (r *router) recvPacket(bs []byte, sinfo *sessionInfo) {
 	case source.isValid() && source == sinfo.theirAddr:
 	case snet.isValid() && snet == sinfo.theirSubnet:
 	default:
-		key, err := r.cryptokey.getPublicKeyForAddress(source)
+		key, err := r.cryptokey.getPublicKeyForAddress(source, 16)
 		if err != nil || key != sinfo.theirPermPub {
 			util_putBytes(bs)
 			return

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -125,11 +125,9 @@ func (r *router) sendPacket(bs []byte) {
 		panic("Tried to send a packet shorter than a header...")
 	}
 	var sourceAddr address
-	var sourceSubnet subnet
 	var dest address
 	var snet subnet
 	copy(sourceAddr[:], bs[8:])
-	copy(sourceSubnet[:], bs[8:])
 	if !r.cryptokey.isValidSource(sourceAddr) {
 		return
 	}

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -134,7 +134,16 @@ func (r *router) sendPacket(bs []byte) {
 	var snet subnet
 	copy(snet[:], bs[24:])
 	if !dest.isValid() && !snet.isValid() {
-		return
+		if key, err := r.cryptokey.getPublicKeyForAddress(dest); err == nil {
+			addr := *address_addrForNodeID(getNodeID(&key))
+			copy(dest[:], addr[:])
+			copy(snet[:], addr[:])
+			if !dest.isValid() && !snet.isValid() {
+				return
+			}
+		} else {
+			return
+		}
 	}
 	doSearch := func(packet []byte) {
 		var nodeID, mask *NodeID

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -32,14 +32,15 @@ import (
 // The router struct has channels to/from the tun/tap device and a self peer (0), which is how messages are passed between this node and the peers/switch layer.
 // The router's mainLoop goroutine is responsible for managing all information related to the dht, searches, and crypto sessions.
 type router struct {
-	core  *Core
-	addr  address
-	in    <-chan []byte // packets we received from the network, link to peer's "out"
-	out   func([]byte)  // packets we're sending to the network, link to peer's "in"
-	recv  chan<- []byte // place where the tun pulls received packets from
-	send  <-chan []byte // place where the tun puts outgoing packets
-	reset chan struct{} // signal that coords changed (re-init sessions/dht)
-	admin chan func()   // pass a lambda for the admin socket to query stuff
+	core      *Core
+	addr      address
+	in        <-chan []byte // packets we received from the network, link to peer's "out"
+	out       func([]byte)  // packets we're sending to the network, link to peer's "in"
+	recv      chan<- []byte // place where the tun pulls received packets from
+	send      <-chan []byte // place where the tun puts outgoing packets
+	reset     chan struct{} // signal that coords changed (re-init sessions/dht)
+	admin     chan func()   // pass a lambda for the admin socket to query stuff
+	cryptokey cryptokey
 }
 
 // Initializes the router struct, which includes setting up channels to/from the tun/tap.
@@ -67,6 +68,7 @@ func (r *router) init(core *Core) {
 	r.core.tun.send = send
 	r.reset = make(chan struct{}, 1)
 	r.admin = make(chan func())
+	r.cryptokey.init(r.core)
 	// go r.mainLoop()
 }
 

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -124,14 +124,11 @@ func (r *router) sendPacket(bs []byte) {
 	}
 	var sourceAddr address
 	var sourceSubnet subnet
+	var dest address
+	var snet subnet
 	copy(sourceAddr[:], bs[8:])
 	copy(sourceSubnet[:], bs[8:])
-	if !sourceAddr.isValid() && !sourceSubnet.isValid() {
-		return
-	}
-	var dest address
 	copy(dest[:], bs[24:])
-	var snet subnet
 	copy(snet[:], bs[24:])
 	if !dest.isValid() && !snet.isValid() {
 		if key, err := r.cryptokey.getPublicKeyForAddress(dest); err == nil {
@@ -142,6 +139,10 @@ func (r *router) sendPacket(bs []byte) {
 				return
 			}
 		} else {
+			return
+		}
+	} else {
+		if !sourceAddr.isValid() && !sourceSubnet.isValid() {
 			return
 		}
 	}

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -589,5 +589,5 @@ func (sinfo *sessionInfo) doRecv(p *wire_trafficPacket) {
 	sinfo.updateNonce(&p.Nonce)
 	sinfo.time = time.Now()
 	sinfo.bytesRecvd += uint64(len(bs))
-	sinfo.core.router.recvPacket(bs, &sinfo.theirAddr, &sinfo.theirSubnet)
+	sinfo.core.router.recvPacket(bs, sinfo)
 }

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -105,7 +105,7 @@ func (tun *tunDevice) read() error {
 			n != 256*int(buf[o+4])+int(buf[o+5])+tun_IPv6_HEADER_LENGTH+o {
 			// Either not an IPv6 packet or not the complete packet for some reason
 			//panic("Should not happen in testing")
-			continue
+			//continue
 		}
 		if buf[o+6] == 58 {
 			// Found an ICMPv6 packet

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -101,11 +101,11 @@ func (tun *tunDevice) read() error {
 		if tun.iface.IsTAP() {
 			o = tun_ETHER_HEADER_LENGTH
 		}
-		if buf[o]&0xf0 != 0x60 ||
-			n != 256*int(buf[o+4])+int(buf[o+5])+tun_IPv6_HEADER_LENGTH+o {
-			// Either not an IPv6 packet or not the complete packet for some reason
-			//panic("Should not happen in testing")
-			//continue
+		switch {
+		case buf[o]&0xf0 == 0x60 && n == 256*int(buf[o+4])+int(buf[o+5])+tun_IPv6_HEADER_LENGTH+o:
+		case buf[o]&0xf0 == 0x40 && n == 256*int(buf[o+2])+int(buf[o+3])+o:
+		default:
+			continue
 		}
 		if buf[o+6] == 58 {
 			// Found an ICMPv6 packet


### PR DESCRIPTION
This PR allows non-Yggdrasil subnets to be routed over Yggdrasil. It allows for specific subnets to be routed to a specific public key (`IPv4Destinations` and `IPv6Destinations`) and allows specifying valid source addresses for crypto-key-routed traffic (`IPv4Sources` and `IPv6Sources`).