### PR TITLE
Chord

### DIFF
--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -415,10 +415,10 @@ func main() {
 	}
 	fmt.Println("Test")
 	Util_testAddrIDMask()
-	idxstore := makeStoreSquareGrid(4)
+	//idxstore := makeStoreSquareGrid(4)
 	//idxstore := makeStoreStar(256)
 	//idxstore := loadGraph("misc/sim/hype-2016-09-19.list")
-	//idxstore := loadGraph("misc/sim/fc00-2017-08-12.txt")
+	idxstore := loadGraph("misc/sim/fc00-2017-08-12.txt")
 	//idxstore := loadGraph("skitter")
 	kstore := getKeyedStore(idxstore)
 	//*

--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -386,7 +386,7 @@ func (n *Node) startTCP(listen string) {
 }
 
 func (n *Node) connectTCP(remoteAddr string) {
-	n.core.AddPeer(remoteAddr)
+	n.core.AddPeer(remoteAddr, remoteAddr)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -437,7 +437,7 @@ func main() {
 	pingNodes(kstore)
 	//pingBench(kstore) // Only after disabling debug output
 	//stressTest(kstore)
-	//time.Sleep(120*time.Second)
+	time.Sleep(120 * time.Second)
 	dumpDHTSize(kstore) // note that this uses racey functions to read things...
 	if false {
 		// This connects the sim to the local network

--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -415,10 +415,10 @@ func main() {
 	}
 	fmt.Println("Test")
 	Util_testAddrIDMask()
-	//idxstore := makeStoreSquareGrid(4)
+	idxstore := makeStoreSquareGrid(4)
 	//idxstore := makeStoreStar(256)
 	//idxstore := loadGraph("misc/sim/hype-2016-09-19.list")
-	idxstore := loadGraph("misc/sim/fc00-2017-08-12.txt")
+	//idxstore := loadGraph("misc/sim/fc00-2017-08-12.txt")
 	//idxstore := loadGraph("skitter")
 	kstore := getKeyedStore(idxstore)
 	//*

--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -300,6 +300,7 @@ func pingNodes(store map[[32]byte]*Node) {
 					}
 				case <-ch:
 					sendTo(payload, destAddr)
+					//dumpDHTSize(store) // note that this uses racey functions to read things...
 				}
 			}
 			ticker.Stop()

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -555,27 +555,23 @@ func (a *admin) getData_getSwitchQueues() admin_nodeInfo {
 func (a *admin) getData_getDHT() []admin_nodeInfo {
 	var infos []admin_nodeInfo
 	getDHT := func() {
-		/* TODO fix this
-		  	now := time.Now()
-				for i := 0; i < a.core.dht.nBuckets(); i++ {
-					b := a.core.dht.getBucket(i)
-					getInfo := func(vs []*dhtInfo, isPeer bool) {
-						for _, v := range vs {
-							addr := *address_addrForNodeID(v.getNodeID())
-							info := admin_nodeInfo{
-								{"ip", net.IP(addr[:]).String()},
-								{"coords", fmt.Sprint(v.coords)},
-								{"bucket", i},
-								{"peer_only", isPeer},
-								{"last_seen", int(now.Sub(v.recv).Seconds())},
-							}
-							infos = append(infos, info)
-						}
-					}
-					getInfo(b.other, false)
-					getInfo(b.peers, true)
-				}
-		*/
+		now := time.Now()
+		var dhtInfos []*dhtInfo
+		for _, v := range a.core.dht.table {
+			dhtInfos = append(dhtInfos, v)
+		}
+		sort.SliceStable(dhtInfos, func(i, j int) bool {
+			return dht_ordered(&a.core.dht.nodeID, dhtInfos[i].getNodeID(), dhtInfos[j].getNodeID())
+		})
+		for _, v := range dhtInfos {
+			addr := *address_addrForNodeID(v.getNodeID())
+			info := admin_nodeInfo{
+				{"ip", net.IP(addr[:]).String()},
+				{"coords", fmt.Sprint(v.coords)},
+				{"last_seen", int(now.Sub(v.recv).Seconds())},
+			}
+			infos = append(infos, info)
+		}
 	}
 	a.core.router.doAdmin(getDHT)
 	return infos

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -554,26 +554,28 @@ func (a *admin) getData_getSwitchQueues() admin_nodeInfo {
 // getData_getDHT returns info from Core.dht for an admin response.
 func (a *admin) getData_getDHT() []admin_nodeInfo {
 	var infos []admin_nodeInfo
-	now := time.Now()
 	getDHT := func() {
-		for i := 0; i < a.core.dht.nBuckets(); i++ {
-			b := a.core.dht.getBucket(i)
-			getInfo := func(vs []*dhtInfo, isPeer bool) {
-				for _, v := range vs {
-					addr := *address_addrForNodeID(v.getNodeID())
-					info := admin_nodeInfo{
-						{"ip", net.IP(addr[:]).String()},
-						{"coords", fmt.Sprint(v.coords)},
-						{"bucket", i},
-						{"peer_only", isPeer},
-						{"last_seen", int(now.Sub(v.recv).Seconds())},
+		/* TODO fix this
+		  	now := time.Now()
+				for i := 0; i < a.core.dht.nBuckets(); i++ {
+					b := a.core.dht.getBucket(i)
+					getInfo := func(vs []*dhtInfo, isPeer bool) {
+						for _, v := range vs {
+							addr := *address_addrForNodeID(v.getNodeID())
+							info := admin_nodeInfo{
+								{"ip", net.IP(addr[:]).String()},
+								{"coords", fmt.Sprint(v.coords)},
+								{"bucket", i},
+								{"peer_only", isPeer},
+								{"last_seen", int(now.Sub(v.recv).Seconds())},
+							}
+							infos = append(infos, info)
+						}
 					}
-					infos = append(infos, info)
+					getInfo(b.other, false)
+					getInfo(b.peers, true)
 				}
-			}
-			getInfo(b.other, false)
-			getInfo(b.peers, true)
-		}
+		*/
 	}
 	a.core.router.doAdmin(getDHT)
 	return infos

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -229,14 +229,10 @@ func DEBUG_wire_encode_coords(coords []byte) []byte {
 // DHT, via core
 
 func (c *Core) DEBUG_getDHTSize() int {
-	total := 0
-	/* FIXME
-	for bidx := 0; bidx < c.dht.nBuckets(); bidx++ {
-		b := c.dht.getBucket(bidx)
-		total += len(b.peers)
-		total += len(b.other)
-	}
-	*/
+	var total int
+	c.router.doAdmin(func() {
+		total = len(c.dht.table)
+	})
 	return total
 }
 

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -233,6 +233,7 @@ func (c *Core) DEBUG_getDHTSize() int {
 	c.router.doAdmin(func() {
 		total = len(c.dht.table)
 	})
+	fmt.Println("DEBUG_getDHTSize():", total)
 	return total
 }
 

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -233,7 +233,6 @@ func (c *Core) DEBUG_getDHTSize() int {
 	c.router.doAdmin(func() {
 		total = len(c.dht.table)
 	})
-	fmt.Println("DEBUG_getDHTSize():", total)
 	return total
 }
 

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -230,11 +230,13 @@ func DEBUG_wire_encode_coords(coords []byte) []byte {
 
 func (c *Core) DEBUG_getDHTSize() int {
 	total := 0
+	/* FIXME
 	for bidx := 0; bidx < c.dht.nBuckets(); bidx++ {
 		b := c.dht.getBucket(bidx)
 		total += len(b.peers)
 		total += len(b.other)
 	}
+	*/
 	return total
 }
 

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -180,7 +180,7 @@ func (t *dht) handleReq(req *dhtReq) {
 		coords: req.Coords,
 	}
 	imp := t.getImportant()
-	if t.isImportant(&info, imp) {
+	if _, isIn := t.table[*info.getNodeID()]; !isIn || t.isImportant(&info, imp) {
 		t.insert(&info)
 	}
 }

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -1,38 +1,10 @@
 package yggdrasil
 
-/*
-
-This part has the (kademlia-like) distributed hash table
-
-It's used to look up coords for a NodeID
-
-Every node participates in the DHT, and the DHT stores no real keys/values
-(Only the peer relationships / lookups are needed)
-
-This version is intentionally fragile, by being recursive instead of iterative
-(it's also not parallel, as a result)
-This is to make sure that DHT black holes are visible if they exist
-(the iterative parallel approach tends to get around them sometimes)
-I haven't seen this get stuck on blackholes, but I also haven't proven it can't
-Slight changes *do* make it blackhole hard, bootstrapping isn't an easy problem
-
-*/
-
 import (
 	"sort"
 	"time"
 )
 
-// Number of DHT buckets, equal to the number of bits in a NodeID.
-// Note that, in practice, nearly all of these will be empty.
-const dht_bucket_number = 8 * NodeIDLen
-
-// Number of nodes to keep in each DHT bucket.
-// Additional entries may be kept for peers, for bootstrapping reasons, if they don't already have an entry in the bucket.
-const dht_bucket_size = 2
-
-// Number of responses to include in a lookup.
-// If extras are given, they will be truncated from the response handler to prevent abuse.
 const dht_lookup_size = 16
 
 // dhtInfo represents everything we know about a node in the DHT.
@@ -41,11 +13,11 @@ type dhtInfo struct {
 	nodeID_hidden *NodeID
 	key           boxPubKey
 	coords        []byte
-	send          time.Time     // When we last sent a message
-	recv          time.Time     // When we last received a message
-	pings         int           // Decide when to drop
-	throttle      time.Duration // Time to wait before pinging a node to bootstrap buckets, increases exponentially from 1 second to 1 minute
-	bootstrapSend time.Time     // The time checked/updated as part of throttle checks
+	send          time.Time // When we last sent a message
+	recv          time.Time // When we last received a message
+	//pings         int           // Decide when to drop
+	//throttle      time.Duration // Time to wait before pinging a node to bootstrap buckets, increases exponentially from 1 second to 1 minute
+	//bootstrapSend time.Time     // The time checked/updated as part of throttle checks
 }
 
 // Returns the *NodeID associated with dhtInfo.key, calculating it on the fly the first time or from a cache all subsequent times.
@@ -54,12 +26,6 @@ func (info *dhtInfo) getNodeID() *NodeID {
 		info.nodeID_hidden = getNodeID(&info.key)
 	}
 	return info.nodeID_hidden
-}
-
-// The nodes we known in a bucket (a region of keyspace with a matching prefix of some length).
-type bucket struct {
-	peers []*dhtInfo
-	other []*dhtInfo
 }
 
 // Request for a node to do a lookup.
@@ -74,42 +40,94 @@ type dhtReq struct {
 // Includes the key and coords of the node that's responding, and the destination they were asked about.
 // The main part is Infos []*dhtInfo, the lookup response.
 type dhtRes struct {
-	Key    boxPubKey // key to respond to
-	Coords []byte    // coords to respond to
+	Key    boxPubKey // key of the sender
+	Coords []byte    // coords of the sender
 	Dest   NodeID
 	Infos  []*dhtInfo // response
 }
 
-// Information about a node, either taken from our table or from a lookup response.
-// Used to schedule pings at a later time (they're throttled to 1/second for background maintenance traffic).
-type dht_rumor struct {
-	info   *dhtInfo
-	target *NodeID
-}
-
 // The main DHT struct.
-// Includes a slice of buckets, to organize known nodes based on their region of keyspace.
-// Also includes information about outstanding DHT requests and the rumor mill of nodes to ping at some point.
 type dht struct {
-	core           *Core
-	nodeID         NodeID
-	buckets_hidden [dht_bucket_number]bucket // Extra is for the self-bucket
-	peers          chan *dhtInfo             // other goroutines put incoming dht updates here
-	reqs           map[boxPubKey]map[NodeID]time.Time
-	offset         int
-	rumorMill      []dht_rumor
+	core   *Core
+	nodeID NodeID
+	table  map[NodeID]*dhtInfo
+	peers  chan *dhtInfo // other goroutines put incoming dht updates here
+	reqs   map[boxPubKey]map[NodeID]time.Time
+	//rumorMill      []dht_rumor
 }
 
-// Initializes the DHT.
 func (t *dht) init(c *Core) {
+	// TODO
 	t.core = c
 	t.nodeID = *t.core.GetNodeID()
 	t.peers = make(chan *dhtInfo, 1024)
-	t.reqs = make(map[boxPubKey]map[NodeID]time.Time)
+	t.reset()
+}
+
+func (t *dht) reset() {
+	t.table = make(map[NodeID]*dhtInfo)
+}
+
+func (t *dht) lookup(nodeID *NodeID, allowWorse bool) []*dhtInfo {
+	return nil
+	var results []*dhtInfo
+	var successor *dhtInfo
+	sTarget := t.nodeID.next()
+	for infoID, info := range t.table {
+		if allowWorse || dht_ordered(&t.nodeID, &infoID, nodeID) {
+			results = append(results, info)
+		} else {
+			if successor == nil || dht_ordered(&sTarget, &infoID, successor.getNodeID()) {
+				successor = info
+			}
+		}
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		return dht_ordered(results[j].getNodeID(), results[i].getNodeID(), nodeID)
+	})
+	if successor != nil {
+		results = append([]*dhtInfo{successor}, results...)
+	}
+	if len(results) > dht_lookup_size {
+		results = results[:dht_lookup_size]
+	}
+	return results
+}
+
+// Insert into table, preserving the time we last sent a packet if the node was already in the table, otherwise setting that time to now
+func (t *dht) insert(info *dhtInfo) {
+	info.recv = time.Now()
+	if oldInfo, isIn := t.table[*info.getNodeID()]; isIn {
+		info.send = oldInfo.send
+	} else {
+		info.send = info.recv
+	}
+	t.table[*info.getNodeID()] = info
+}
+
+// Return true if first/second/third are (partially) ordered correctly
+//  FIXME? maybe total ordering makes more sense
+func dht_ordered(first, second, third *NodeID) bool {
+	var ordered bool
+	for idx := 0; idx < NodeIDLen; idx++ {
+		f, s, t := first[idx], second[idx], third[idx]
+		switch {
+		case f == s && s == t:
+			continue
+		case f <= s && s <= t:
+			ordered = true // nothing wrapped around 0
+		case t <= f && f <= s:
+			ordered = true // 0 is between second and third
+		case s <= t && t <= f:
+			ordered = true // 0 is between first and second
+		}
+		break
+	}
+	return ordered
 }
 
 // Reads a request, performs a lookup, and responds.
-// If the node that sent the request isn't in our DHT, but should be, then we add them.
+// Update info about the node that sent the request.
 func (t *dht) handleReq(req *dhtReq) {
 	// Send them what they asked for
 	loc := t.core.switchTable.getLocator()
@@ -129,11 +147,50 @@ func (t *dht) handleReq(req *dhtReq) {
 	// For bootstrapping to work, we need to add these nodes to the table
 	// Using insertIfNew, they can lie about coords, but searches will route around them
 	// Using the mill would mean trying to block off the mill becomes an attack vector
-	t.insertIfNew(&info, false)
+	t.insert(&info)
+}
+
+// Sends a lookup response to the specified node.
+func (t *dht) sendRes(res *dhtRes, req *dhtReq) {
+	// Send a reply for a dhtReq
+	bs := res.encode()
+	shared := t.core.sessions.getSharedKey(&t.core.boxPriv, &req.Key)
+	payload, nonce := boxSeal(shared, bs, nil)
+	p := wire_protoTrafficPacket{
+		Coords:  req.Coords,
+		ToKey:   req.Key,
+		FromKey: t.core.boxPub,
+		Nonce:   *nonce,
+		Payload: payload,
+	}
+	packet := p.encode()
+	t.core.router.out(packet)
+}
+
+// Returns nodeID + 1
+func (nodeID NodeID) next() NodeID {
+	for idx := len(nodeID); idx >= 0; idx-- {
+		nodeID[idx] += 1
+		if nodeID[idx] != 0 {
+			break
+		}
+	}
+	return nodeID
+}
+
+// Returns nodeID - 1
+func (nodeID NodeID) prev() NodeID {
+	for idx := len(nodeID); idx >= 0; idx-- {
+		nodeID[idx] -= 1
+		if nodeID[idx] != 0xff {
+			break
+		}
+	}
+	return nodeID
 }
 
 // Reads a lookup response, checks that we had sent a matching request, and processes the response info.
-// This mainly consists of updating the node we asked in our DHT (they responded, so we know they're still alive), and adding the response info to the rumor mill.
+// This mainly consists of updating the node we asked in our DHT (they responded, so we know they're still alive), and deciding if we want to do anything with their responses
 func (t *dht) handleRes(res *dhtRes) {
 	t.core.searches.handleDHTRes(res)
 	reqs, isIn := t.reqs[res.Key]
@@ -145,223 +202,36 @@ func (t *dht) handleRes(res *dhtRes) {
 		return
 	}
 	delete(reqs, res.Dest)
-	now := time.Now()
 	rinfo := dhtInfo{
-		key:           res.Key,
-		coords:        res.Coords,
-		send:          now, // Technically wrong but should be OK...
-		recv:          now,
-		throttle:      time.Second,
-		bootstrapSend: now,
+		key:    res.Key,
+		coords: res.Coords,
 	}
-	// If they're already in the table, then keep the correct send time
-	bidx, isOK := t.getBucketIndex(rinfo.getNodeID())
-	if !isOK {
-		return
-	}
-	b := t.getBucket(bidx)
-	for _, oldinfo := range b.peers {
-		if oldinfo.key == rinfo.key {
-			rinfo.send = oldinfo.send
-			rinfo.throttle = oldinfo.throttle
-			rinfo.bootstrapSend = oldinfo.bootstrapSend
+	t.insert(&rinfo) // Or at the end, after checking successor/predecessor?
+	var successor *dhtInfo
+	var predecessor *dhtInfo
+	for infoID, info := range t.table {
+		// Get current successor and predecessor
+		if successor == nil || dht_ordered(&t.nodeID, &infoID, successor.getNodeID()) {
+			successor = info
 		}
-	}
-	for _, oldinfo := range b.other {
-		if oldinfo.key == rinfo.key {
-			rinfo.send = oldinfo.send
-			rinfo.throttle = oldinfo.throttle
-			rinfo.bootstrapSend = oldinfo.bootstrapSend
+		if predecessor == nil || dht_ordered(predecessor.getNodeID(), &infoID, &t.nodeID) {
+			predecessor = info
 		}
-	}
-	// Insert into table
-	t.insert(&rinfo, false)
-	if res.Dest == *rinfo.getNodeID() {
-		return
-	} // No infinite recursions
-	if len(res.Infos) > dht_lookup_size {
-		// Ignore any "extra" lookup results
-		res.Infos = res.Infos[:dht_lookup_size]
 	}
 	for _, info := range res.Infos {
-		if dht_firstCloserThanThird(info.getNodeID(), &res.Dest, rinfo.getNodeID()) {
-			t.addToMill(info, info.getNodeID())
-		}
-	}
-}
-
-// Does a DHT lookup and returns the results, sorted in ascending order of distance from the destination.
-func (t *dht) lookup(nodeID *NodeID, allowCloser bool) []*dhtInfo {
-	// FIXME this allocates a bunch, sorts, and keeps the part it likes
-	// It would be better to only track the part it likes to begin with
-	addInfos := func(res []*dhtInfo, infos []*dhtInfo) []*dhtInfo {
-		for _, info := range infos {
-			if info == nil {
-				panic("Should never happen!")
-			}
-			if allowCloser || dht_firstCloserThanThird(info.getNodeID(), nodeID, &t.nodeID) {
-				res = append(res, info)
-			}
-		}
-		return res
-	}
-	var res []*dhtInfo
-	for bidx := 0; bidx < t.nBuckets(); bidx++ {
-		b := t.getBucket(bidx)
-		res = addInfos(res, b.peers)
-		res = addInfos(res, b.other)
-	}
-	doSort := func(infos []*dhtInfo) {
-		less := func(i, j int) bool {
-			return dht_firstCloserThanThird(infos[i].getNodeID(),
-				nodeID,
-				infos[j].getNodeID())
-		}
-		sort.SliceStable(infos, less)
-	}
-	doSort(res)
-	if len(res) > dht_lookup_size {
-		res = res[:dht_lookup_size]
-	}
-	return res
-}
-
-// Gets the bucket for a specified matching prefix length.
-func (t *dht) getBucket(bidx int) *bucket {
-	return &t.buckets_hidden[bidx]
-}
-
-// Lists the number of buckets.
-func (t *dht) nBuckets() int {
-	return len(t.buckets_hidden)
-}
-
-// Inserts a node into the DHT if they meet certain requirements.
-// In particular, they must either be a peer that's not already in the DHT, or else be someone we should insert into the DHT (see: shouldInsert).
-func (t *dht) insertIfNew(info *dhtInfo, isPeer bool) {
-	// Insert if no "other" entry already exists
-	nodeID := info.getNodeID()
-	bidx, isOK := t.getBucketIndex(nodeID)
-	if !isOK {
-		return
-	}
-	b := t.getBucket(bidx)
-	if (isPeer && !b.containsOther(info)) || t.shouldInsert(info) {
-		// We've never heard this node before
-		// TODO is there a better time than "now" to set send/recv to?
-		// (Is there another "natural" choice that bootstraps faster?)
-		info.send = time.Now()
-		info.recv = info.send
-		t.insert(info, isPeer)
-	}
-}
-
-// Adds a node to the DHT, possibly removing another node in the process.
-func (t *dht) insert(info *dhtInfo, isPeer bool) {
-	// First update the time on this info
-	info.recv = time.Now()
-	// Get the bucket for this node
-	nodeID := info.getNodeID()
-	bidx, isOK := t.getBucketIndex(nodeID)
-	if !isOK {
-		return
-	}
-	b := t.getBucket(bidx)
-	if !isPeer && !b.containsOther(info) {
-		// This is a new entry, give it an old age so it's pinged sooner
-		// This speeds up bootstrapping
-		info.recv = info.recv.Add(-time.Hour)
-	}
-	if isPeer || info.throttle > time.Minute {
-		info.throttle = time.Minute
-	}
-	// First drop any existing entry from the bucket
-	b.drop(&info.key)
-	// Now add to the *end* of the bucket
-	if isPeer {
-		// TODO make sure we don't duplicate peers in b.other too
-		b.peers = append(b.peers, info)
-		return
-	}
-	b.other = append(b.other, info)
-	// Shrink from the *front* to requied size
-	for len(b.other) > dht_bucket_size {
-		b.other = b.other[1:]
-	}
-}
-
-// Gets the bucket index for the bucket where we would put the given NodeID.
-func (t *dht) getBucketIndex(nodeID *NodeID) (int, bool) {
-	for bidx := 0; bidx < t.nBuckets(); bidx++ {
-		them := nodeID[bidx/8] & (0x80 >> byte(bidx%8))
-		me := t.nodeID[bidx/8] & (0x80 >> byte(bidx%8))
-		if them != me {
-			return bidx, true
-		}
-	}
-	return t.nBuckets(), false
-}
-
-// Helper called by containsPeer, containsOther, and contains.
-// Returns true if a node with the same ID *and coords* is already in the given part of the bucket.
-func dht_bucket_check(newInfo *dhtInfo, infos []*dhtInfo) bool {
-	// Compares if key and coords match
-	if newInfo == nil {
-		panic("Should never happen")
-	}
-	for _, info := range infos {
-		if info == nil {
-			panic("Should never happen")
-		}
-		if info.key != newInfo.key {
+		if *info.getNodeID() == t.nodeID {
 			continue
+		} // Skip self
+		// Send a request to all better successors or predecessors
+		// We could try sending to only the best, but then packet loss matters more
+		if successor == nil || dht_ordered(&t.nodeID, info.getNodeID(), successor.getNodeID()) {
+			// ping
 		}
-		if len(info.coords) != len(newInfo.coords) {
-			continue
-		}
-		match := true
-		for idx := 0; idx < len(info.coords); idx++ {
-			if info.coords[idx] != newInfo.coords[idx] {
-				match = false
-				break
-			}
-		}
-		if match {
-			return true
+		if predecessor == nil || dht_ordered(predecessor.getNodeID(), info.getNodeID(), &t.nodeID) {
+			// ping
 		}
 	}
-	return false
-}
-
-// Calls bucket_check over the bucket's peers infos.
-func (b *bucket) containsPeer(info *dhtInfo) bool {
-	return dht_bucket_check(info, b.peers)
-}
-
-// Calls bucket_check over the bucket's other info.
-func (b *bucket) containsOther(info *dhtInfo) bool {
-	return dht_bucket_check(info, b.other)
-}
-
-// returns containsPeer || containsOther
-func (b *bucket) contains(info *dhtInfo) bool {
-	return b.containsPeer(info) || b.containsOther(info)
-}
-
-// Removes a node with the corresponding key, if any, from a bucket.
-func (b *bucket) drop(key *boxPubKey) {
-	clean := func(infos []*dhtInfo) []*dhtInfo {
-		cleaned := infos[:0]
-		for _, info := range infos {
-			if info.key == *key {
-				continue
-			}
-			cleaned = append(cleaned, info)
-		}
-		return cleaned
-	}
-	b.peers = clean(b.peers)
-	b.other = clean(b.other)
+	// TODO add everyting else to a rumor mill for later use? (when/how?)
 }
 
 // Sends a lookup request to the specified node.
@@ -390,75 +260,10 @@ func (t *dht) sendReq(req *dhtReq, dest *dhtInfo) {
 	reqsToDest[req.Dest] = time.Now()
 }
 
-// Sends a lookup response to the specified node.
-func (t *dht) sendRes(res *dhtRes, req *dhtReq) {
-	// Send a reply for a dhtReq
-	bs := res.encode()
-	shared := t.core.sessions.getSharedKey(&t.core.boxPriv, &req.Key)
-	payload, nonce := boxSeal(shared, bs, nil)
-	p := wire_protoTrafficPacket{
-		Coords:  req.Coords,
-		ToKey:   req.Key,
-		FromKey: t.core.boxPub,
-		Nonce:   *nonce,
-		Payload: payload,
-	}
-	packet := p.encode()
-	t.core.router.out(packet)
-}
-
-// Returns true of a bucket contains no peers and no other nodes.
-func (b *bucket) isEmpty() bool {
-	return len(b.peers)+len(b.other) == 0
-}
-
-// Gets the next node that should be pinged from the bucket.
-// There's a cooldown of 6 seconds between ping attempts for each node, to give them time to respond.
-// It returns the least recently pinged node, subject to that send cooldown.
-func (b *bucket) nextToPing() *dhtInfo {
-	// Check the nodes in the bucket
-	// Return whichever one responded least recently
-	// Delay of 6 seconds between pinging the same node
-	//  Gives them time to respond
-	//  And time between traffic loss from short term congestion in the network
-	var toPing *dhtInfo
-	update := func(infos []*dhtInfo) {
-		for _, next := range infos {
-			if time.Since(next.send) < 6*time.Second {
-				continue
-			}
-			if toPing == nil || next.recv.Before(toPing.recv) {
-				toPing = next
-			}
-		}
-	}
-	update(b.peers)
-	update(b.other)
-	return toPing
-}
-
-// Returns a useful target address to ask about for pings.
-// Equal to the our node's ID, except for exactly 1 bit at the bucket index.
-func (t *dht) getTarget(bidx int) *NodeID {
-	targetID := t.nodeID
-	targetID[bidx/8] ^= 0x80 >> byte(bidx%8)
-	return &targetID
-}
-
-// Sends a ping to a node, or removes the node if it has failed to respond to too many pings.
-// If target is nil, we will ask the node about our own NodeID.
 func (t *dht) ping(info *dhtInfo, target *NodeID) {
-	if info.pings > 2 {
-		bidx, isOK := t.getBucketIndex(info.getNodeID())
-		if !isOK {
-			panic("This should never happen")
-		}
-		b := t.getBucket(bidx)
-		b.drop(&info.key)
-		return
-	}
+	// Creates a req for the node at dhtInfo, asking them about the target (if one is given) or themself (if no target is given)
 	if target == nil {
-		target = &t.nodeID
+		target = info.getNodeID()
 	}
 	loc := t.core.switchTable.getLocator()
 	coords := loc.getCoords()
@@ -467,160 +272,24 @@ func (t *dht) ping(info *dhtInfo, target *NodeID) {
 		Coords: coords,
 		Dest:   *target,
 	}
-	info.pings++
 	info.send = time.Now()
 	t.sendReq(&req, info)
 }
 
-// Adds a node info and target to the rumor mill.
-// The node will be asked about the target at a later point, if doing so would still be useful at the time.
-func (t *dht) addToMill(info *dhtInfo, target *NodeID) {
-	rumor := dht_rumor{
-		info:   info,
-		target: target,
-	}
-	t.rumorMill = append(t.rumorMill, rumor)
-}
-
-// Regular periodic maintenance.
-// If the mill is empty, it adds two pings to the rumor mill.
-// The first is to the node that responded least recently, provided that it's been at least 1 minute, to make sure we eventually detect and remove unresponsive nodes.
-// The second is used for bootstrapping, and attempts to fill some bucket, iterating over buckets and resetting after it hits the last non-empty one.
-// If the mill is not empty, it pops nodes from the mill until it finds one that would be useful to ping (see: shouldInsert), and then pings it.
 func (t *dht) doMaintenance() {
-	// First clean up reqs
-	for key, reqs := range t.reqs {
-		for target, timeout := range reqs {
-			if time.Since(timeout) > time.Minute {
-				delete(reqs, target)
-			}
-		}
-		if len(reqs) == 0 {
-			delete(t.reqs, key)
-		}
-	}
-	if len(t.rumorMill) == 0 {
-		// Ping the least recently contacted node
-		//  This is to make sure we eventually notice when someone times out
-		var oldest *dhtInfo
-		last := 0
-		for bidx := 0; bidx < t.nBuckets(); bidx++ {
-			b := t.getBucket(bidx)
-			if !b.isEmpty() {
-				last = bidx
-				toPing := b.nextToPing()
-				if toPing == nil {
-					continue
-				} // We've recently pinged everyone in b
-				if oldest == nil || toPing.recv.Before(oldest.recv) {
-					oldest = toPing
-				}
-			}
-		}
-		if oldest != nil && time.Since(oldest.recv) > time.Minute {
-			// Ping the oldest node in the DHT, but don't ping nodes that have been checked within the last minute
-			t.addToMill(oldest, nil)
-		}
-		// Refresh buckets
-		if t.offset > last {
-			t.offset = 0
-		}
-		target := t.getTarget(t.offset)
-		func() {
-			closer := t.lookup(target, false)
-			for _, info := range closer {
-				// Throttled ping of a node that's closer to the destination
-				if time.Since(info.recv) > info.throttle {
-					t.addToMill(info, target)
-					t.offset++
-					info.bootstrapSend = time.Now()
-					info.throttle *= 2
-					if info.throttle > time.Minute {
-						info.throttle = time.Minute
-					}
-					return
-				}
-			}
-			if len(closer) == 0 {
-				// If we don't know of anyone closer at all, then there's a hole in our dht
-				// Ping the closest node we know and ignore the throttle, to try to fill it
-				for _, info := range t.lookup(target, true) {
-					t.addToMill(info, target)
-					t.offset++
-					return
-				}
-			}
-		}()
-		//t.offset++
-	}
-	for len(t.rumorMill) > 0 {
-		var rumor dht_rumor
-		rumor, t.rumorMill = t.rumorMill[0], t.rumorMill[1:]
-		if rumor.target == rumor.info.getNodeID() {
-			// Note that the above is a pointer comparison, and target can be nil
-			// This is only for adding new nodes (learned from other lookups)
-			// It only makes sense to ping if the node isn't already in the table
-			if !t.shouldInsert(rumor.info) {
-				continue
-			}
-		}
-		t.ping(rumor.info, rumor.target)
-		break
-	}
-}
-
-// Returns true if it would be worth pinging the specified node.
-// This requires that the bucket doesn't already contain the node, and that either the bucket isn't full yet or the node is closer to us in keyspace than some other node in that bucket.
-func (t *dht) shouldInsert(info *dhtInfo) bool {
-	bidx, isOK := t.getBucketIndex(info.getNodeID())
-	if !isOK {
-		return false
-	}
-	b := t.getBucket(bidx)
-	if b.containsOther(info) {
-		return false
-	}
-	if len(b.other) < dht_bucket_size {
-		return true
-	}
-	for _, other := range b.other {
-		if dht_firstCloserThanThird(info.getNodeID(), &t.nodeID, other.getNodeID()) {
-			return true
+	// Ping successor, asking for their predecessor, and clean up old/expired info
+	var successor *dhtInfo
+	now := time.Now()
+	for infoID, info := range t.table {
+		if now.Sub(info.recv) > time.Minute {
+			delete(t.table, infoID)
+		} else if successor == nil || dht_ordered(&t.nodeID, &infoID, successor.getNodeID()) {
+			successor = info
 		}
 	}
-	return false
-}
-
-// Returns true if the keyspace distance between the first and second node is smaller than the keyspace distance between the second and third node.
-func dht_firstCloserThanThird(first *NodeID,
-	second *NodeID,
-	third *NodeID) bool {
-	for idx := 0; idx < NodeIDLen; idx++ {
-		f := first[idx] ^ second[idx]
-		t := third[idx] ^ second[idx]
-		if f == t {
-			continue
-		}
-		return f < t
-	}
-	return false
-}
-
-// Resets the DHT in response to coord changes.
-// This empties all buckets, resets the bootstrapping cycle to 0, and empties the rumor mill.
-// It adds all old "other" node info to the rumor mill, so they'll be pinged quickly.
-// If those nodes haven't also changed coords, then this is a relatively quick way to notify those nodes of our new coords and re-add them to our own DHT if they respond.
-func (t *dht) reset() {
-	// This is mostly so bootstrapping will reset to resend coords into the network
-	t.offset = 0
-	t.rumorMill = nil // reset mill
-	for _, b := range t.buckets_hidden {
-		b.peers = b.peers[:0]
-		for _, info := range b.other {
-			// Add other nodes to the rumor mill so they'll be pinged soon
-			// This will hopefully tell them our coords and re-learn theirs quickly if they haven't changed
-			t.addToMill(info, info.getNodeID())
-		}
-		b.other = b.other[:0]
+	if successor != nil &&
+		now.Sub(successor.recv) > 30*time.Second &&
+		now.Sub(successor.send) > 6*time.Second {
+		t.ping(successor, nil)
 	}
 }

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -183,7 +183,7 @@ func (p *peer) linkLoop() {
 			}
 			p.sendSwitchMsg()
 		case _ = <-tick.C:
-			break             // FIXME disabled the below completely to test something
+			//break             // FIXME disabled the below completely to test something
 			pdinfo := p.dinfo // FIXME this is a bad workarond NPE on the next line
 			if pdinfo != nil {
 				dinfo := *pdinfo

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -183,8 +183,10 @@ func (p *peer) linkLoop() {
 			}
 			p.sendSwitchMsg()
 		case _ = <-tick.C:
-			if p.dinfo != nil {
-				p.core.dht.peers <- p.dinfo
+			pdinfo := p.dinfo // FIXME this is a bad workarond NPE on the next line
+			if pdinfo != nil {
+				dinfo := *pdinfo
+				p.core.dht.peers <- &dinfo
 			}
 		}
 	}

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -183,6 +183,7 @@ func (p *peer) linkLoop() {
 			}
 			p.sendSwitchMsg()
 		case _ = <-tick.C:
+			break             // FIXME disabled the below completely to test something
 			pdinfo := p.dinfo // FIXME this is a bad workarond NPE on the next line
 			if pdinfo != nil {
 				dinfo := *pdinfo
@@ -332,7 +333,7 @@ func (p *peer) handleSwitchMsg(packet []byte) {
 		key:    p.box,
 		coords: loc.getCoords(),
 	}
-	p.core.dht.peers <- &dinfo
+	//p.core.dht.peers <- &dinfo
 	p.dinfo = &dinfo
 }
 

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -91,8 +91,12 @@ func (r *router) mainLoop() {
 		case p := <-r.send:
 			r.sendPacket(p)
 		case info := <-r.core.dht.peers:
+			now := time.Now()
+			oldInfo, isIn := r.core.dht.table[*info.getNodeID()]
 			r.core.dht.insert(info)
-			info.throttle = 0
+			if isIn && now.Sub(oldInfo.recv) < 45*time.Second {
+				info.recv = oldInfo.recv
+			}
 		case <-r.reset:
 			r.core.sessions.resetInits()
 			r.core.dht.reset()

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -92,6 +92,7 @@ func (r *router) mainLoop() {
 			r.sendPacket(p)
 		case info := <-r.core.dht.peers:
 			r.core.dht.insert(info)
+			info.throttle = 0
 		case <-r.reset:
 			r.core.sessions.resetInits()
 			r.core.dht.reset()

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -91,8 +91,7 @@ func (r *router) mainLoop() {
 		case p := <-r.send:
 			r.sendPacket(p)
 		case info := <-r.core.dht.peers:
-			r.core.dht.insertIfNew(info, false) // Insert as a normal node
-			r.core.dht.insertIfNew(info, true)  // Insert as a peer
+			r.core.dht.insert(info)
 		case <-r.reset:
 			r.core.sessions.resetInits()
 			r.core.dht.reset()

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -113,13 +113,11 @@ func (s *searches) addToSearch(sinfo *searchInfo, res *dhtRes) {
 	// Sort
 	sort.SliceStable(sinfo.toVisit, func(i, j int) bool {
 		// Should return true if i is closer to the destination than j
-		// FIXME for some reason it works better backwards, why?!
-		//return dht_ordered(sinfo.toVisit[j].getNodeID(), sinfo.toVisit[i].getNodeID(), &res.Dest)
 		return dht_ordered(&res.Dest, sinfo.toVisit[i].getNodeID(), sinfo.toVisit[j].getNodeID())
 	})
 	// Truncate to some maximum size
 	if len(sinfo.toVisit) > search_MAX_SEARCH_SIZE {
-		sinfo.toVisit = sinfo.toVisit[:search_MAX_SEARCH_SIZE] //FIXME debug
+		sinfo.toVisit = sinfo.toVisit[:search_MAX_SEARCH_SIZE]
 	}
 }
 

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -96,7 +96,8 @@ func (s *searches) addToSearch(sinfo *searchInfo, res *dhtRes) {
 		if *info.getNodeID() == s.core.dht.nodeID || sinfo.visited[*info.getNodeID()] {
 			continue
 		}
-		if true || dht_ordered(from.getNodeID(), info.getNodeID(), &res.Dest) {
+		if dht_ordered(&sinfo.dest, info.getNodeID(), from.getNodeID()) {
+			// Response is closer to the destination
 			sinfo.toVisit = append(sinfo.toVisit, info)
 		}
 	}
@@ -118,7 +119,7 @@ func (s *searches) addToSearch(sinfo *searchInfo, res *dhtRes) {
 	})
 	// Truncate to some maximum size
 	if len(sinfo.toVisit) > search_MAX_SEARCH_SIZE {
-		sinfo.toVisit = sinfo.toVisit[:search_MAX_SEARCH_SIZE]
+		sinfo.toVisit = sinfo.toVisit[:search_MAX_SEARCH_SIZE] //FIXME debug
 	}
 }
 

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -126,10 +126,7 @@ func (s *searches) doSearchStep(sinfo *searchInfo) {
 		// Send to the next search target
 		var next *dhtInfo
 		next, sinfo.toVisit = sinfo.toVisit[0], sinfo.toVisit[1:]
-		//var oldPings int
-		//oldPings, next.pings = next.pings, 0
 		s.core.dht.ping(next, &sinfo.dest)
-		//next.pings = oldPings // Don't evict a node for searching with it too much
 		sinfo.visited[*next.getNodeID()] = true
 	}
 }

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -113,11 +113,12 @@ func (s *searches) addToSearch(sinfo *searchInfo, res *dhtRes) {
 	sort.SliceStable(sinfo.toVisit, func(i, j int) bool {
 		// Should return true if i is closer to the destination than j
 		// FIXME for some reason it works better backwards, why?!
-		return dht_ordered(sinfo.toVisit[j].getNodeID(), sinfo.toVisit[i].getNodeID(), &res.Dest)
+		//return dht_ordered(sinfo.toVisit[j].getNodeID(), sinfo.toVisit[i].getNodeID(), &res.Dest)
+		return dht_ordered(&res.Dest, sinfo.toVisit[i].getNodeID(), sinfo.toVisit[j].getNodeID())
 	})
 	// Truncate to some maximum size
 	if len(sinfo.toVisit) > search_MAX_SEARCH_SIZE {
-		//sinfo.toVisit = sinfo.toVisit[:search_MAX_SEARCH_SIZE]
+		sinfo.toVisit = sinfo.toVisit[:search_MAX_SEARCH_SIZE]
 	}
 }
 

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -92,7 +92,7 @@ func (s *searches) addToSearch(sinfo *searchInfo, res *dhtRes) {
 		if sinfo.visited[*info.getNodeID()] {
 			continue
 		}
-		if dht_firstCloserThanThird(info.getNodeID(), &res.Dest, from.getNodeID()) {
+		if dht_ordered(from.getNodeID(), info.getNodeID(), &res.Dest) {
 			sinfo.toVisit = append(sinfo.toVisit, info)
 		}
 	}
@@ -107,7 +107,7 @@ func (s *searches) addToSearch(sinfo *searchInfo, res *dhtRes) {
 	}
 	// Sort
 	sort.SliceStable(sinfo.toVisit, func(i, j int) bool {
-		return dht_firstCloserThanThird(sinfo.toVisit[i].getNodeID(), &res.Dest, sinfo.toVisit[j].getNodeID())
+		return dht_ordered(sinfo.toVisit[j].getNodeID(), sinfo.toVisit[i].getNodeID(), &res.Dest)
 	})
 	// Truncate to some maximum size
 	if len(sinfo.toVisit) > search_MAX_SEARCH_SIZE {
@@ -126,10 +126,10 @@ func (s *searches) doSearchStep(sinfo *searchInfo) {
 		// Send to the next search target
 		var next *dhtInfo
 		next, sinfo.toVisit = sinfo.toVisit[0], sinfo.toVisit[1:]
-		var oldPings int
-		oldPings, next.pings = next.pings, 0
+		//var oldPings int
+		//oldPings, next.pings = next.pings, 0
 		s.core.dht.ping(next, &sinfo.dest)
-		next.pings = oldPings // Don't evict a node for searching with it too much
+		//next.pings = oldPings // Don't evict a node for searching with it too much
 		sinfo.visited[*next.getNodeID()] = true
 	}
 }

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -89,7 +89,7 @@ func (s *searches) addToSearch(sinfo *searchInfo, res *dhtRes) {
 	// Add responses to toVisit if closer to dest than the res node
 	from := dhtInfo{key: res.Key, coords: res.Coords}
 	for _, info := range res.Infos {
-		if sinfo.visited[*info.getNodeID()] {
+		if *info.getNodeID() == s.core.dht.nodeID || sinfo.visited[*info.getNodeID()] {
 			continue
 		}
 		if dht_ordered(from.getNodeID(), info.getNodeID(), &res.Dest) {

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -358,7 +358,7 @@ func (ss *sessions) getSharedKey(myPriv *boxPrivKey,
 		return skey
 	}
 	// First do some cleanup
-	const maxKeys = dht_bucket_number * dht_bucket_size
+	const maxKeys = 1024
 	for key := range ss.permShared {
 		// Remove a random key until the store is small enough
 		if len(ss.permShared) < maxKeys {

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -158,9 +158,9 @@ type switchTable struct {
 	core     *Core
 	key      sigPubKey           // Our own key
 	time     time.Time           // Time when locator.tstamp was last updated
-	parent   switchPort          // Port of whatever peer is our parent, or self if we're root
 	drop     map[sigPubKey]int64 // Tstamp associated with a dropped root
 	mutex    sync.RWMutex        // Lock for reads/writes of switchData
+	parent   switchPort          // Port of whatever peer is our parent, or self if we're root
 	data     switchData          //
 	updater  atomic.Value        // *sync.Once
 	table    atomic.Value        // lookupTable


### PR DESCRIPTION
This patch switches from a kad-based DHT to a chord-based one. This is *technically* backwards incompatible, in the sense that a network with mixed DHT implementations isn't guaranteed to converge, but the wire formats don't change, and searches still seem to succeed in a network with the old DHT nodes (though they seem to take a little longer, I think due to getting unexpected results).

The main advantage of the chord-based approach is that only O(1) state is required for correctness, the rest is just to make searches finish faster (or peers, for bootstrapping reasons, but we know about them for free). This opens the door for future optimizations, such as reducing idle DHT traffic, or prioritizing successor and predecessor to make nodes reachable more quickly after a coord change.