### PR TITLE
Neighbor discovery changes for TAP mode

### DIFF
--- a/src/yggdrasil/icmpv6.go
+++ b/src/yggdrasil/icmpv6.go
@@ -67,8 +67,8 @@ func (i *icmpv6) init(t *tunDevice) {
 	i.mylladdr = net.IP{
 		0xFE, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0xFE}
-	copy(i.mymac[1:], i.tun.core.boxPub[:])
-	copy(i.mylladdr[9:], i.tun.core.boxPub[:])
+	copy(i.mymac[:], i.tun.core.router.addr[:])
+	copy(i.mylladdr[9:], i.tun.core.router.addr[1:])
 }
 
 // Parses an incoming ICMPv6 packet. The packet provided may be either an


### PR DESCRIPTION
This changes the behaviour of ND in TAP mode by:

1. Learning MAC addresses through ND advertisements
2. Requesting the host MAC address through ND solicitation when it is not known at startup
3. Selecting the correct MAC address for traffic received before sending to the TUN
4. Unique link-local address and MAC address based on the first few bytes of the node's public encryption key

This *should* in theory allow bridging the TAP adapter for the routed `/64` subnet and should also fix cases where TAP required the node to send some traffic to learn the MAC before received traffic could be routed correctly.