### PR TITLE
Tune DHT a little better

### DIFF
--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -439,7 +439,7 @@ func main() {
 	pingNodes(kstore)
 	//pingBench(kstore) // Only after disabling debug output
 	//stressTest(kstore)
-	time.Sleep(120 * time.Second)
+	//time.Sleep(120 * time.Second)
 	dumpDHTSize(kstore) // note that this uses racey functions to read things...
 	if false {
 		// This connects the sim to the local network

--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -267,6 +267,7 @@ func pingNodes(store map[[32]byte]*Node) {
 			copy(packet[8:24], sourceAddr)
 			copy(packet[24:40], destAddr)
 			copy(packet[40:], bs)
+			packet[0] = 6 << 4
 			source.send <- packet
 		}
 		destCount := 0


### PR DESCRIPTION
This fixes the sim to work again after the ckr changes, and adjusts which nodes appear in DHT lookup responses a little bit, which should make it bootstrap a bit faster (based on a few tests in the sim). A DHT full of these nods *may* give slightly more useful lookup responses to nodes running the old kad DHT.