### PR TITLE
Latency optimization for switch coord selection

### DIFF
--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -463,6 +463,10 @@ func (t *switchTable) unlockedHandleMsg(msg *switchMsg, fromPort switchPort, rep
 		if !equiv(&sender.locator, &t.data.locator) {
 			doUpdate = true
 			t.data.seq++
+			for port, peer := range t.data.peers {
+				peer.cost = 0
+				t.data.peers[port] = peer
+			}
 			select {
 			case t.core.router.reset <- struct{}{}:
 			default:


### PR DESCRIPTION
The basic idea here is to do two things:
1. When the root updates a timestamp, keep an exponentially weighted rolling average of how much time passes between receiving the updated timestamp from each peer, relative to the time the current parent sends it.
2. When the parent disconnects or changes coords, switch your new parent to whichever node has the lowest average latency.

There should probably be some point at which another node is stable enough and low latency enough that we should set them as the parent immediately, instead of waiting for the current parent's state to change. It needs to be more than simply having lower latency, because that seems to cause too much route flapping when there are multiple peers with similar latency (particularly for large-ish networks in the sim, where latency is smaller than the variation from the runtime's goroutine scheduler).

A complete version of this (with the remaining issue fixed) would count as a fix for #173 I think.