### PR TITLE
Give a lower priority to (outgoing) socks connections.

### DIFF
--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -88,6 +88,7 @@ type peer struct {
 	endpoint     string
 	friendlyName string
 	firstSeen    time.Time       // To track uptime for getPeers
+	priority     uint8           // Higher priority -> prefer as a parent in the tree
 	linkOut      (chan []byte)   // used for protocol traffic (to bypass queues)
 	doSend       (chan struct{}) // tell the linkLoop to send a switchMsg
 	dinfo        *dhtInfo        // used to keep the DHT working
@@ -321,7 +322,7 @@ func (p *peer) handleSwitchMsg(packet []byte) {
 		}
 		prevKey = hop.Next
 	}
-	p.core.switchTable.handleMsg(&msg, p.port)
+	p.core.switchTable.handleMsg(&msg, p.port, p.priority)
 	if !p.core.switchTable.checkRoot(&msg) {
 		// Bad switch message
 		// Stop forwarding traffic from it

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -292,6 +292,10 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 	in := func(bs []byte) {
 		p.handlePacket(bs)
 	}
+	// Set priority
+	if _, isSocks := sock.(*wrappedConn); !isSocks {
+		p.priority = 1
+	}
 	out := make(chan []byte, 1)
 	defer close(out)
 	go func() {


### PR DESCRIPTION
The basic idea here is that peers get a priority. If peer A's priority is higher than peer B, then we'll always prefer peer A as a parent instead of peer B, as long as it meets the other requirements (no loops, etc).

Priority defaults to 0. Currently, we set priority to 1 if we see that it's *not* a `wrappedConn`, so direct connections should get priority over `socks://`. Something should also be done to check if an incoming connection is proxied, but I'm not sure what.

If we decide to go this route, we can consider giving users some way to manually set priority for specific peers / kinds of peers, but this is one of those things where doing it wrong can hurt other people's network performance, so we probably need to be careful about that.