### PR TITLE
Add -json flag for -genconf and -normaliseconf

### DIFF
--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -95,8 +95,8 @@ func doGenconf(isjson bool) string {
 func main() {
 	// Configure the command line parameters.
 	genconf := flag.Bool("genconf", false, "print a new config to stdout")
-	useconf := flag.Bool("useconf", false, "read config from stdin")
-	useconffile := flag.String("useconffile", "", "read config from specified file path")
+	useconf := flag.Bool("useconf", false, "read HJSON/JSON config from stdin")
+	useconffile := flag.String("useconffile", "", "read HJSON/JSON config from specified file path")
 	normaliseconf := flag.Bool("normaliseconf", false, "use in combination with either -useconf or -useconffile, outputs your configuration normalised")
 	confjson := flag.Bool("json", false, "print configuration from -genconf or -normaliseconf as JSON instead of HJSON")
 	autoconf := flag.Bool("autoconf", false, "automatic mode (dynamic IP, peer with IPv6 neighbors)")

--- a/yggdrasil.go
+++ b/yggdrasil.go
@@ -76,9 +76,15 @@ func generateConfig(isAutoconf bool) *nodeConfig {
 
 // Generates a new configuration and returns it in HJSON format. This is used
 // with -genconf.
-func doGenconf() string {
+func doGenconf(isjson bool) string {
 	cfg := generateConfig(false)
-	bs, err := hjson.Marshal(cfg)
+	var bs []byte
+	var err error
+	if isjson {
+		bs, err = json.MarshalIndent(cfg, "", "  ")
+	} else {
+		bs, err = hjson.Marshal(cfg)
+	}
 	if err != nil {
 		panic(err)
 	}
@@ -92,6 +98,7 @@ func main() {
 	useconf := flag.Bool("useconf", false, "read config from stdin")
 	useconffile := flag.String("useconffile", "", "read config from specified file path")
 	normaliseconf := flag.Bool("normaliseconf", false, "use in combination with either -useconf or -useconffile, outputs your configuration normalised")
+	confjson := flag.Bool("json", false, "print configuration from -genconf or -normaliseconf as JSON instead of HJSON")
 	autoconf := flag.Bool("autoconf", false, "automatic mode (dynamic IP, peer with IPv6 neighbors)")
 	flag.Parse()
 
@@ -186,7 +193,12 @@ func main() {
 		// their configuration file with newly mapped names (like above) or to
 		// convert from plain JSON to commented HJSON.
 		if *normaliseconf {
-			bs, err := hjson.Marshal(cfg)
+			var bs []byte
+			if *confjson {
+				bs, err = json.MarshalIndent(cfg, "", "  ")
+			} else {
+				bs, err = hjson.Marshal(cfg)
+			}
 			if err != nil {
 				panic(err)
 			}
@@ -195,7 +207,7 @@ func main() {
 		}
 	case *genconf:
 		// Generate a new configuration and print it to stdout.
-		fmt.Println(doGenconf())
+		fmt.Println(doGenconf(*confjson))
 	default:
 		// No flags were provided, therefore print the list of flags to stdout.
 		flag.PrintDefaults()


### PR DESCRIPTION
This adds the `-json` flag as an option for `-genconf` and `-normaliseconf`.

We already have the ability to parse normal JSON as well as HJSON - this just makes it easier to clean up the configuration into standard JSON format without comments etc.

Example:
```
yggdrasilctl -genconf -json
yggdrasilctl -useconffile /etc/yggdrasil.conf -normaliseconf -json
```