### PR TITLE
Try to SO_REUSEPORT on multicast socket

### DIFF
--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -1,6 +1,7 @@
 package yggdrasil
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -35,7 +36,10 @@ func (m *multicast) start() error {
 			return err
 		}
 		listenString := fmt.Sprintf("[::]:%v", addr.Port)
-		conn, err := net.ListenPacket("udp6", listenString)
+		lc := net.ListenConfig{
+			Control: multicastReuse,
+		}
+		conn, err := lc.ListenPacket(context.Background(), "udp6", listenString)
 		if err != nil {
 			return err
 		}

--- a/src/yggdrasil/multicast_other.go
+++ b/src/yggdrasil/multicast_other.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!netbsd,!freebsd,!openbsd,!dragonflybsd
+// +build !linux,!darwin,!netbsd,!freebsd,!openbsd,!dragonflybsd,!windows
 
 package yggdrasil
 

--- a/src/yggdrasil/multicast_other.go
+++ b/src/yggdrasil/multicast_other.go
@@ -1,0 +1,9 @@
+// +build !linux,!darwin,!netbsd,!freebsd,!openbsd,!dragonflybsd
+
+package yggdrasil
+
+import "syscall"
+
+func multicastReuse(network string, address string, c syscall.RawConn) error {
+	return nil
+}

--- a/src/yggdrasil/multicast_unix.go
+++ b/src/yggdrasil/multicast_unix.go
@@ -1,0 +1,22 @@
+// +build linux darwin netbsd freebsd openbsd dragonflybsd
+
+package yggdrasil
+
+import "syscall"
+import "golang.org/x/sys/unix"
+
+func multicastReuse(network string, address string, c syscall.RawConn) error {
+	var control error
+	var reuseport error
+
+	control = c.Control(func(fd uintptr) {
+		reuseport = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+	})
+
+	switch {
+	case reuseport != nil:
+		return reuseport
+	default:
+		return control
+	}
+}

--- a/src/yggdrasil/multicast_windows.go
+++ b/src/yggdrasil/multicast_windows.go
@@ -1,0 +1,22 @@
+// +build windows
+
+package yggdrasil
+
+import "syscall"
+import "golang.org/x/sys/windows"
+
+func multicastReuse(network string, address string, c syscall.RawConn) error {
+	var control error
+	var reuseaddr error
+
+	control = c.Control(func(fd uintptr) {
+		reuseaddr = windows.SetsockoptInt(windows.Handle(fd), windows.SOL_SOCKET, windows.SO_REUSEADDR, 1)
+	})
+
+	switch {
+	case reuseaddr != nil:
+		return reuseaddr
+	default:
+		return control
+	}
+}


### PR DESCRIPTION
This PR aims to fix #222 by setting `SO_REUSEPORT` (or `SO_REUSEADDR` on Windows) on the multicast socket. This allows multiple Yggdrasil process to run side-by-side with multicast support enabled, as long as the `Listen` and `AdminListen` directives are configured differently on each instance.

Currently this only adds support for Linux, Darwin, Windows and the BSDs. On other platforms (Solaris, Plan9) nothing is done and reusing the multicast socket will fail in the usual way.

This PR does use `ListenConfig` which I believe is only present in Go 1.11, so we may be tying ourselves to requiring Go 1.11 to build Yggdrasil. I don't suppose this is a problem, and we may already do that in other places, but worth mentioning regardless.