### PR TITLE
switch bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Memory leaks in the DHT fixed
 - Crash where ICMPv6 NDP goroutine would incorrectly start in TUN mode fixed
+- Remove peers from the switch table of they stop sending switch messages but keep the TCP connection alive
 
 ## [0.2.7] - 2018-10-13
 ### Added


### PR DESCRIPTION
Fixes two bugs in the switch:
1. A bug introduced in the switch latency changes, where some info was being reset in cases were it shouldn't be, which would (probably) have cause unnecessarily flapping in the event that the root goes offline or a common ancestor of all peers changes coords.
2. Fixed a bug where, if a peer keeps a connection alive, but doesn't send any switch traffic, then the peer will stay in the switch table indefinitely. They will now be removed from the switch table if they fail to respond for 1 switch timeout period, + a little extra time in case they weren't responding because they had no path to the root (e.g. one of their ancestors, or the root, went offline or broke a link). For non-malicious peers, this is most likely to be an issue if `ReadTimeout` is set to a very large value in the config, as can sometimes be necessary to keep `socks://` or high-latency `tcp://` connections from breaking in lossy environments.

Also updates the changelog to mention the fix to bug 2, since that's been around in previous releases.