### PR TITLE
Strip v from version during imprint

### DIFF
--- a/build
+++ b/build
@@ -10,7 +10,7 @@ done
 echo "Downloading..."
 for CMD in `ls cmd/` ; do
   echo "Building: $CMD"
-  IMPRINT="-X github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil.buildName=$(sh contrib/semver/name.sh) -X github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil.buildVersion=$(sh contrib/semver/version.sh)"
+  IMPRINT="-X github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil.buildName=$(sh contrib/semver/name.sh) -X github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil.buildVersion=$(sh contrib/semver/version.sh --bare)"
   if [ $DEBUG ]; then
     go build -ldflags="$IMPRINT" -tags debug -v ./cmd/$CMD
   else

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -183,10 +183,10 @@ func main() {
 			}
 		case "getself":
 			for k, v := range res["self"].(map[string]interface{}) {
-				if buildname, ok := v.(map[string]interface{})["build_name"].(string); ok {
+				if buildname, ok := v.(map[string]interface{})["build_name"].(string); ok && buildname != "unknown" {
 					fmt.Println("Build name:", buildname)
 				}
-				if buildversion, ok := v.(map[string]interface{})["build_version"].(string); ok {
+				if buildversion, ok := v.(map[string]interface{})["build_version"].(string); ok && buildversion != "unknown" {
 					fmt.Println("Build version:", buildversion)
 				}
 				fmt.Println("IPv6 address:", k)

--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -12,7 +12,7 @@ fi
 
 PKGBRANCH=$(basename `git name-rev --name-only HEAD`)
 PKGNAME=$(sh contrib/semver/name.sh)
-PKGVERSION=$(sh contrib/semver/version.sh | cut -c 2-)
+PKGVERSION=$(sh contrib/semver/version.sh --bare)
 PKGARCH=${PKGARCH-amd64}
 PKGFILE=$PKGNAME-$PKGVERSION-$PKGARCH.deb
 PKGREPLACES=yggdrasil

--- a/contrib/macos/create-pkg.sh
+++ b/contrib/macos/create-pkg.sh
@@ -72,7 +72,7 @@ chmod +x pkgbuild/root/usr/local/bin/yggdrasilctl
 
 # Work out metadata for the package info
 PKGNAME=$(sh contrib/semver/name.sh)
-PKGVERSION=$(sh contrib/semver/version.sh | cut -c 2-)
+PKGVERSION=$(sh contrib/semver/version.sh --bare)
 PKGARCH=${PKGARCH-amd64}
 PAYLOADSIZE=$(( $(wc -c pkgbuild/flat/base.pkg/Payload | awk '{ print $1 }') / 1024 ))
 

--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -12,6 +12,13 @@ MERGE=$(git rev-list $TAG..master --grep "from $DEVELOPBRANCH" 2>/dev/null | hea
 # Get the number of merges since the last merge to master
 PATCH=$(git rev-list $TAG..master --count --merges --grep="from $DEVELOPBRANCH" 2>/dev/null)
 
+# Decide whether we should prepend the version with "v" - the default is that
+# we do because we use it in git tags, but we might not always need it
+PREPEND="v"
+if [ "$1" == "--bare" ]; then
+  PREPEND=""
+fi
+
 # If it fails then there's no last tag - go from the first commit
 if [ $? != 0 ]; then
   PATCH=$(git rev-list HEAD --count 2>/dev/null)
@@ -22,7 +29,7 @@ if [ $? != 0 ]; then
     exit 1
   fi
 
-  printf 'v0.0.%d' "$PATCH"
+  printf '%s0.0.%d' "$PREPEND" "$PATCH"
   exit 1
 fi
 
@@ -39,12 +46,12 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 # Output in the desired format
 if [ $PATCH = 0 ]; then
   if [ ! -z $FULL ]; then
-    printf 'v%d.%d.0' "$MAJOR" "$MINOR"
+    printf '%s%d.%d.0' "$PREPEND" "$MAJOR" "$MINOR"
   else
-    printf 'v%d.%d' "$MAJOR" "$MINOR"
+    printf '%s%d.%d' "$PREPEND" "$MAJOR" "$MINOR"
   fi
 else
-  printf 'v%d.%d.%d' "$MAJOR" "$MINOR" "$PATCH"
+  printf '%s%d.%d.%d' "$PREPEND" "$MAJOR" "$MINOR" "$PATCH"
 fi
 
 # Add the build tag on non-master branches

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -556,13 +556,18 @@ func (a *admin) getData_getSelf() *admin_nodeInfo {
 	table := a.core.switchTable.table.Load().(lookupTable)
 	coords := table.self.getCoords()
 	self := admin_nodeInfo{
-		{"build_name", GetBuildName()},
-		{"build_version", GetBuildVersion()},
 		{"box_pub_key", hex.EncodeToString(a.core.boxPub[:])},
 		{"ip", a.core.GetAddress().String()},
 		{"subnet", a.core.GetSubnet().String()},
 		{"coords", fmt.Sprint(coords)},
 	}
+	if name := GetBuildName(); name != "unknown" {
+		self = append(self, admin_pair{"build_name", name})
+	}
+	if version := GetBuildVersion(); version != "unknown" {
+		self = append(self, admin_pair{"build_version", version})
+	}
+
 	return &self
 }
 

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -87,11 +87,11 @@ func GetBuildVersion() string {
 func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 	c.log = log
 
-	if buildName != "" {
-		c.log.Println("Build name:", buildName)
+	if name := GetBuildName(); name != "unknown" {
+		c.log.Println("Build name:", name)
 	}
-	if buildVersion != "" {
-		c.log.Println("Build version:", buildVersion)
+	if version := GetBuildVersion(); version != "unknown" {
+		c.log.Println("Build version:", version)
 	}
 
 	c.log.Println("Starting up...")


### PR DESCRIPTION
This gives us a "bare" version number, i.e. `0.2.7-0089` instead of `v0.2.7-0089`, which looks a bit nicer in `-version` and `getSelf` etc. This may also be useful in some packaging cases.