### PR TITLE
Allow disabling admin socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Docker support
 - Add `-json` command line flag for generating and normalising configuration in plain JSON
 - Build name and version numbers are now imprinted onto the build, accessible through `yggdrasil -version` and `yggdrasilctl getSelf`
+- Add ability to disable admin socket by setting `AdminListen` to `"none"`
 
 ### Changed
 - Switched to Chord DHT (instead of Kademlia, although protocol-compatible)

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -3,7 +3,7 @@ package config
 // NodeConfig defines all configuration values needed to run a signle yggdrasil node
 type NodeConfig struct {
 	Listen                      string              `comment:"Listen address for peer connections. Default is to listen for all\nTCP connections over IPv4 and IPv6 with a random port."`
-	AdminListen                 string              `comment:"Listen address for admin connections Default is to listen for local\nconnections either on TCP/9001 or a UNIX socket depending on your\nplatform. Use this value for yggdrasilctl -endpoint=X."`
+	AdminListen                 string              `comment:"Listen address for admin connections. Default is to listen for local\nconnections either on TCP/9001 or a UNIX socket depending on your\nplatform. Use this value for yggdrasilctl -endpoint=X. To disable\nthe admin socket, use the value \"none\" instead."`
 	Peers                       []string            `comment:"List of connection strings for static peers in URI format, e.g.\ntcp://a.b.c.d:e or socks://a.b.c.d:e/f.g.h.i:j."`
 	InterfacePeers              map[string][]string `comment:"List of connection strings for static peers in URI format, arranged\nby source interface, e.g. { \"eth0\": [ tcp://a.b.c.d:e ] }. Note that\nSOCKS peerings will NOT be affected by this option and should go in\nthe \"Peers\" section instead."`
 	ReadTimeout                 int32               `comment:"Read timeout for connections, specified in milliseconds. If less\nthan 6000 and not negative, 6000 (the default) is used. If negative,\nreads won't time out."`

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -326,7 +326,7 @@ func (a *admin) init(c *Core, listenaddr string) {
 
 // start runs the admin API socket to listen for / respond to admin API calls.
 func (a *admin) start() error {
-	if a.listenaddr != "none" {
+	if a.listenaddr != "none" && a.listenaddr != "" {
 		go a.listen()
 	}
 	return nil

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -326,7 +326,9 @@ func (a *admin) init(c *Core, listenaddr string) {
 
 // start runs the admin API socket to listen for / respond to admin API calls.
 func (a *admin) start() error {
-	go a.listen()
+	if a.listenaddr != "none" {
+		go a.listen()
+	}
 	return nil
 }
 


### PR DESCRIPTION
This small PR allows you to disable the admin socket for security reasons by setting `AdminListen` to `"none"`. 