### PR TITLE
Add starting point for an RPM spec file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,29 +25,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - in case of vulnerabilities.
 -->
 
-## [0.x.x] - TBD
+## [0.3.0] - 2018-12-12
 ### Added
-- Crypto-key routing support for both IPv4 and IPv6
-- Add `SwitchOptions` in configuration file for tuning the switch
+- Crypto-key routing support for tunnelling both IPv4 and IPv6 over Yggdrasil
+- Add advanced `SwitchOptions` in configuration file for tuning the switch
 - Add `dhtPing` to the admin socket to aid in crawling the network
 - New macOS .pkgs built automatically by CircleCI
-- Add Docker support
-- Add `-json` command line flag for generating and normalising configuration in plain JSON
+- Add Dockerfile to repository for Docker support
+- Add `-json` command line flag for generating and normalising configuration in plain JSON instead of HJSON
 - Build name and version numbers are now imprinted onto the build, accessible through `yggdrasil -version` and `yggdrasilctl getSelf`
 - Add ability to disable admin socket by setting `AdminListen` to `"none"`
 
 ### Changed
-- Switched to Chord DHT (instead of Kademlia, although protocol-compatible)
-- Admin socket clean-up (making some names consistent)
-- Latency-based parent selection for the switch instead of uptime-based
-- Real peering endpoints now shown in the admin socket `getPeers` call
+- Switched to Chord DHT (instead of Kademlia, although still compatible at the protocol level)
+- Cleaned up some of the parameter naming in the admin socket
+- Latency-based parent selection for the switch instead of uptime-based (should help to avoid high latency links somewhat)
+- Real peering endpoints now shown in the admin socket `getPeers` call to help identify peerings
 - Reuse the multicast port on supported platforms so that multiple Yggdrasil processes can run
 - `yggdrasilctl` now has more useful help text (with `-help` or when no arguments passed)
 
 ### Fixed
 - Memory leaks in the DHT fixed
-- Crash where ICMPv6 NDP goroutine would incorrectly start in TUN mode fixed
-- Remove peers from the switch table of they stop sending switch messages but keep the TCP connection alive
+- Crash fixed where the ICMPv6 NDP goroutine would incorrectly start in TUN mode
+- Removing peers from the switch table if they stop sending switch messages but keep the TCP connection alive
 
 ## [0.2.7] - 2018-10-13
 ### Added

--- a/contrib/rpm/yggdrasil.spec
+++ b/contrib/rpm/yggdrasil.spec
@@ -1,0 +1,47 @@
+Name:           yggdrasil
+Version:        0.3.0
+Release:        1%{?dist}
+Summary:        End-to-end encrypted IPv6 networking
+
+License:        GPLv3
+URL:            https://yggdrasil-network.github.io
+Source0:        https://codeload.github.com/yggdrasil-network/yggdrasil-go/tar.gz/v0.3.0
+
+%{?systemd_requires}
+BuildRequires:  systemd golang >= 1.11
+
+%description
+Yggdrasil is a proof-of-concept to explore a wholly different approach to
+network routing. Whereas current computer networks depend heavily on very
+centralised design and configuration, Yggdrasil breaks this mould by making
+use of a global spanning tree to form a scalable IPv6 encrypted mesh network.
+
+%prep
+%setup -qn yggdrasil-go-%{version}
+
+%build
+./build -t -l "-linkmode=external"
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/%{_bindir}
+mkdir -p %{buildroot}/%{_sysconfdir}/systemd/system
+install -m 0755 yggdrasil %{buildroot}/%{_bindir}/yggdrasil
+install -m 0755 yggdrasilctl %{buildroot}/%{_bindir}/yggdrasilctl
+install -m 0755 contrib/systemd/yggdrasil.service %{buildroot}/%{_sysconfdir}/systemd/system/yggdrasil.service
+install -m 0755 contrib/systemd/yggdrasil-resume.service %{buildroot}/%{_sysconfdir}/systemd/system/yggdrasil-resume.service
+
+%files
+%{_bindir}/yggdrasil
+%{_bindir}/yggdrasilctl
+%{_sysconfdir}/systemd/system/yggdrasil.service
+%{_sysconfdir}/systemd/system/yggdrasil-resume.service
+
+%post
+%systemd_post yggdrasil.service
+
+%preun
+%systemd_preun yggdrasil.service
+
+%postun
+%systemd_postun_with_restart yggdrasil.service


### PR DESCRIPTION
This is an example, but incomplete, way that we can create a source RPM package for Yggdrasil.

Assuming `rpmdevtools` and `rpmbuild` installed, and that `yggdrasil.spec` has been updated to reflect the correct version, paths etc.

1. Run `rpmdev-setuptree`
1. Copy `yggdrasil.spec` into `~/rpmbuild/SPECS`
1. Download the `.tar.gz` source file from `Source0` in `yggdrasil.spec` into `~/rpmbuild/SOURCES`
1. From `~/rpmbuild/SPECS`, run `rpmbuild -bs yggdrasil.spec` to build the source RPM
1. Run something like `rpmbuild --rebuild ../SRPMS/yggdrasil-0.3.0-1.fc29.src.rpm` to build the binary RPM

This currently doesn't do anything to back up and normalise the configuration during upgrades like the current Debian package does, but there do seem to be some helper macros for handling the systemd components.