### PR TITLE
Use AF_UNIX socket by default for admin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `-json` command line flag for generating and normalising configuration in plain JSON instead of HJSON
 - Build name and version numbers are now imprinted onto the build, accessible through `yggdrasil -version` and `yggdrasilctl getSelf`
 - Add ability to disable admin socket by setting `AdminListen` to `"none"`
+- `yggdrasilctl` now tries to look for the default configuration file to find `AdminListen` if `-endpoint` is not specified
+- `yggdrasilctl` now returns more useful logging in the event of a fatal error
 
 ### Changed
 - Switched to Chord DHT (instead of Kademlia, although still compatible at the protocol level)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Switched to Chord DHT (instead of Kademlia, although still compatible at the protocol level)
+- The `AdminListen` option and `yggdrasilctl` now default to `unix:///var/run/yggdrasil.sock` on BSDs, macOS and Linux
 - Cleaned up some of the parameter naming in the admin socket
 - Latency-based parent selection for the switch instead of uptime-based (should help to avoid high latency links somewhat)
 - Real peering endpoints now shown in the admin socket `getPeers` call to help identify peerings

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -26,6 +26,13 @@ type admin_info map[string]interface{}
 func main() {
 	logbuffer := &bytes.Buffer{}
 	logger := log.New(logbuffer, "", log.Flags())
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Println("Fatal error:", r)
+			fmt.Print(logbuffer)
+			os.Exit(1)
+		}
+	}()
 
 	endpoint := defaults.GetDefaults().DefaultAdminListen
 
@@ -102,7 +109,6 @@ func main() {
 		conn, err = net.Dial("tcp", endpoint)
 	}
 	if err != nil {
-		fmt.Print(logbuffer)
 		panic(err)
 	}
 	logger.Println("Connected")
@@ -137,7 +143,6 @@ func main() {
 	}
 
 	if err := encoder.Encode(&send); err != nil {
-		fmt.Print(logbuffer)
 		panic(err)
 	}
 	logger.Printf("Request sent")

--- a/src/defaults/defaults.go
+++ b/src/defaults/defaults.go
@@ -7,6 +7,9 @@ type platformDefaultParameters struct {
 	// Admin socket
 	DefaultAdminListen string
 
+	// Configuration (used for yggdrasilctl)
+	DefaultConfigFile string
+
 	// TUN/TAP
 	MaximumIfMTU     int
 	DefaultIfMTU     int

--- a/src/defaults/defaults_darwin.go
+++ b/src/defaults/defaults_darwin.go
@@ -9,6 +9,9 @@ func GetDefaults() platformDefaultParameters {
 		// Admin
 		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
 
+		// Configuration (used for yggdrasilctl)
+		DefaultConfigFile: "/etc/yggdrasil.conf",
+
 		// TUN/TAP
 		MaximumIfMTU:     65535,
 		DefaultIfMTU:     65535,

--- a/src/defaults/defaults_darwin.go
+++ b/src/defaults/defaults_darwin.go
@@ -7,7 +7,7 @@ package defaults
 func GetDefaults() platformDefaultParameters {
 	return platformDefaultParameters{
 		// Admin
-		DefaultAdminListen: "tcp://localhost:9001",
+		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
 
 		// TUN/TAP
 		MaximumIfMTU:     65535,

--- a/src/defaults/defaults_freebsd.go
+++ b/src/defaults/defaults_freebsd.go
@@ -9,6 +9,9 @@ func GetDefaults() platformDefaultParameters {
 		// Admin
 		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
 
+		// Configuration (used for yggdrasilctl)
+		DefaultConfigFile: "/etc/yggdrasil.conf",
+
 		// TUN/TAP
 		MaximumIfMTU:     32767,
 		DefaultIfMTU:     32767,

--- a/src/defaults/defaults_freebsd.go
+++ b/src/defaults/defaults_freebsd.go
@@ -7,7 +7,7 @@ package defaults
 func GetDefaults() platformDefaultParameters {
 	return platformDefaultParameters{
 		// Admin
-		DefaultAdminListen: "tcp://localhost:9001",
+		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
 
 		// TUN/TAP
 		MaximumIfMTU:     32767,

--- a/src/defaults/defaults_linux.go
+++ b/src/defaults/defaults_linux.go
@@ -9,6 +9,9 @@ func GetDefaults() platformDefaultParameters {
 		// Admin
 		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
 
+		// Configuration (used for yggdrasilctl)
+		DefaultConfigFile: "/etc/yggdrasil.conf",
+
 		// TUN/TAP
 		MaximumIfMTU:     65535,
 		DefaultIfMTU:     65535,

--- a/src/defaults/defaults_linux.go
+++ b/src/defaults/defaults_linux.go
@@ -7,7 +7,7 @@ package defaults
 func GetDefaults() platformDefaultParameters {
 	return platformDefaultParameters{
 		// Admin
-		DefaultAdminListen: "tcp://localhost:9001",
+		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
 
 		// TUN/TAP
 		MaximumIfMTU:     65535,

--- a/src/defaults/defaults_netbsd.go
+++ b/src/defaults/defaults_netbsd.go
@@ -7,7 +7,7 @@ package defaults
 func GetDefaults() platformDefaultParameters {
 	return platformDefaultParameters{
 		// Admin
-		DefaultAdminListen: "tcp://localhost:9001",
+		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
 
 		// TUN/TAP
 		MaximumIfMTU:     9000,

--- a/src/defaults/defaults_netbsd.go
+++ b/src/defaults/defaults_netbsd.go
@@ -9,6 +9,9 @@ func GetDefaults() platformDefaultParameters {
 		// Admin
 		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
 
+		// Configuration (used for yggdrasilctl)
+		DefaultConfigFile: "/etc/yggdrasil.conf",
+
 		// TUN/TAP
 		MaximumIfMTU:     9000,
 		DefaultIfMTU:     9000,

--- a/src/defaults/defaults_openbsd.go
+++ b/src/defaults/defaults_openbsd.go
@@ -9,6 +9,9 @@ func GetDefaults() platformDefaultParameters {
 		// Admin
 		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
 
+		// Configuration (used for yggdrasilctl)
+		DefaultConfigFile: "/etc/yggdrasil.conf",
+
 		// TUN/TAP
 		MaximumIfMTU:     16384,
 		DefaultIfMTU:     16384,

--- a/src/defaults/defaults_openbsd.go
+++ b/src/defaults/defaults_openbsd.go
@@ -7,7 +7,7 @@ package defaults
 func GetDefaults() platformDefaultParameters {
 	return platformDefaultParameters{
 		// Admin
-		DefaultAdminListen: "tcp://localhost:9001",
+		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
 
 		// TUN/TAP
 		MaximumIfMTU:     16384,

--- a/src/defaults/defaults_other.go
+++ b/src/defaults/defaults_other.go
@@ -9,6 +9,9 @@ func GetDefaults() platformDefaultParameters {
 		// Admin
 		DefaultAdminListen: "tcp://localhost:9001",
 
+		// Configuration (used for yggdrasilctl)
+		DefaultConfigFile: "/etc/yggdrasil.conf",
+
 		// TUN/TAP
 		MaximumIfMTU:     65535,
 		DefaultIfMTU:     65535,

--- a/src/defaults/defaults_windows.go
+++ b/src/defaults/defaults_windows.go
@@ -9,6 +9,9 @@ func GetDefaults() platformDefaultParameters {
 		// Admin
 		DefaultAdminListen: "tcp://localhost:9001",
 
+		// Configuration (used for yggdrasilctl)
+		DefaultConfigFile: "C:\\Program Files\\Yggdrasil\\yggdrasil.conf",
+
 		// TUN/TAP
 		MaximumIfMTU:     65535,
 		DefaultIfMTU:     65535,

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -343,11 +343,14 @@ func (a *admin) listen() {
 	if err == nil {
 		switch strings.ToLower(u.Scheme) {
 		case "unix":
+			if _, err := os.Stat(a.listenaddr[7:]); err == nil {
+				a.core.log.Println("WARNING:", a.listenaddr[7:], "already exists and may be in use by another process")
+			}
 			a.listener, err = net.Listen("unix", a.listenaddr[7:])
 			if err == nil {
 				if err := os.Chmod(a.listenaddr[7:], 0660); err != nil {
-      		a.core.log.Printf("WARNING:", a.listenaddr[:7], "may have unsafe permissions!")
-      	}
+					a.core.log.Println("WARNING:", a.listenaddr[:7], "may have unsafe permissions!")
+				}
 			}
 		case "tcp":
 			a.listener, err = net.Listen("tcp", u.Host)

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -344,6 +344,11 @@ func (a *admin) listen() {
 		switch strings.ToLower(u.Scheme) {
 		case "unix":
 			a.listener, err = net.Listen("unix", a.listenaddr[7:])
+			if err == nil {
+				if err := os.Chmod(a.listenaddr[7:], 0660); err != nil {
+      		a.core.log.Printf("WARNING:", a.listenaddr[:7], "may have unsafe permissions!")
+      	}
+			}
 		case "tcp":
 			a.listener, err = net.Listen("tcp", u.Host)
 		default:

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -348,8 +348,12 @@ func (a *admin) listen() {
 			}
 			a.listener, err = net.Listen("unix", a.listenaddr[7:])
 			if err == nil {
-				if err := os.Chmod(a.listenaddr[7:], 0660); err != nil {
-					a.core.log.Println("WARNING:", a.listenaddr[:7], "may have unsafe permissions!")
+				switch a.listenaddr[7:8] {
+				case "@": // maybe abstract namespace
+				default:
+					if err := os.Chmod(a.listenaddr[7:], 0660); err != nil {
+						a.core.log.Println("WARNING:", a.listenaddr[:7], "may have unsafe permissions!")
+					}
 				}
 			}
 		case "tcp":


### PR DESCRIPTION
This PR contains the changes needed to switch to UNIX sockets for the admin API by default on supported platforms.