### PR TITLE
CKR tweaks

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -268,11 +268,11 @@ func (a *admin) init(c *Core, listenaddr string) {
 		return admin_info{"source_subnets": subnets}, nil
 	})
 	a.addHandler("getRoutes", []string{}, func(in admin_info) (admin_info, error) {
-		var routes []string
+		routes := make(admin_info)
 		a.core.router.doAdmin(func() {
 			getRoutes := func(ckrs []cryptokey_route) {
 				for _, ckr := range ckrs {
-					routes = append(routes, fmt.Sprintf("%s via %s", ckr.subnet.String(), hex.EncodeToString(ckr.destination[:])))
+					routes[ckr.subnet.String()] = hex.EncodeToString(ckr.destination[:])
 				}
 			}
 			getRoutes(a.core.router.cryptokey.ipv4routes)

--- a/src/yggdrasil/ckr.go
+++ b/src/yggdrasil/ckr.go
@@ -241,6 +241,16 @@ func (c *cryptokey) getPublicKeyForAddress(addr address, addrlen int) (boxPubKey
 	for _, route := range *routingtable {
 		// Does this subnet match the given IP?
 		if route.subnet.Contains(ip) {
+			// Check if the routing cache is above a certain size, if it is evict
+			// a random entry so we can make room for this one. We take advantage
+			// of the fact that the iteration order is random here
+			if len(*routingcache) > 1024 {
+				for k := range *routingcache {
+					delete(*routingcache, k)
+					break
+				}
+			}
+
 			// Cache the entry for future packets to get a faster lookup
 			(*routingcache)[addr] = route
 


### PR DESCRIPTION
This PR includes two tweaks:

1. Enforces the maximum size of the CKR cache for each protocol to 1024 entries
1. Updates the format of `getRoutes` in the admin socket so that it is half-way sane