### PR TITLE
Compile really static with no pie

### DIFF
--- a/build
+++ b/build
@@ -5,6 +5,7 @@ PKGNAME=${PKGNAME:-$(sh contrib/semver/name.sh)}
 PKGVER=${PKGVER:-$(sh contrib/semver/version.sh --bare)}
 
 LDFLAGS="-X $PKGSRC.buildName=$PKGNAME -X $PKGSRC.buildVersion=$PKGVER"
+LDFLAGS="$LDFLAGS -extldflags '-static -no-pie'"
 
 while getopts "udtc:l:" option
 do


### PR DESCRIPTION
On Alpine Linux (musl-libc based GNU/Linux distribution)

Before: $ file yggdrasil
yggdrasil: ELF 64-bit LSB pie executable x86-64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-musl-x86_64.so.1, stripped

After: $ file yggdrasil
yggdrasil: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped