### PR TITLE
Update debian package again

### DIFF
--- a/contrib/systemd/yggdrasil.service
+++ b/contrib/systemd/yggdrasil.service
@@ -4,6 +4,7 @@ Wants=network.target
 After=network.target
 
 [Service]
+Group=yggdrasil
 ProtectHome=true
 ProtectSystem=true
 SyslogIdentifier=yggdrasil
@@ -12,7 +13,7 @@ ExecStartPre=/bin/sh -ec "if ! test -s /etc/yggdrasil.conf; \
                 yggdrasil -genconf > /etc/yggdrasil.conf; \
                 echo 'WARNING: A new /etc/yggdrasil.conf file has been generated.'; \
             fi"
-ExecStart=/bin/sh -c "exec yggdrasil -useconf < /etc/yggdrasil.conf"
+ExecStart=/usr/bin/yggdrasil -useconffile /etc/yggdrasil.conf
 Restart=always
 
 [Install]


### PR DESCRIPTION
This adds group ID `yggdrasil` which can be used to read `/etc/yggdrasil.conf` and to use the UNIX admin socket, and automatically enables/starts Yggdrasil if there is an existing `/etc/yggdrasil.conf` (or this causes a problem where if upgrading a remote host, it may not start again).