### PR TITLE
Fix bug in yggdrasilctl where -endpoint gets ignored

### DIFF
--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -87,6 +87,7 @@ func main() {
 			logger.Println("Falling back to platform default", defaults.GetDefaults().DefaultAdminListen)
 		}
 	} else {
+		endpoint = *server
 		logger.Println("Using endpoint", endpoint, "from command line")
 	}
 


### PR DESCRIPTION
This fixes the bug where `-endpoint` gets ignored by accident.