### PR TITLE
Fix panic if Peers or InterfacePeers is commented out

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -191,19 +191,8 @@ func main() {
 		}
 		// Check to see if the peers are in a parsable format, if not then default
 		// them to the TCP scheme
-		for index, peer := range dat["Peers"].([]interface{}) {
-			uri := peer.(string)
-			if strings.HasPrefix(uri, "tcp://") || strings.HasPrefix(uri, "socks://") {
-				continue
-			}
-			if strings.HasPrefix(uri, "tcp:") {
-				uri = uri[4:]
-			}
-			(dat["Peers"].([]interface{}))[index] = "tcp://" + uri
-		}
-		// Now do the same with the interface peers
-		for intf, peers := range dat["InterfacePeers"].(map[string]interface{}) {
-			for index, peer := range peers.([]interface{}) {
+		if peers, ok := dat["Peers"].([]interface{}); ok {
+			for index, peer := range peers {
 				uri := peer.(string)
 				if strings.HasPrefix(uri, "tcp://") || strings.HasPrefix(uri, "socks://") {
 					continue
@@ -211,7 +200,22 @@ func main() {
 				if strings.HasPrefix(uri, "tcp:") {
 					uri = uri[4:]
 				}
-				((dat["InterfacePeers"].(map[string]interface{}))[intf]).([]interface{})[index] = "tcp://" + uri
+				(dat["Peers"].([]interface{}))[index] = "tcp://" + uri
+			}
+		}
+		// Now do the same with the interface peers
+		if interfacepeers, ok := dat["InterfacePeers"].(map[string]interface{}); ok {
+			for intf, peers := range interfacepeers {
+				for index, peer := range peers.([]interface{}) {
+					uri := peer.(string)
+					if strings.HasPrefix(uri, "tcp://") || strings.HasPrefix(uri, "socks://") {
+						continue
+					}
+					if strings.HasPrefix(uri, "tcp:") {
+						uri = uri[4:]
+					}
+					((dat["InterfacePeers"].(map[string]interface{}))[intf]).([]interface{})[index] = "tcp://" + uri
+				}
 			}
 		}
 		// Overlay our newly mapped configuration onto the autoconf node config that


### PR DESCRIPTION
This fixes a panic at startup if `Peers` or `InterfacePeers` are commented out. This was introduced by the new code in `cmd/yggdrasil/main.go` which aims to fix the formatting of old peer entries.