### PR TITLE
Minor TCP change

### DIFF
--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -59,8 +59,6 @@ func (iface *tcpInterface) setExtraOptions(c net.Conn) {
 	switch sock := c.(type) {
 	case *net.TCPConn:
 		sock.SetNoDelay(true)
-		sock.SetKeepAlive(true)
-		sock.SetKeepAlivePeriod(iface.tcp_timeout)
 	// TODO something for socks5
 	default:
 	}


### PR DESCRIPTION
Undoes some of the changes from the fastpeer branch because TCP keepalive behavior is platform dependent, and I don't want to deal with that, so we'll have to keep doing things at the application level.