### PR TITLE
Point hjson to master repo following comments merge

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -18,9 +18,9 @@ import (
 
 	"golang.org/x/text/encoding/unicode"
 
+	"github.com/hjson/hjson-go"
 	"github.com/kardianos/minwinsvc"
 	"github.com/mitchellh/mapstructure"
-	"github.com/neilalexander/hjson-go"
 
 	"github.com/yggdrasil-network/yggdrasil-go/src/config"
 	"github.com/yggdrasil-network/yggdrasil-go/src/defaults"

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -17,7 +17,7 @@ import (
 
 	"golang.org/x/text/encoding/unicode"
 
-	"github.com/neilalexander/hjson-go"
+	"github.com/hjson/hjson-go"
 	"github.com/yggdrasil-network/yggdrasil-go/src/defaults"
 )
 

--- a/contrib/config/yggdrasilconf.go
+++ b/contrib/config/yggdrasilconf.go
@@ -14,7 +14,7 @@ import (
 	"io/ioutil"
 	"strconv"
 
-	"github.com/neilalexander/hjson-go"
+	"github.com/hjson/hjson-go"
 	"golang.org/x/text/encoding/unicode"
 
 	"github.com/yggdrasil-network/yggdrasil-go/src/config"

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/yggdrasil-network/yggdrasil-go
 
 require (
 	github.com/docker/libcontainer v2.2.1+incompatible
+	github.com/hjson/hjson-go v0.0.0-20181010104306-a25ecf6bd222
 	github.com/kardianos/minwinsvc v0.0.0-20151122163309-cad6b2b879b0
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/neilalexander/hjson-go v0.0.0-20180509131856-23267a251165
 	github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091
 	github.com/yggdrasil-network/water v0.0.0-20180615095340-f732c88f34ae
 	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 github.com/docker/libcontainer v2.2.1+incompatible h1:++SbbkCw+X8vAd4j2gOCzZ2Nn7s2xFALTf7LZKmM1/0=
 github.com/docker/libcontainer v2.2.1+incompatible/go.mod h1:osvj61pYsqhNCMLGX31xr7klUBhHb/ZBuXS0o1Fvwbw=
+github.com/hjson/hjson-go v0.0.0-20181010104306-a25ecf6bd222 h1:xmvkbxXDeN1ffWq8kvrhyqVYAO2aXuRBsbpxVTR+JyU=
+github.com/hjson/hjson-go v0.0.0-20181010104306-a25ecf6bd222/go.mod h1:qsetwF8NlsTsOTwZTApNlTCerV+b2GjYRRcIk4JMFio=
 github.com/kardianos/minwinsvc v0.0.0-20151122163309-cad6b2b879b0 h1:YnZmFjg0Nvk8851WTVWlqMC1ecJH07Ctz+Ezxx4u54g=
 github.com/kardianos/minwinsvc v0.0.0-20151122163309-cad6b2b879b0/go.mod h1:rUi0/YffDo1oXBOGn1KRq7Fr07LX48XEBecQnmwjsAo=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/neilalexander/hjson-go v0.0.0-20180509131856-23267a251165 h1:Oo7Yfu5lEQLGvvh2p9Z8FRHJIsl7fdOCK9xXFNBkqmQ=
-github.com/neilalexander/hjson-go v0.0.0-20180509131856-23267a251165/go.mod h1:l+Zao6IpQ+6d/y7LnYnOfbfOeU/9xRiTi4HLVpnkcTg=
 github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091 h1:1zN6ImoqhSJhN8hGXFaJlSC8msLmIbX8bFqOfWLKw0w=
 github.com/songgao/packets v0.0.0-20160404182456-549a10cd4091/go.mod h1:N20Z5Y8oye9a7HmytmZ+tr8Q2vlP0tAHP13kTHzwvQY=
 github.com/yggdrasil-network/water v0.0.0-20180615095340-f732c88f34ae h1:MYCANF1kehCG6x6G+/9txLfq6n3lS5Vp0Mxn1hdiBAc=


### PR DESCRIPTION
Support for HJSON comments was merged into `hjson-go` in hjson/hjson-go#11 so this updates the `go.mod` etc to point to the master repo again instead of my fork.