### PR TITLE
Multithread the admin socket

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -395,7 +395,7 @@ func (a *admin) listen() {
 	for {
 		conn, err := a.listener.Accept()
 		if err == nil {
-			a.handleRequest(conn)
+			go a.handleRequest(conn)
 		}
 	}
 }


### PR DESCRIPTION
This multithreads the admin socket so that a waiting request doesn't block other requests. 