### PR TITLE
CircleCI: don't recreate tags that already exist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
           name: Create tags (master branch only)
           command: >
               if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                git tag -f -a $(sh contrib/semver/version.sh) -m "Created by CircleCI" && git push -f --tags;
+                git tag -a $(sh contrib/semver/version.sh) -m "Created by CircleCI" && git push --tags;
               else
                 echo "Only runs for master branch (this is ${CIRCLE_BRANCH})";
               fi;

--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -33,9 +33,6 @@ if [ $? != 0 ]; then
   exit 1
 fi
 
-# Get the number of merges on the current branch since the last tag
-BUILD=$(git rev-list $TAG..HEAD --count --merges)
-
 # Split out into major, minor and patch numbers
 MAJOR=$(echo $TAG | cut -c 2- | cut -d "." -f 1)
 MINOR=$(echo $TAG | cut -c 2- | cut -d "." -f 2)
@@ -53,6 +50,10 @@ if [ $PATCH = 0 ]; then
 else
   printf '%s%d.%d.%d' "$PREPEND" "$MAJOR" "$MINOR" "$PATCH"
 fi
+
+# Get the number of merges on the current branch since the last tag
+TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*\.[0-9]*" 2>/dev/null)
+BUILD=$(git rev-list $TAG..$BRANCH --count)
 
 # Add the build tag on non-master branches
 if [ $BRANCH != "master" ]; then

--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -52,8 +52,8 @@ else
 fi
 
 # Get the number of merges on the current branch since the last tag
-TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*\.[0-9]*" 2>/dev/null)
-BUILD=$(git rev-list $TAG..$BRANCH --count)
+TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*\.[0-9]*" --first-parent master 2>/dev/null)
+BUILD=$(git rev-list $TAG.. --count)
 
 # Add the build tag on non-master branches
 if [ $BRANCH != "master" ]; then
@@ -62,6 +62,6 @@ if [ $BRANCH != "master" ]; then
   fi
 else
   if [ $BUILD != 0 ]; then
-    printf -- "-%d" "$BUILD"
+    printf -- "-%d" "$(($BUILD+1))"
   fi
 fi

--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -59,4 +59,8 @@ if [ $BRANCH != "master" ]; then
   if [ $BUILD != 0 ]; then
     printf -- "-%04d" "$BUILD"
   fi
+else
+  if [ $BUILD != 0 ]; then
+    printf -- "-%d" "$BUILD"
+  fi
 fi


### PR DESCRIPTION
This prevents tags from being moved if multiple commits are made on the same release, e.g. to fix a packaging problem.