### PR TITLE
Added compile support for Arm v6

### DIFF
--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -26,9 +26,10 @@ elif [ $PKGARCH = "i386" ]; then GOARCH=386 GOOS=linux ./build
 elif [ $PKGARCH = "mipsel" ]; then GOARCH=mipsle GOOS=linux ./build
 elif [ $PKGARCH = "mips" ]; then GOARCH=mips64 GOOS=linux ./build
 elif [ $PKGARCH = "armhf" ]; then GOARCH=arm GOOS=linux GOARM=7 ./build
+elif [ $PKGARCH = "armv6" ]; then  export PKGARCH="armhf"; GOARCH=arm GOOS=linux GOARM=6 ./build;
 elif [ $PKGARCH = "arm64" ]; then GOARCH=arm64 GOOS=linux ./build
 else
-  echo "Specify PKGARCH=amd64,i386,mips,mipsel,armhf,arm64"
+  echo "Specify PKGARCH=amd64,i386,mips,mipsel,armv6,armhf,arm64"
   exit 1
 fi
 

--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -25,11 +25,10 @@ if [ $PKGARCH = "amd64" ]; then GOARCH=amd64 GOOS=linux ./build
 elif [ $PKGARCH = "i386" ]; then GOARCH=386 GOOS=linux ./build
 elif [ $PKGARCH = "mipsel" ]; then GOARCH=mipsle GOOS=linux ./build
 elif [ $PKGARCH = "mips" ]; then GOARCH=mips64 GOOS=linux ./build
-elif [ $PKGARCH = "armhf" ]; then GOARCH=arm GOOS=linux GOARM=7 ./build
-elif [ $PKGARCH = "armv6" ]; then  export PKGARCH="armhf"; GOARCH=arm GOOS=linux GOARM=6 ./build;
+elif [ $PKGARCH = "armhf" ]; then GOARCH=arm GOOS=linux GOARM=6 ./build
 elif [ $PKGARCH = "arm64" ]; then GOARCH=arm64 GOOS=linux ./build
 else
-  echo "Specify PKGARCH=amd64,i386,mips,mipsel,armv6,armhf,arm64"
+  echo "Specify PKGARCH=amd64,i386,mips,mipsel,armhf,arm64"
   exit 1
 fi
 


### PR DESCRIPTION
Support for older raspberry pis and Pi Zero

`armhf` is already used for v7 so `armv6` also sets arch back to `armhf`

Tested On Raspberry Pi B+