### PR TITLE
Don't fail if tag exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
           name: Create tags (master branch only)
           command: >
               if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                git tag -a $(sh contrib/semver/version.sh) -m "Created by CircleCI" && git push --tags;
+                (git tag -a $(sh contrib/semver/version.sh) -m "Created by CircleCI" && git push --tags) || true;
               else
                 echo "Only runs for master branch (this is ${CIRCLE_BRANCH})";
               fi;


### PR DESCRIPTION
This will stop the CircleCI pipeline failing if the tag already exists.