### PR TITLE
Tune DHT a little better

### DIFF
--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -134,6 +134,15 @@ func (t *dht) insert(info *dhtInfo) {
 	t.table[*info.getNodeID()] = info
 }
 
+// Insert a peer into the table if it hasn't been pinged lately, to keep peers from dropping
+func (t *dht) insertPeer(info *dhtInfo) {
+	oldInfo, isIn := t.table[*info.getNodeID()]
+	if !isIn || time.Since(oldInfo.recv) > 45*time.Second {
+		// TODO? also check coords?
+		t.insert(info)
+	}
+}
+
 // Return true if first/second/third are (partially) ordered correctly.
 func dht_ordered(first, second, third *crypto.NodeID) bool {
 	lessOrEqual := func(first, second *crypto.NodeID) bool {

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -12,7 +12,12 @@ import (
 	"github.com/yggdrasil-network/yggdrasil-go/src/crypto"
 )
 
-const dht_lookup_size = 16
+const (
+	dht_lookup_size     = 16
+	dht_timeout         = 6 * time.Minute
+	dht_max_delay       = 5 * time.Minute
+	dht_max_delay_dirty = 30 * time.Second
+)
 
 // dhtInfo represents everything we know about a node in the DHT.
 // This includes its key, a cache of it's NodeID, coords, and timing/ping related info for deciding who/when to ping nodes for maintenance.
@@ -23,6 +28,7 @@ type dhtInfo struct {
 	recv          time.Time // When we last received a message
 	pings         int       // Time out if at least 3 consecutive maintenance pings drop
 	throttle      time.Duration
+	dirty         bool // Set to true if we've used this node in ping responses (for queries about someone other than the person doing the asking, i.e. real searches) since the last time we heard from the node
 }
 
 // Returns the *NodeID associated with dhtInfo.key, calculating it on the fly the first time or from a cache all subsequent times.
@@ -137,7 +143,7 @@ func (t *dht) insert(info *dhtInfo) {
 // Insert a peer into the table if it hasn't been pinged lately, to keep peers from dropping
 func (t *dht) insertPeer(info *dhtInfo) {
 	oldInfo, isIn := t.table[*info.getNodeID()]
-	if !isIn || time.Since(oldInfo.recv) > 45*time.Second {
+	if !isIn || time.Since(oldInfo.recv) > dht_max_delay+30*time.Second {
 		// TODO? also check coords?
 		t.insert(info)
 	}
@@ -193,6 +199,14 @@ func (t *dht) handleReq(req *dhtReq) {
 	}
 	if _, isIn := t.table[*info.getNodeID()]; !isIn && t.isImportant(&info) {
 		t.ping(&info, nil)
+	}
+	// Maybe mark nodes from lookup as dirty
+	if req.Dest != *info.getNodeID() {
+		// This node asked about someone other than themself, so this wasn't just idle traffic.
+		for _, info := range res.Infos {
+			// Mark nodes dirty so we're sure to check up on them again later
+			info.dirty = true
+		}
 	}
 }
 
@@ -311,19 +325,24 @@ func (t *dht) doMaintenance() {
 	}
 	t.callbacks = newCallbacks
 	for infoID, info := range t.table {
-		if now.Sub(info.recv) > time.Minute || info.pings > 3 {
+		if now.Sub(info.recv) > dht_timeout || info.pings > 6 {
 			delete(t.table, infoID)
 			t.imp = nil
 		}
 	}
 	for _, info := range t.getImportant() {
-		if now.Sub(info.recv) > info.throttle {
+		switch {
+		case now.Sub(info.recv) > info.throttle:
+			info.throttle *= 2
+			if info.throttle < time.Second {
+				info.throttle = time.Second
+			} else if info.throttle > dht_max_delay {
+				info.throttle = dht_max_delay
+			}
+			fallthrough
+		case info.dirty && now.Sub(info.recv) > dht_max_delay_dirty:
 			t.ping(info, nil)
 			info.pings++
-			info.throttle += time.Second
-			if info.throttle > 30*time.Second {
-				info.throttle = 30 * time.Second
-			}
 		}
 	}
 }

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -110,12 +110,7 @@ func (r *router) mainLoop() {
 		case p := <-r.send:
 			r.sendPacket(p)
 		case info := <-r.core.dht.peers:
-			now := time.Now()
-			oldInfo, isIn := r.core.dht.table[*info.getNodeID()]
-			r.core.dht.insert(info)
-			if isIn && now.Sub(oldInfo.recv) < 45*time.Second {
-				info.recv = oldInfo.recv
-			}
+			r.core.dht.insertPeer(info)
 		case <-r.reset:
 			r.core.sessions.resetInits()
 			r.core.dht.reset()


### PR DESCRIPTION
Does two things:
1. Moves the peer-specific logic for adding nodes to the DHT from router.go to dht.go and fixes #271 by adjusting how peers get inserted into the DHT (they're only really needed for bootstrapping reasons). I'm not sure why the old version wasn't working right, but I think it was spamming peers with DHT traffic more often than needed, so this may also happen to reduce idle bandwidth.
2. Tries to fix #273 by adjusting how DHT throttle works. Things will now throttle back exponentially. If the DHT is in use, it should ping nodes after at most 30 seconds, which is how things currently work in the master branch. However, if DHT info about a node has *not* been used (specifically, if you haven't sent it as a response to a node that asked about an ID other than their own), then maximum the throttle backs off has been increased to 5 minutes, with timeouts after 6 minutes. This should decrease idle bandwidth use (from the DHT) by a factor of ~10. However, this needs testing, as it currently still seems to ping all nodes after 30 seconds (I suspect this is from idle traffic sent by old kad nodes, which would flag dht info as being used when it's really not).

I need to add some debug output and run some more tests, to try and confirm that old kad nodes are responsible for part 2 not working right, but I'm opening the PR now just to document what's going on / let someone else try testing if I don't manage to get to it in the next few days.