### PR TITLE
Spelling fixes Round 1 (DO NOT USE)

### DIFF
--- a/src/yggdrasil/adapter.go
+++ b/src/yggdrasil/adapter.go
@@ -17,7 +17,7 @@ type Adapter struct {
 	recv <-chan []byte
 }
 
-// Initialises the adapter.
+// Initializes the adapter.
 func (adapter *Adapter) init(core *Core, send chan<- []byte, recv <-chan []byte) {
 	adapter.core = core
 	adapter.send = send

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -145,7 +145,8 @@ func (t *dht) insertPeer(info *dhtInfo) {
 	oldInfo, isIn := t.table[*info.getNodeID()]
 	if !isIn || time.Since(oldInfo.recv) > dht_max_delay+30*time.Second {
 		// TODO? also check coords?
-		t.insert(info)
+		newInfo := *info // Insert a copy
+		t.insert(&newInfo)
 	}
 }
 

--- a/src/yggdrasil/icmpv6.go
+++ b/src/yggdrasil/icmpv6.go
@@ -56,7 +56,7 @@ func ipv6Header_Marshal(h *ipv6.Header) ([]byte, error) {
 	return b, nil
 }
 
-// Initialises the ICMPv6 module by assigning our link-local IPv6 address and
+// Initializes the ICMPv6 module by assigning our link-local IPv6 address and
 // our MAC address. ICMPv6 messages will always appear to originate from these
 // addresses.
 func (i *icmpv6) init(t *tunAdapter) {

--- a/src/yggdrasil/nodeinfo.go
+++ b/src/yggdrasil/nodeinfo.go
@@ -41,7 +41,7 @@ type nodeinfoReqRes struct {
 	NodeInfo    nodeinfoPayload
 }
 
-// Initialises the nodeinfo cache/callback maps, and starts a goroutine to keep
+// Initializes the nodeinfo cache/callback maps, and starts a goroutine to keep
 // the cache/callback maps clean of stale entries
 func (m *nodeinfo) init(core *Core) {
 	m.core = core

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -14,7 +14,7 @@ import (
 )
 
 // The peers struct represents peers with an active connection.
-// Incomping packets are passed to the corresponding peer, which handles them somehow.
+// Incoming packets are passed to the corresponding peer, which handles them somehow.
 // In most cases, this involves passing the packet to the handler for outgoing traffic to another peer.
 // In other cases, it's link protocol traffic used to build the spanning tree, in which case this checks signatures and passes the message along to the switch.
 type peers struct {
@@ -341,7 +341,7 @@ func (p *peer) handleSwitchMsg(packet []byte) {
 }
 
 // This generates the bytes that we sign or check the signature of for a switchMsg.
-// It begins with the next node's key, followed by the root and the timetsamp, followed by coords being advertised to the next node.
+// It begins with the next node's key, followed by the root and the timestamp, followed by coords being advertised to the next node.
 func getBytesForSig(next *crypto.SigPubKey, msg *switchMsg) []byte {
 	var loc switchLocator
 	for _, hop := range msg.Hops {

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -10,9 +10,9 @@ package yggdrasil
 //  Could be used to DoS (connect, give someone else's keys, spew garbage)
 //  I guess the "peer" part should watch for link packets, disconnect?
 
-// TCP connections start with a metadata exchange.
+// TCP connections start with a meta data exchange.
 //  It involves exchanging version numbers and crypto keys
-//  See version.go for version metadata format
+//  See version.go for version meta data format
 
 import (
 	"errors"
@@ -74,7 +74,7 @@ func (iface *tcpInterface) connect(addr string, intf string) {
 	iface.call(addr, nil, intf)
 }
 
-// Attempst to initiate a connection to the provided address, viathe provided socks proxy address.
+// Attempts to initiate a connection to the provided address, via the provided socks proxy address.
 func (iface *tcpInterface) connectSOCKS(socksaddr, peeraddr string) {
 	iface.call(peeraddr, &socksaddr, "")
 }
@@ -370,7 +370,7 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 	return
 }
 
-// This reads from the socket into a []byte buffer for incomping messages.
+// This reads from the socket into a []byte buffer for incoming messages.
 // It copies completed messages out of the cache into a new slice, and passes them to the peer struct via the provided `in func([]byte)` argument.
 // Then it shifts the incomplete fragments of data forward so future reads won't overwrite it.
 func (iface *tcpInterface) reader(sock net.Conn, in func([]byte)) error {


### PR DESCRIPTION
Spelling fixes done by running aspell over it.