### PR TITLE
insert a copy when calling dht.insertPeer

### DIFF
--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -145,7 +145,8 @@ func (t *dht) insertPeer(info *dhtInfo) {
 	oldInfo, isIn := t.table[*info.getNodeID()]
 	if !isIn || time.Since(oldInfo.recv) > dht_max_delay+30*time.Second {
 		// TODO? also check coords?
-		t.insert(info)
+		newInfo := *info // Insert a copy
+		t.insert(&newInfo)
 	}
 }
 


### PR DESCRIPTION
Possibly fixes misc dht bugs.

Basically, the `peer` struct creates a `dhtInfo` and passes it into the dht via a channel to the router. This happens by passing a pointer to the struct. This pointer was then getting directly inserted into the DHT, instead of inserting a copy of the struct. That would cause things like e.g. `dhtInfo.pings` to not get reset when inserting a new copy, so the new info could immediately get dropped again due to looking bad.