### PR TITLE
Don't process ICMPv6 messages when in TUN mode

### DIFF
--- a/src/yggdrasil/icmpv6.go
+++ b/src/yggdrasil/icmpv6.go
@@ -156,6 +156,9 @@ func (i *icmpv6) parse_packet_tun(datain []byte, datamac *[]byte) ([]byte, error
 	// Check for a supported message type
 	switch icmpv6Header.Type {
 	case ipv6.ICMPTypeNeighborSolicitation:
+		if !i.tun.iface.IsTAP() {
+			return nil, errors.New("Ignoring Neighbor Solicitation in TUN mode")
+		}
 		response, err := i.handle_ndp(datain[ipv6.HeaderLen:])
 		if err == nil {
 			// Create our ICMPv6 response
@@ -173,6 +176,9 @@ func (i *icmpv6) parse_packet_tun(datain []byte, datamac *[]byte) ([]byte, error
 			return nil, err
 		}
 	case ipv6.ICMPTypeNeighborAdvertisement:
+		if !i.tun.iface.IsTAP() {
+			return nil, errors.New("Ignoring Neighbor Advertisement in TUN mode")
+		}
 		if datamac != nil {
 			var addr address.Address
 			var target address.Address

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -214,11 +214,12 @@ func (tun *tunAdapter) read() error {
 			continue
 		}
 		if buf[o+6] == 58 {
-			// Found an ICMPv6 packet
-			b := make([]byte, n)
-			copy(b, buf)
-			// tun.icmpv6.recv <- b
-			go tun.icmpv6.parse_packet(b)
+			if tun.iface.IsTAP() {
+				// Found an ICMPv6 packet
+				b := make([]byte, n)
+				copy(b, buf)
+				go tun.icmpv6.parse_packet(b)
+			}
 		}
 		packet := append(util.GetBytes(), buf[o:n]...)
 		tun.send <- packet


### PR DESCRIPTION
This ensures that NDP is not processed when in TUN mode. Ordinarily this shouldn't happen but it does seem to be possible in some very extreme edge-cases, e.g. unusual configuration mixing L2 and L3 interfaces on a router.