### PR TITLE
Rewrite contrib/semver/version.sh

### DIFF
--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -1,63 +1,30 @@
 #!/bin/sh
 
-# Merge commits from this branch are counted
-DEVELOPBRANCH="yggdrasil-network/develop"
-
 # Get the last tag
-TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*\.0" 2>/dev/null)
+TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*\.[0-9]*" 2>/dev/null)
+test $? != 0 && (echo "unknown"; exit 1)
 
-# Get last merge to master
-MERGE=$(git rev-list $TAG..master --grep "from $DEVELOPBRANCH" 2>/dev/null | head -n 1)
-
-# Get the number of merges since the last merge to master
-PATCH=$(git rev-list $TAG..master --count --merges --grep="from $DEVELOPBRANCH" --first-parent master 2>/dev/null)
-
-# Decide whether we should prepend the version with "v" - the default is that
-# we do because we use it in git tags, but we might not always need it
-PREPEND="v"
-if [ "$1" = "--bare" ]; then
-  PREPEND=""
-fi
-
-# If it fails then there's no last tag - go from the first commit
-if [ $? != 0 ]; then
-  PATCH=$(git rev-list HEAD --count 2>/dev/null)
-
-  # Complain if the git history is not available
-  if [ $? != 0 ]; then
-    printf 'unknown'
-    exit 1
-  fi
-
-  printf '%s0.0.%d' "$PREPEND" "$PATCH"
-  exit 1
-fi
+# Get the current branch
+BRANCH=$(git symbolic-ref -q HEAD --short 2>/dev/null)
+test $? != 0 && BRANCH="master"
 
 # Split out into major, minor and patch numbers
 MAJOR=$(echo $TAG | cut -c 2- | cut -d "." -f 1)
 MINOR=$(echo $TAG | cut -c 2- | cut -d "." -f 2)
-
-# Get the current checked out branch
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+PATCH=$(echo $TAG | cut -c 2- | cut -d "." -f 3)
 
 # Output in the desired format
-if [ $PATCH = 0 ]; then
-  if [ ! -z $FULL ]; then
-    printf '%s%d.%d.0' "$PREPEND" "$MAJOR" "$MINOR"
-  else
-    printf '%s%d.%d' "$PREPEND" "$MAJOR" "$MINOR"
-  fi
+if [ $((PATCH)) -eq 0 ]; then
+  printf '%s%d.%d' "$PREPEND" "$((MAJOR))" "$((MINOR))"
 else
-  printf '%s%d.%d.%d' "$PREPEND" "$MAJOR" "$MINOR" "$PATCH"
+  printf '%s%d.%d.%d' "$PREPEND" "$((MAJOR))" "$((MINOR))" "$((PATCH))"
 fi
 
-# Get the number of merges on the current branch since the last tag
-TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*\.[0-9]*" --first-parent master 2>/dev/null)
-BUILD=$(git rev-list $TAG.. --count)
-
 # Add the build tag on non-master branches
-if [ $BRANCH != "master" ]; then
-  if [ $BUILD != 0 ]; then
-    printf -- "-%04d" "$BUILD"
+if [ "$BRANCH" != "master" ]; then
+  BUILD=$(git rev-list $TAG..HEAD --count)
+
+  if [ $? == 0 ] && [ $((BUILD)) -gt 0 ]; then
+      printf -- "-%04d" "$((BUILD))"
   fi
 fi

--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -2,11 +2,20 @@
 
 # Get the last tag
 TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*\.[0-9]*" 2>/dev/null)
-(test $? != 0 || test -z "$TAG") && (echo "unknown"; exit 1)
+
+# Did getting the tag succeed?
+if [ $? != 0 ] || [ -z "$TAG" ]; then
+  printf "unknown"
+  exit 1
+fi
 
 # Get the current branch
 BRANCH=$(git symbolic-ref -q HEAD --short 2>/dev/null)
-(test $? != 0 || test -z "$BRANCH") && BRANCH="master"
+
+# Did getting the branch succeed?
+if [ $? != 0 ] || [ -z "$BRANCH" ]; then
+  BRANCH="master"
+fi
 
 # Split out into major, minor and patch numbers
 MAJOR=$(echo $TAG | cut -c 2- | cut -d "." -f 1)
@@ -22,10 +31,15 @@ fi
 
 # Add the build tag on non-master branches
 if [ "$BRANCH" != "master" ]; then
-  BUILD=$(git rev-list $TAG..HEAD --count)
-  if [ $? = 0 ] && [ -n "$BUILD" ]; then
-    if [ $((BUILD)) -gt 0 ]; then
-        printf -- "-%04d" "$((BUILD))"
-    fi
+  BUILD=$(git rev-list $TAG..HEAD --count 2>/dev/null)
+
+  # Did getting the count of commits since the tag succeed?
+  if [ $? != 0 ] && [ -z "$BUILD" ]; then
+    exit 1
+  fi
+
+  # Is the build greater than zero?
+  if [ $((BUILD)) -gt 0 ]; then
+      printf -- "-%04d" "$((BUILD))"
   fi
 fi

--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -5,7 +5,7 @@ TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*\.[0-9]*" 2>/dev/nu
 
 # Did getting the tag succeed?
 if [ $? != 0 ] || [ -z "$TAG" ]; then
-  printf "unknown"
+  printf -- "unknown"
   exit 1
 fi
 
@@ -34,7 +34,8 @@ if [ "$BRANCH" != "master" ]; then
   BUILD=$(git rev-list $TAG..HEAD --count 2>/dev/null)
 
   # Did getting the count of commits since the tag succeed?
-  if [ $? != 0 ] && [ -z "$BUILD" ]; then
+  if [ $? != 0 ] || [ -z "$BUILD" ]; then
+    printf -- "-unknown"
     exit 1
   fi
 

--- a/contrib/semver/version.sh
+++ b/contrib/semver/version.sh
@@ -2,11 +2,11 @@
 
 # Get the last tag
 TAG=$(git describe --abbrev=0 --tags --match="v[0-9]*\.[0-9]*\.[0-9]*" 2>/dev/null)
-test $? != 0 && (echo "unknown"; exit 1)
+(test $? != 0 || test -z "$TAG") && (echo "unknown"; exit 1)
 
 # Get the current branch
 BRANCH=$(git symbolic-ref -q HEAD --short 2>/dev/null)
-test $? != 0 && BRANCH="master"
+(test $? != 0 || test -z "$BRANCH") && BRANCH="master"
 
 # Split out into major, minor and patch numbers
 MAJOR=$(echo $TAG | cut -c 2- | cut -d "." -f 1)
@@ -23,8 +23,9 @@ fi
 # Add the build tag on non-master branches
 if [ "$BRANCH" != "master" ]; then
   BUILD=$(git rev-list $TAG..HEAD --count)
-
-  if [ $? == 0 ] && [ $((BUILD)) -gt 0 ]; then
-      printf -- "-%04d" "$((BUILD))"
+  if [ $? = 0 ] && [ -n "$BUILD" ]; then
+    if [ $((BUILD)) -gt 0 ]; then
+        printf -- "-%04d" "$((BUILD))"
+    fi
   fi
 fi


### PR DESCRIPTION
This does away with the automatic versioning based on merge commits. It's too painful, breaks with forks and often gets it wrong. It also checks results more thoroughly and reports `unknown` if the git history is not usable.

Versioning is now done entirely based on the most recent `v0.0.0` tag, and the `-0000` suffix is added for commits since that tag for non-`master` branches.

For a new release, the tag will need to be created by hand.