### PR TITLE
Use central NodeConfig for components

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
-	"time"
 
 	"golang.org/x/text/encoding/unicode"
 
@@ -243,27 +242,6 @@ func main() {
 	for _, pBoxStr := range cfg.AllowedEncryptionPublicKeys {
 		n.core.AddAllowedEncryptionPublicKey(pBoxStr)
 	}
-	// If any static peers were provided in the configuration above then we should
-	// configure them. The loop ensures that disconnected peers will eventually
-	// be reconnected with.
-	go func() {
-		if len(cfg.Peers) == 0 && len(cfg.InterfacePeers) == 0 {
-			return
-		}
-		for {
-			for _, peer := range cfg.Peers {
-				n.core.AddPeer(peer, "")
-				time.Sleep(time.Second)
-			}
-			for intf, intfpeers := range cfg.InterfacePeers {
-				for _, peer := range intfpeers {
-					n.core.AddPeer(peer, intf)
-					time.Sleep(time.Second)
-				}
-			}
-			time.Sleep(time.Minute)
-		}
-	}()
 	// The Stop function ensures that the TUN/TAP adapter is correctly shut down
 	// before the program exits.
 	defer func() {

--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"regexp"
 	"strings"
 	"syscall"
 
@@ -221,15 +220,6 @@ func main() {
 	// Setup the Yggdrasil node itself. The node{} type includes a Core, so we
 	// don't need to create this manually.
 	n := node{}
-	// Check to see if any multicast interface expressions were provided in the
-	// config. If they were then set them now.
-	for _, ll := range cfg.MulticastInterfaces {
-		ifceExpr, err := regexp.Compile(ll)
-		if err != nil {
-			panic(err)
-		}
-		n.core.AddMulticastInterfaceExpr(ifceExpr)
-	}
 	// Now that we have a working configuration, we can now actually start
 	// Yggdrasil. This will start the router, switch, DHT node, TCP and UDP
 	// sockets, TUN/TAP adapter and multicast discovery port.

--- a/src/yggdrasil/adapter.go
+++ b/src/yggdrasil/adapter.go
@@ -3,9 +3,10 @@ package yggdrasil
 // Defines the minimum required struct members for an adapter type (this is
 // now the base type for tunAdapter in tun.go)
 type Adapter struct {
-	core *Core
-	send chan<- []byte
-	recv <-chan []byte
+	core        *Core
+	send        chan<- []byte
+	recv        <-chan []byte
+	reconfigure chan chan error
 }
 
 // Initialises the adapter.
@@ -13,4 +14,5 @@ func (adapter *Adapter) init(core *Core, send chan<- []byte, recv <-chan []byte)
 	adapter.core = core
 	adapter.send = send
 	adapter.recv = recv
+	adapter.reconfigure = make(chan chan error, 1)
 }

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -352,7 +352,7 @@ func (a *admin) init(c *Core) {
 		if in["box_pub_key"] == nil && in["coords"] == nil {
 			var nodeinfo []byte
 			a.core.router.doAdmin(func() {
-				nodeinfo = []byte(a.core.nodeinfo.getNodeInfo())
+				nodeinfo = []byte(a.core.router.nodeinfo.getNodeInfo())
 			})
 			var jsoninfo interface{}
 			if err := json.Unmarshal(nodeinfo, &jsoninfo); err != nil {
@@ -864,7 +864,7 @@ func (a *admin) admin_getNodeInfo(keyString, coordString string, nocache bool) (
 		copy(key[:], keyBytes)
 	}
 	if !nocache {
-		if response, err := a.core.nodeinfo.getCachedNodeInfo(key); err == nil {
+		if response, err := a.core.router.nodeinfo.getCachedNodeInfo(key); err == nil {
 			return response, nil
 		}
 	}
@@ -882,14 +882,14 @@ func (a *admin) admin_getNodeInfo(keyString, coordString string, nocache bool) (
 	}
 	response := make(chan *nodeinfoPayload, 1)
 	sendNodeInfoRequest := func() {
-		a.core.nodeinfo.addCallback(key, func(nodeinfo *nodeinfoPayload) {
+		a.core.router.nodeinfo.addCallback(key, func(nodeinfo *nodeinfoPayload) {
 			defer func() { recover() }()
 			select {
 			case response <- nodeinfo:
 			default:
 			}
 		})
-		a.core.nodeinfo.sendNodeInfo(key, coords, false)
+		a.core.router.nodeinfo.sendNodeInfo(key, coords, false)
 	}
 	a.core.router.doAdmin(sendNodeInfoRequest)
 	go func() {

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -52,7 +52,7 @@ func (a *admin) addHandler(name string, args []string, handler func(admin_info) 
 }
 
 // init runs the initial admin setup.
-func (a *admin) init(c *Core, listenaddr string) {
+func (a *admin) init(c *Core) {
 	a.core = c
 	a.reconfigure = make(chan bool, 1)
 	go func() {
@@ -69,7 +69,9 @@ func (a *admin) init(c *Core, listenaddr string) {
 			}
 		}
 	}()
-	a.listenaddr = listenaddr
+	a.core.configMutex.RLock()
+	a.listenaddr = a.core.config.AdminListen
+	a.core.configMutex.RUnlock()
 	a.addHandler("list", []string{}, func(in admin_info) (admin_info, error) {
 		handlers := make(map[string]interface{})
 		for _, handler := range a.handlers {

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -57,17 +57,15 @@ func (a *admin) init(c *Core) {
 	a.reconfigure = make(chan chan error, 1)
 	go func() {
 		for {
-			select {
-			case e := <-a.reconfigure:
-				a.core.configMutex.RLock()
-				if a.core.config.AdminListen != a.core.configOld.AdminListen {
-					a.listenaddr = a.core.config.AdminListen
-					a.close()
-					a.start()
-				}
-				a.core.configMutex.RUnlock()
-				e <- nil
+			e := <-a.reconfigure
+			a.core.configMutex.RLock()
+			if a.core.config.AdminListen != a.core.configOld.AdminListen {
+				a.listenaddr = a.core.config.AdminListen
+				a.close()
+				a.start()
 			}
+			a.core.configMutex.RUnlock()
+			e <- nil
 		}
 	}()
 	a.core.configMutex.RLock()

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -61,7 +61,9 @@ func (a *admin) init(c *Core) {
 			case e := <-a.reconfigure:
 				a.core.configMutex.RLock()
 				if a.core.config.AdminListen != a.core.configOld.AdminListen {
-					a.core.log.Println("AdminListen has changed!")
+					a.listenaddr = a.core.config.AdminListen
+					a.close()
+					a.start()
 				}
 				a.core.configMutex.RUnlock()
 				e <- nil

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -350,7 +350,10 @@ func (a *admin) init(c *Core) {
 		}
 		var box_pub_key, coords string
 		if in["box_pub_key"] == nil && in["coords"] == nil {
-			nodeinfo := []byte(a.core.nodeinfo.getNodeInfo())
+			var nodeinfo []byte
+			a.core.router.doAdmin(func() {
+				nodeinfo = []byte(a.core.nodeinfo.getNodeInfo())
+			})
 			var jsoninfo interface{}
 			if err := json.Unmarshal(nodeinfo, &jsoninfo); err != nil {
 				return admin_info{}, err

--- a/src/yggdrasil/ckr.go
+++ b/src/yggdrasil/ckr.go
@@ -38,14 +38,12 @@ func (c *cryptokey) init(core *Core) {
 	c.reconfigure = make(chan chan error, 1)
 	go func() {
 		for {
-			select {
-			case e := <-c.reconfigure:
-				var err error
-				c.core.router.doAdmin(func() {
-					err = c.core.router.cryptokey.configure()
-				})
-				e <- err
-			}
+			e := <-c.reconfigure
+			var err error
+			c.core.router.doAdmin(func() {
+				err = c.core.router.cryptokey.configure()
+			})
+			e <- err
 		}
 	}()
 

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -141,6 +141,7 @@ func (c *Core) UpdateConfig(config *config.NodeConfig) {
 		c.peers.reconfigure,
 		c.router.reconfigure,
 		c.router.tun.reconfigure,
+		c.router.cryptokey.reconfigure,
 		c.switchTable.reconfigure,
 		c.tcp.reconfigure,
 		c.multicast.reconfigure,

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net"
-	"regexp"
 	"sync"
 	"time"
 
@@ -47,7 +46,6 @@ type Core struct {
 	tcp         tcpInterface
 	awdl        awdl
 	log         *log.Logger
-	ifceExpr    []*regexp.Regexp // the zone of link-local IPv6 peers must match this
 }
 
 func (c *Core) init() error {
@@ -311,13 +309,6 @@ func (c *Core) SetLogger(log *log.Logger) {
 // tcp://a.b.c.d:e, udp://a.b.c.d:e, socks://a.b.c.d:e/f.g.h.i:j
 func (c *Core) AddPeer(addr string, sintf string) error {
 	return c.admin.addPeer(addr, sintf)
-}
-
-// Adds an expression to select multicast interfaces for peer discovery. This
-// should be done before calling Start. This function can be called multiple
-// times to add multiple search expressions.
-func (c *Core) AddMulticastInterfaceExpr(expr *regexp.Regexp) {
-	c.ifceExpr = append(c.ifceExpr, expr)
 }
 
 // Adds an allowed public key. This allow peerings to be restricted only to

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -44,7 +44,6 @@ type Core struct {
 	admin       admin
 	searches    searches
 	multicast   multicast
-	nodeinfo    nodeinfo
 	tcp         tcpInterface
 	awdl        awdl
 	log         *log.Logger
@@ -83,7 +82,6 @@ func (c *Core) init() error {
 	copy(c.sigPriv[:], sigPrivHex)
 
 	c.admin.init(c)
-	c.nodeinfo.init(c)
 	c.searches.init(c)
 	c.dht.init(c)
 	c.sessions.init(c)
@@ -197,8 +195,6 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 
 	c.init()
 
-	c.nodeinfo.setNodeInfo(nc.NodeInfo, nc.NodeInfoPrivacy)
-
 	if err := c.tcp.init(c); err != nil {
 		c.log.Println("Failed to start TCP interface")
 		return err
@@ -297,12 +293,12 @@ func (c *Core) GetSubnet() *net.IPNet {
 
 // Gets the nodeinfo.
 func (c *Core) GetNodeInfo() nodeinfoPayload {
-	return c.nodeinfo.getNodeInfo()
+	return c.router.nodeinfo.getNodeInfo()
 }
 
 // Sets the nodeinfo.
 func (c *Core) SetNodeInfo(nodeinfo interface{}, nodeinfoprivacy bool) {
-	c.nodeinfo.setNodeInfo(nodeinfo, nodeinfoprivacy)
+	c.router.nodeinfo.setNodeInfo(nodeinfo, nodeinfoprivacy)
 }
 
 // Sets the output logger of the Yggdrasil node after startup. This may be

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -231,31 +231,6 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 		return err
 	}
 
-	c.router.cryptokey.setEnabled(nc.TunnelRouting.Enable)
-	if c.router.cryptokey.isEnabled() {
-		c.log.Println("Crypto-key routing enabled")
-		for ipv6, pubkey := range nc.TunnelRouting.IPv6Destinations {
-			if err := c.router.cryptokey.addRoute(ipv6, pubkey); err != nil {
-				panic(err)
-			}
-		}
-		for _, source := range nc.TunnelRouting.IPv6Sources {
-			if err := c.router.cryptokey.addSourceSubnet(source); err != nil {
-				panic(err)
-			}
-		}
-		for ipv4, pubkey := range nc.TunnelRouting.IPv4Destinations {
-			if err := c.router.cryptokey.addRoute(ipv4, pubkey); err != nil {
-				panic(err)
-			}
-		}
-		for _, source := range nc.TunnelRouting.IPv4Sources {
-			if err := c.router.cryptokey.addSourceSubnet(source); err != nil {
-				panic(err)
-			}
-		}
-	}
-
 	if err := c.admin.start(); err != nil {
 		c.log.Println("Failed to start admin socket")
 		return err

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -109,13 +109,14 @@ func (c *Core) UpdateConfig(config *config.NodeConfig) {
 
 	components := []chan chan error{
 		c.admin.reconfigure,
-		c.searches.reconfigure,
-		c.dht.reconfigure,
-		c.sessions.reconfigure,
+		//c.searches.reconfigure,
+		//c.dht.reconfigure,
+		//c.sessions.reconfigure,
+		//c.peers.reconfigure,
+		//c.router.reconfigure,
+		//c.switchTable.reconfigure,
+		c.tcp.reconfigure,
 		c.multicast.reconfigure,
-		c.peers.reconfigure,
-		c.router.reconfigure,
-		c.switchTable.reconfigure,
 	}
 
 	for _, component := range components {

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -2,7 +2,6 @@ package yggdrasil
 
 import (
 	"encoding/hex"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net"
@@ -110,12 +109,13 @@ func (c *Core) UpdateConfig(config *config.NodeConfig) {
 
 	components := []chan chan error{
 		c.admin.reconfigure,
-		//c.searches.reconfigure,
-		//c.dht.reconfigure,
-		//c.sessions.reconfigure,
-		//c.peers.reconfigure,
-		//c.router.reconfigure,
-		//c.switchTable.reconfigure,
+		c.searches.reconfigure,
+		c.dht.reconfigure,
+		c.sessions.reconfigure,
+		c.peers.reconfigure,
+		c.router.reconfigure,
+		c.router.tun.reconfigure,
+		c.switchTable.reconfigure,
 		c.tcp.reconfigure,
 		c.multicast.reconfigure,
 	}
@@ -240,8 +240,7 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 		return err
 	}
 
-	ip := net.IP(c.router.addr[:]).String()
-	if err := c.router.tun.start(nc.IfName, nc.IfTAPMode, fmt.Sprintf("%s/%d", ip, 8*len(address.GetPrefix())-1), nc.IfMTU); err != nil {
+	if err := c.router.tun.start(); err != nil {
 		c.log.Println("Failed to start TUN/TAP")
 		return err
 	}

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -517,7 +517,7 @@ func (c *Core) DEBUG_setLogger(log *log.Logger) {
 }
 
 func (c *Core) DEBUG_setIfceExpr(expr *regexp.Regexp) {
-	c.ifceExpr = append(c.ifceExpr, expr)
+	c.log.Println("DEBUG_setIfceExpr no longer implemented")
 }
 
 func (c *Core) DEBUG_addAllowedEncryptionPublicKey(boxStr string) {

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -16,6 +16,7 @@ import "fmt"
 import "net"
 import "log"
 import "regexp"
+import "encoding/hex"
 
 import _ "net/http/pprof"
 import "net/http"
@@ -23,6 +24,7 @@ import "runtime"
 import "os"
 
 import "github.com/yggdrasil-network/yggdrasil-go/src/address"
+import "github.com/yggdrasil-network/yggdrasil-go/src/config"
 import "github.com/yggdrasil-network/yggdrasil-go/src/crypto"
 import "github.com/yggdrasil-network/yggdrasil-go/src/defaults"
 
@@ -52,7 +54,17 @@ func StartProfiler(log *log.Logger) error {
 func (c *Core) Init() {
 	bpub, bpriv := crypto.NewBoxKeys()
 	spub, spriv := crypto.NewSigKeys()
-	c.init(bpub, bpriv, spub, spriv)
+	hbpub := hex.EncodeToString(bpub[:])
+	hbpriv := hex.EncodeToString(bpriv[:])
+	hspub := hex.EncodeToString(spub[:])
+	hspriv := hex.EncodeToString(spriv[:])
+	c.config = config.NodeConfig{
+		EncryptionPublicKey:  hbpub,
+		EncryptionPrivateKey: hbpriv,
+		SigningPublicKey:     hspub,
+		SigningPrivateKey:    hspriv,
+	}
+	c.init( /*bpub, bpriv, spub, spriv*/ )
 	c.switchTable.start()
 	c.router.start()
 }
@@ -350,7 +362,7 @@ func (c *Core) DEBUG_init(bpub []byte,
 	bpriv []byte,
 	spub []byte,
 	spriv []byte) {
-	var boxPub crypto.BoxPubKey
+	/*var boxPub crypto.BoxPubKey
 	var boxPriv crypto.BoxPrivKey
 	var sigPub crypto.SigPubKey
 	var sigPriv crypto.SigPrivKey
@@ -358,7 +370,18 @@ func (c *Core) DEBUG_init(bpub []byte,
 	copy(boxPriv[:], bpriv)
 	copy(sigPub[:], spub)
 	copy(sigPriv[:], spriv)
-	c.init(&boxPub, &boxPriv, &sigPub, &sigPriv)
+	c.init(&boxPub, &boxPriv, &sigPub, &sigPriv)*/
+	hbpub := hex.EncodeToString(bpub[:])
+	hbpriv := hex.EncodeToString(bpriv[:])
+	hspub := hex.EncodeToString(spub[:])
+	hspriv := hex.EncodeToString(spriv[:])
+	c.config = config.NodeConfig{
+		EncryptionPublicKey:  hbpub,
+		EncryptionPrivateKey: hbpriv,
+		SigningPublicKey:     hspub,
+		SigningPrivateKey:    hspriv,
+	}
+	c.init( /*bpub, bpriv, spub, spriv*/ )
 
 	if err := c.router.start(); err != nil {
 		panic(err)
@@ -427,7 +450,8 @@ func (c *Core) DEBUG_addSOCKSConn(socksaddr, peeraddr string) {
 
 //*
 func (c *Core) DEBUG_setupAndStartGlobalTCPInterface(addrport string) {
-	if err := c.tcp.init(c, addrport, 0); err != nil {
+	c.config.Listen = addrport
+	if err := c.tcp.init(c /*, addrport, 0*/); err != nil {
 		c.log.Println("Failed to start TCP interface:", err)
 		panic(err)
 	}
@@ -474,7 +498,8 @@ func (c *Core) DEBUG_addKCPConn(saddr string) {
 
 func (c *Core) DEBUG_setupAndStartAdminInterface(addrport string) {
 	a := admin{}
-	a.init(c, addrport)
+	c.config.AdminListen = addrport
+	a.init(c /*, addrport*/)
 	c.admin = a
 }
 

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -82,10 +82,8 @@ func (t *dht) init(c *Core) {
 	t.reconfigure = make(chan chan error, 1)
 	go func() {
 		for {
-			select {
-			case e := <-t.reconfigure:
-				e <- nil
-			}
+			e := <-t.reconfigure
+			e <- nil
 		}
 	}()
 	t.nodeID = *t.core.GetNodeID()

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -65,11 +65,12 @@ type dhtReqKey struct {
 
 // The main DHT struct.
 type dht struct {
-	core      *Core
-	nodeID    crypto.NodeID
-	peers     chan *dhtInfo                  // other goroutines put incoming dht updates here
-	reqs      map[dhtReqKey]time.Time        // Keeps track of recent outstanding requests
-	callbacks map[dhtReqKey]dht_callbackInfo // Search and admin lookup callbacks
+	core        *Core
+	reconfigure chan bool
+	nodeID      crypto.NodeID
+	peers       chan *dhtInfo                  // other goroutines put incoming dht updates here
+	reqs        map[dhtReqKey]time.Time        // Keeps track of recent outstanding requests
+	callbacks   map[dhtReqKey]dht_callbackInfo // Search and admin lookup callbacks
 	// These next two could be replaced by a single linked list or similar...
 	table map[crypto.NodeID]*dhtInfo
 	imp   []*dhtInfo
@@ -78,6 +79,18 @@ type dht struct {
 // Initializes the DHT.
 func (t *dht) init(c *Core) {
 	t.core = c
+	t.reconfigure = make(chan bool, 1)
+	go func() {
+		for {
+			select {
+			case _ = <-t.reconfigure:
+				t.core.configMutex.RLock()
+				t.core.log.Println("Notified: dht")
+				t.core.configMutex.RUnlock()
+				continue
+			}
+		}
+	}()
 	t.nodeID = *t.core.GetNodeID()
 	t.peers = make(chan *dhtInfo, 1024)
 	t.callbacks = make(map[dhtReqKey]dht_callbackInfo)

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -66,7 +66,7 @@ type dhtReqKey struct {
 // The main DHT struct.
 type dht struct {
 	core        *Core
-	reconfigure chan bool
+	reconfigure chan chan error
 	nodeID      crypto.NodeID
 	peers       chan *dhtInfo                  // other goroutines put incoming dht updates here
 	reqs        map[dhtReqKey]time.Time        // Keeps track of recent outstanding requests
@@ -79,15 +79,12 @@ type dht struct {
 // Initializes the DHT.
 func (t *dht) init(c *Core) {
 	t.core = c
-	t.reconfigure = make(chan bool, 1)
+	t.reconfigure = make(chan chan error, 1)
 	go func() {
 		for {
 			select {
-			case _ = <-t.reconfigure:
-				t.core.configMutex.RLock()
-				t.core.log.Println("Notified: dht")
-				t.core.configMutex.RUnlock()
-				continue
+			case e := <-t.reconfigure:
+				e <- nil
 			}
 		}
 	}()

--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -25,13 +25,11 @@ func (m *multicast) init(core *Core) {
 	m.reconfigure = make(chan chan error, 1)
 	go func() {
 		for {
-			select {
-			case e := <-m.reconfigure:
-				m.myAddrMutex.Lock()
-				m.myAddr = m.core.tcp.getAddr()
-				m.myAddrMutex.Unlock()
-				e <- nil
-			}
+			e := <-m.reconfigure
+			m.myAddrMutex.Lock()
+			m.myAddr = m.core.tcp.getAddr()
+			m.myAddrMutex.Unlock()
+			e <- nil
 		}
 	}()
 	m.groupAddr = "[ff02::114]:9001"

--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -11,22 +11,19 @@ import (
 
 type multicast struct {
 	core        *Core
-	reconfigure chan bool
+	reconfigure chan chan error
 	sock        *ipv6.PacketConn
 	groupAddr   string
 }
 
 func (m *multicast) init(core *Core) {
 	m.core = core
-	m.reconfigure = make(chan bool, 1)
+	m.reconfigure = make(chan chan error, 1)
 	go func() {
 		for {
 			select {
-			case _ = <-m.reconfigure:
-				m.core.configMutex.RLock()
-				m.core.log.Println("Notified: multicast")
-				m.core.configMutex.RUnlock()
-				continue
+			case e := <-m.reconfigure:
+				e <- nil
 			}
 		}
 	}()

--- a/src/yggdrasil/nodeinfo.go
+++ b/src/yggdrasil/nodeinfo.go
@@ -170,7 +170,7 @@ func (m *nodeinfo) sendNodeInfo(key crypto.BoxPubKey, coords []byte, isResponse 
 	nodeinfo := nodeinfoReqRes{
 		SendCoords: table.self.getCoords(),
 		IsResponse: isResponse,
-		NodeInfo:   m.core.nodeinfo.getNodeInfo(),
+		NodeInfo:   m.getNodeInfo(),
 	}
 	bs := nodeinfo.encode()
 	shared := m.core.sessions.getSharedKey(&m.core.boxPriv, &key)

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -19,6 +19,7 @@ import (
 // In other cases, it's link protocol traffic used to build the spanning tree, in which case this checks signatures and passes the message along to the switch.
 type peers struct {
 	core                        *Core
+	reconfigure                 chan bool
 	mutex                       sync.Mutex   // Synchronize writes to atomic
 	ports                       atomic.Value //map[switchPort]*peer, use CoW semantics
 	authMutex                   sync.RWMutex
@@ -31,6 +32,18 @@ func (ps *peers) init(c *Core) {
 	defer ps.mutex.Unlock()
 	ps.putPorts(make(map[switchPort]*peer))
 	ps.core = c
+	ps.reconfigure = make(chan bool, 1)
+	go func() {
+		for {
+			select {
+			case _ = <-ps.reconfigure:
+				ps.core.configMutex.RLock()
+				ps.core.log.Println("Notified: peers")
+				ps.core.configMutex.RUnlock()
+				continue
+			}
+		}
+	}()
 	ps.allowedEncryptionPublicKeys = make(map[crypto.BoxPubKey]struct{})
 }
 

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -35,10 +35,8 @@ func (ps *peers) init(c *Core) {
 	ps.reconfigure = make(chan chan error, 1)
 	go func() {
 		for {
-			select {
-			case e := <-ps.reconfigure:
-				e <- nil
-			}
+			e := <-ps.reconfigure
+			e <- nil
 		}
 	}()
 	ps.allowedEncryptionPublicKeys = make(map[crypto.BoxPubKey]struct{})

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -127,6 +127,14 @@ func (r *router) mainLoop() {
 		case f := <-r.admin:
 			f()
 		case e := <-r.reconfigure:
+			// Send reconfigure notification to cryptokey
+			response := make(chan error)
+			r.cryptokey.reconfigure <- response
+			if err := <-response; err != nil {
+				e <- err
+			}
+
+			// Anything else to do?
 			e <- nil
 		}
 	}

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -127,14 +127,6 @@ func (r *router) mainLoop() {
 		case f := <-r.admin:
 			f()
 		case e := <-r.reconfigure:
-			// Send reconfigure notification to cryptokey
-			response := make(chan error)
-			r.cryptokey.reconfigure <- response
-			if err := <-response; err != nil {
-				e <- err
-			}
-
-			// Anything else to do?
 			e <- nil
 		}
 	}

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -127,7 +127,9 @@ func (r *router) mainLoop() {
 		case f := <-r.admin:
 			f()
 		case e := <-r.reconfigure:
-			e <- nil
+			r.core.configMutex.RLock()
+			e <- r.core.nodeinfo.setNodeInfo(r.core.config.NodeInfo, r.core.config.NodeInfoPrivacy)
+			r.core.configMutex.RUnlock()
 		}
 	}
 }

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -43,22 +43,19 @@ type searchInfo struct {
 // This stores a map of active searches.
 type searches struct {
 	core        *Core
-	reconfigure chan bool
+	reconfigure chan chan error
 	searches    map[crypto.NodeID]*searchInfo
 }
 
 // Intializes the searches struct.
 func (s *searches) init(core *Core) {
 	s.core = core
-	s.reconfigure = make(chan bool, 1)
+	s.reconfigure = make(chan chan error, 1)
 	go func() {
 		for {
 			select {
-			case _ = <-s.reconfigure:
-				s.core.configMutex.RLock()
-				s.core.log.Println("Notified: searches")
-				s.core.configMutex.RUnlock()
-				continue
+			case e := <-s.reconfigure:
+				e <- nil
 			}
 		}
 	}()

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -53,10 +53,8 @@ func (s *searches) init(core *Core) {
 	s.reconfigure = make(chan chan error, 1)
 	go func() {
 		for {
-			select {
-			case e := <-s.reconfigure:
-				e <- nil
-			}
+			e := <-s.reconfigure
+			e <- nil
 		}
 	}()
 	s.searches = make(map[crypto.NodeID]*searchInfo)

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -18,7 +18,7 @@ import (
 // This includes coords, permanent and ephemeral keys, handles and nonces, various sorts of timing information for timeout and maintenance, and some metadata for the admin API.
 type sessionInfo struct {
 	core         *Core
-	reconfigure  chan bool
+	reconfigure  chan chan error
 	theirAddr    address.Address
 	theirSubnet  address.Subnet
 	theirPermPub crypto.BoxPubKey
@@ -102,7 +102,7 @@ func (s *sessionInfo) timedout() bool {
 // Additionally, stores maps of address/subnet onto keys, and keys onto handles.
 type sessions struct {
 	core        *Core
-	reconfigure chan bool
+	reconfigure chan chan error
 	lastCleanup time.Time
 	// Maps known permanent keys to their shared key, used by DHT a lot
 	permShared map[crypto.BoxPubKey]*crypto.BoxSharedKey
@@ -126,19 +126,23 @@ type sessions struct {
 // Initializes the session struct.
 func (ss *sessions) init(core *Core) {
 	ss.core = core
-	ss.reconfigure = make(chan bool, 1)
+	ss.reconfigure = make(chan chan error, 1)
 	go func() {
 		for {
 			select {
-			case newConfig := <-ss.reconfigure:
-				ss.core.configMutex.RLock()
-				ss.core.log.Println("Notified: sessions")
-				ss.core.configMutex.RUnlock()
-
-				for _, sinfo := range ss.sinfos {
-					sinfo.reconfigure <- newConfig
+			case e := <-ss.reconfigure:
+				responses := make(map[crypto.Handle]chan error)
+				for index, session := range ss.sinfos {
+					responses[index] = make(chan error)
+					session.reconfigure <- responses[index]
 				}
-				continue
+				for _, response := range responses {
+					if err := <-response; err != nil {
+						e <- err
+						continue
+					}
+				}
+				e <- nil
 			}
 		}
 	}()
@@ -289,7 +293,7 @@ func (ss *sessions) createSession(theirPermKey *crypto.BoxPubKey) *sessionInfo {
 	}
 	sinfo := sessionInfo{}
 	sinfo.core = ss.core
-	sinfo.reconfigure = make(chan bool, 1)
+	sinfo.reconfigure = make(chan chan error, 1)
 	sinfo.theirPermPub = *theirPermKey
 	pub, priv := crypto.NewBoxKeys()
 	sinfo.mySesPub = *pub
@@ -558,11 +562,8 @@ func (sinfo *sessionInfo) doWorker() {
 			} else {
 				return
 			}
-		case _ = <-sinfo.reconfigure:
-			sinfo.core.configMutex.RLock()
-			sinfo.core.log.Println("Notified: sessionInfo")
-			sinfo.core.configMutex.RUnlock()
-			continue
+		case e := <-sinfo.reconfigure:
+			e <- nil
 		}
 	}
 }

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -182,12 +182,12 @@ type switchTable struct {
 const SwitchQueueTotalMinSize = 4 * 1024 * 1024
 
 // Initializes the switchTable struct.
-func (t *switchTable) init(core *Core, key crypto.SigPubKey) {
+func (t *switchTable) init(core *Core) {
 	now := time.Now()
 	t.core = core
 	t.reconfigure = make(chan bool, 1)
-	t.key = key
-	locator := switchLocator{root: key, tstamp: now.Unix()}
+	t.key = t.core.sigPub
+	locator := switchLocator{root: t.key, tstamp: now.Unix()}
 	peers := make(map[switchPort]peerInfo)
 	t.data = switchData{locator: locator, peers: peers}
 	t.updater.Store(&sync.Once{})

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -186,7 +186,9 @@ func (t *switchTable) init(core *Core) {
 	now := time.Now()
 	t.core = core
 	t.reconfigure = make(chan bool, 1)
+	t.core.configMutex.RLock()
 	t.key = t.core.sigPub
+	t.core.configMutex.RUnlock()
 	locator := switchLocator{root: t.key, tstamp: now.Unix()}
 	peers := make(map[switchPort]peerInfo)
 	t.data = switchData{locator: locator, peers: peers}

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -90,18 +90,16 @@ func (iface *tcpInterface) init(core *Core) (err error) {
 	iface.reconfigure = make(chan chan error, 1)
 	go func() {
 		for {
-			select {
-			case e := <-iface.reconfigure:
-				iface.core.configMutex.RLock()
-				updated := iface.core.config.Listen != iface.core.configOld.Listen
-				iface.core.configMutex.RUnlock()
-				if updated {
-					iface.serv_stop <- true
-					iface.serv.Close()
-					e <- iface.listen()
-				} else {
-					e <- nil
-				}
+			e := <-iface.reconfigure
+			iface.core.configMutex.RLock()
+			updated := iface.core.config.Listen != iface.core.configOld.Listen
+			iface.core.configMutex.RUnlock()
+			if updated {
+				iface.serv_stop <- true
+				iface.serv.Close()
+				e <- iface.listen()
+			} else {
+				e <- nil
 			}
 		}
 	}()

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -140,6 +140,10 @@ func (iface *tcpInterface) listener() {
 	iface.core.log.Println("Listening for TCP on:", iface.serv.Addr().String())
 	for {
 		sock, err := iface.serv.Accept()
+		if err != nil {
+			iface.core.log.Println("Failed to accept connection:", err)
+			return
+		}
 		select {
 		case <-iface.serv_stop:
 			iface.core.log.Println("Stopping listener")

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -83,8 +83,10 @@ func (iface *tcpInterface) connectSOCKS(socksaddr, peeraddr string) {
 // Initializes the struct.
 func (iface *tcpInterface) init(core *Core) (err error) {
 	iface.core = core
+	iface.core.configMutex.RLock()
 	iface.tcp_addr = iface.core.config.Listen
 	iface.tcp_timeout = time.Duration(iface.core.config.ReadTimeout) * time.Millisecond
+	iface.core.configMutex.RUnlock()
 	if iface.tcp_timeout >= 0 && iface.tcp_timeout < default_tcp_timeout {
 		iface.tcp_timeout = default_tcp_timeout
 	}

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -40,6 +40,7 @@ type tcpInterface struct {
 	core        *Core
 	serv        net.Listener
 	tcp_timeout time.Duration
+	tcp_addr    string
 	mutex       sync.Mutex // Protecting the below
 	calls       map[string]struct{}
 	conns       map[tcpInfo](chan struct{})
@@ -80,15 +81,15 @@ func (iface *tcpInterface) connectSOCKS(socksaddr, peeraddr string) {
 }
 
 // Initializes the struct.
-func (iface *tcpInterface) init(core *Core, addr string, readTimeout int32) (err error) {
+func (iface *tcpInterface) init(core *Core) (err error) {
 	iface.core = core
-
-	iface.tcp_timeout = time.Duration(readTimeout) * time.Millisecond
+	iface.tcp_addr = iface.core.config.Listen
+	iface.tcp_timeout = time.Duration(iface.core.config.ReadTimeout) * time.Millisecond
 	if iface.tcp_timeout >= 0 && iface.tcp_timeout < default_tcp_timeout {
 		iface.tcp_timeout = default_tcp_timeout
 	}
 
-	iface.serv, err = net.Listen("tcp", addr)
+	iface.serv, err = net.Listen("tcp", iface.tcp_addr)
 	if err == nil {
 		iface.calls = make(map[string]struct{})
 		iface.conns = make(map[tcpInfo](chan struct{}))

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -53,8 +53,8 @@ type tcpInterface struct {
 type tcpInfo struct {
 	box        crypto.BoxPubKey
 	sig        crypto.SigPubKey
-	localAddr  string
 	remoteAddr string
+	remotePort string
 }
 
 // Wrapper function to set additional options for specific connection types.
@@ -313,8 +313,7 @@ func (iface *tcpInterface) handler(sock net.Conn, incoming bool) {
 		}
 	}
 	// Check if we already have a connection to this node, close and block if yes
-	info.localAddr, _, _ = net.SplitHostPort(sock.LocalAddr().String())
-	info.remoteAddr, _, _ = net.SplitHostPort(sock.RemoteAddr().String())
+	info.remoteAddr, info.remotePort, _ = net.SplitHostPort(sock.RemoteAddr().String())
 	iface.mutex.Lock()
 	if blockChan, isIn := iface.conns[info]; isIn {
 		iface.mutex.Unlock()

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -54,6 +54,7 @@ func (tun *tunAdapter) init(core *Core, send chan<- []byte, recv <-chan []byte) 
 					tun.core.config.IfMTU != tun.core.configOld.IfMTU
 				tun.core.configMutex.RUnlock()
 				if updated {
+					tun.core.log.Println("Reconfiguring TUN/TAP is not supported yet")
 					e <- nil
 				} else {
 					e <- nil

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -46,19 +46,17 @@ func (tun *tunAdapter) init(core *Core, send chan<- []byte, recv <-chan []byte) 
 	tun.icmpv6.init(tun)
 	go func() {
 		for {
-			select {
-			case e := <-tun.reconfigure:
-				tun.core.configMutex.RLock()
-				updated := tun.core.config.IfName != tun.core.configOld.IfName ||
-					tun.core.config.IfTAPMode != tun.core.configOld.IfTAPMode ||
-					tun.core.config.IfMTU != tun.core.configOld.IfMTU
-				tun.core.configMutex.RUnlock()
-				if updated {
-					tun.core.log.Println("Reconfiguring TUN/TAP is not supported yet")
-					e <- nil
-				} else {
-					e <- nil
-				}
+			e := <-tun.reconfigure
+			tun.core.configMutex.RLock()
+			updated := tun.core.config.IfName != tun.core.configOld.IfName ||
+				tun.core.config.IfTAPMode != tun.core.configOld.IfTAPMode ||
+				tun.core.config.IfMTU != tun.core.configOld.IfMTU
+			tun.core.configMutex.RUnlock()
+			if updated {
+				tun.core.log.Println("Reconfiguring TUN/TAP is not supported yet")
+				e <- nil
+			} else {
+				e <- nil
 			}
 		}
 	}()

--- a/src/yggdrasil/tun.go
+++ b/src/yggdrasil/tun.go
@@ -5,6 +5,8 @@ package yggdrasil
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -42,11 +44,34 @@ func getSupportedMTU(mtu int) int {
 func (tun *tunAdapter) init(core *Core, send chan<- []byte, recv <-chan []byte) {
 	tun.Adapter.init(core, send, recv)
 	tun.icmpv6.init(tun)
+	go func() {
+		for {
+			select {
+			case e := <-tun.reconfigure:
+				tun.core.configMutex.RLock()
+				updated := tun.core.config.IfName != tun.core.configOld.IfName ||
+					tun.core.config.IfTAPMode != tun.core.configOld.IfTAPMode ||
+					tun.core.config.IfMTU != tun.core.configOld.IfMTU
+				tun.core.configMutex.RUnlock()
+				if updated {
+					e <- nil
+				} else {
+					e <- nil
+				}
+			}
+		}
+	}()
 }
 
 // Starts the setup process for the TUN/TAP adapter, and if successful, starts
 // the read/write goroutines to handle packets on that interface.
-func (tun *tunAdapter) start(ifname string, iftapmode bool, addr string, mtu int) error {
+func (tun *tunAdapter) start() error {
+	tun.core.configMutex.RLock()
+	ifname := tun.core.config.IfName
+	iftapmode := tun.core.config.IfTAPMode
+	addr := fmt.Sprintf("%s/%d", net.IP(tun.core.router.addr[:]).String(), 8*len(address.GetPrefix())-1)
+	mtu := tun.core.config.IfMTU
+	tun.core.configMutex.RUnlock()
 	if ifname != "none" {
 		if err := tun.setup(ifname, iftapmode, addr, mtu); err != nil {
 			return err


### PR DESCRIPTION
This addresses #294 by updating the various `init` functions to use their `Core` reference to obtain the current node config. It also adds the ability to notify each component that the configuration has changed.