### PR TITLE
Further nodeconfig changes

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -227,11 +227,6 @@ func main() {
 		logger.Println("An error occurred during startup")
 		panic(err)
 	}
-	// Check to see if any allowed encryption keys were provided in the config.
-	// If they were then set them now.
-	for _, pBoxStr := range cfg.AllowedEncryptionPublicKeys {
-		n.core.AddAllowedEncryptionPublicKey(pBoxStr)
-	}
 	// The Stop function ensures that the TUN/TAP adapter is correctly shut down
 	// before the program exits.
 	defer func() {

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -765,35 +765,20 @@ func (a *admin) getData_getSessions() []admin_nodeInfo {
 
 // getAllowedEncryptionPublicKeys returns the public keys permitted for incoming peer connections.
 func (a *admin) getAllowedEncryptionPublicKeys() []string {
-	pubs := a.core.peers.getAllowedEncryptionPublicKeys()
-	var out []string
-	for _, pub := range pubs {
-		out = append(out, hex.EncodeToString(pub[:]))
-	}
-	return out
+	return a.core.peers.getAllowedEncryptionPublicKeys()
 }
 
 // addAllowedEncryptionPublicKey whitelists a key for incoming peer connections.
 func (a *admin) addAllowedEncryptionPublicKey(bstr string) (err error) {
-	boxBytes, err := hex.DecodeString(bstr)
-	if err == nil {
-		var box crypto.BoxPubKey
-		copy(box[:], boxBytes)
-		a.core.peers.addAllowedEncryptionPublicKey(&box)
-	}
-	return
+	a.core.peers.addAllowedEncryptionPublicKey(bstr)
+	return nil
 }
 
 // removeAllowedEncryptionPublicKey removes a key from the whitelist for incoming peer connections.
 // If none are set, an empty list permits all incoming connections.
 func (a *admin) removeAllowedEncryptionPublicKey(bstr string) (err error) {
-	boxBytes, err := hex.DecodeString(bstr)
-	if err == nil {
-		var box crypto.BoxPubKey
-		copy(box[:], boxBytes)
-		a.core.peers.removeAllowedEncryptionPublicKey(&box)
-	}
-	return
+	a.core.peers.removeAllowedEncryptionPublicKey(bstr)
+	return nil
 }
 
 // Send a DHT ping to the node with the provided key and coords, optionally looking up the specified target NodeID.

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -212,15 +212,6 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 		return err
 	}
 
-	c.sessions.setSessionFirewallState(nc.SessionFirewall.Enable)
-	c.sessions.setSessionFirewallDefaults(
-		nc.SessionFirewall.AllowFromDirect,
-		nc.SessionFirewall.AllowFromRemote,
-		nc.SessionFirewall.AlwaysAllowOutbound,
-	)
-	c.sessions.setSessionFirewallWhitelist(nc.SessionFirewall.WhitelistEncryptionPublicKeys)
-	c.sessions.setSessionFirewallBlacklist(nc.SessionFirewall.BlacklistEncryptionPublicKeys)
-
 	if err := c.router.start(); err != nil {
 		c.log.Println("Failed to start router")
 		return err


### PR DESCRIPTION
This adds support for handling `AllowedEncryptionPublicKeys` internally rather than in `cmd/yggdrasil/main.go`. 