### PR TITLE
make ansible key generator a tiny bit faster

### DIFF
--- a/contrib/ansible/genkeys.go
+++ b/contrib/ansible/genkeys.go
@@ -117,6 +117,8 @@ func bubbleUpTo(sets []keySet, num int) []keySet {
 			var tmp = sets[i]
 			sets[i] = sets[i + 1]
 			sets[i + 1] = tmp
+		} else {
+			break
 		}
 	}
 	return sets


### PR DESCRIPTION
Depending on what the parameters are, this is either not faster at all, or *a lot* faster. 
See this benchmark:
```
[jcgruenhage@desperate-nobel yggdrasil-go]$ hyperfine "./genkeysslow -hosts 5000 -tries 8000" "./genkeysfast -hosts 5000 -tries 8000"
Benchmark #1: ./genkeysslow -hosts 5000 -tries 8000
  Time (mean ± σ):      5.247 s ±  0.114 s    [User: 5.003 s, System: 0.184 s]
  Range (min … max):    5.157 s …  5.553 s    10 runs
 
Benchmark #2: ./genkeysfast -hosts 5000 -tries 8000
  Time (mean ± σ):      2.885 s ±  0.026 s    [User: 2.683 s, System: 0.167 s]
  Range (min … max):    2.855 s …  2.945 s    10 runs
 
Summary
  './genkeysfast -hosts 5000 -tries 8000' ran
    1.82 ± 0.04 times faster than './genkeysslow -hosts 5000 -tries 8000'

```