### PR TITLE
Fix a deadlock

### DIFF
--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -625,5 +625,8 @@ func (sinfo *sessionInfo) doRecv(p *wire_trafficPacket) {
 	sinfo.updateNonce(&p.Nonce)
 	sinfo.time = time.Now()
 	sinfo.bytesRecvd += uint64(len(bs))
-	sinfo.core.router.toRecv <- router_recvPacket{bs, sinfo}
+	select {
+	case sinfo.core.router.toRecv <- router_recvPacket{bs, sinfo}:
+	default: // avoid deadlocks, maybe do this somewhere else?...
+	}
 }


### PR DESCRIPTION
A deadlock managed to creep in at some point, where the crypto worker goroutine for a session could block waiting for the router to be free. This is a problem if the router is already waiting for the worker to be free, if it expects the worker to encrypt a packet or something.

I'm not 100% happy with this workaround, but I'd rather get a fix in now and come up with a better solution later. Specifically, I'd rather drop the packet *before* decrypting it, to not waste CPU cycles, but that will require splitting up the crypto worker to an encryption worker and a decryption worker, I think...