### PR TITLE
Idle link logic changes

### DIFF
--- a/src/util/util.go
+++ b/src/util/util.go
@@ -3,6 +3,7 @@ package util
 // These are misc. utility functions that didn't really fit anywhere else
 
 import "runtime"
+import "time"
 
 // A wrapper around runtime.Gosched() so it doesn't need to be imported elsewhere.
 func Yield() {
@@ -43,4 +44,15 @@ func PutBytes(bs []byte) {
 	case byteStore <- bs:
 	default:
 	}
+}
+
+// This is a workaround to go's broken timer implementation
+func TimerStop(t *time.Timer) bool {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+	return true
 }

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -97,9 +97,7 @@ func (c *Core) DEBUG_getPeers() *peers {
 }
 
 func (ps *peers) DEBUG_newPeer(box crypto.BoxPubKey, sig crypto.SigPubKey, link crypto.BoxSharedKey) *peer {
-	//in <-chan []byte,
-	//out chan<- []byte) *peer {
-	return ps.newPeer(&box, &sig, &link, "(simulator)") //, in, out)
+	return ps.newPeer(&box, &sig, &link, "(simulator)", nil)
 }
 
 /*

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -113,7 +113,7 @@ type peer struct {
 }
 
 // Creates a new peer with the specified box, sig, and linkShared keys, using the lowest unoccupied port number.
-func (ps *peers) newPeer(box *crypto.BoxPubKey, sig *crypto.SigPubKey, linkShared *crypto.BoxSharedKey, endpoint string) *peer {
+func (ps *peers) newPeer(box *crypto.BoxPubKey, sig *crypto.SigPubKey, linkShared *crypto.BoxSharedKey, endpoint string, closer func()) *peer {
 	now := time.Now()
 	p := peer{box: *box,
 		sig:        *sig,
@@ -123,6 +123,7 @@ func (ps *peers) newPeer(box *crypto.BoxPubKey, sig *crypto.SigPubKey, linkShare
 		firstSeen:  now,
 		doSend:     make(chan struct{}, 1),
 		dinfo:      make(chan *dhtInfo, 1),
+		close:      closer,
 		core:       ps.core}
 	ps.mutex.Lock()
 	defer ps.mutex.Unlock()

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -67,7 +67,7 @@ func (r *router) init(core *Core) {
 	r.addr = *address.AddrForNodeID(&r.core.dht.nodeID)
 	r.subnet = *address.SubnetForNodeID(&r.core.dht.nodeID)
 	in := make(chan []byte, 32) // TODO something better than this...
-	p := r.core.peers.newPeer(&r.core.boxPub, &r.core.sigPub, &crypto.BoxSharedKey{}, "(self)")
+	p := r.core.peers.newPeer(&r.core.boxPub, &r.core.sigPub, &crypto.BoxSharedKey{}, "(self)", nil)
 	p.out = func(packet []byte) {
 		// This is to make very sure it never blocks
 		select {

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -281,6 +281,7 @@ func (t *switchTable) cleanPeers() {
 		if now.Sub(peer.time) > switch_timeout+switch_throttle {
 			// Longer than switch_timeout to make sure we don't remove a working peer because the root stopped responding.
 			delete(t.data.peers, port)
+			go t.core.peers.removePeer(port) // TODO figure out if it's safe to do this without a goroutine, or make it safe
 		}
 	}
 	if _, isIn := t.data.peers[t.parent]; !isIn {


### PR DESCRIPTION
The current behavior in `master` and `develop` is to send keep-alive traffic every 4 seconds, and to time out after 6+ seconds (user configurable).

Currently, `link` doesn't time out the connection. Instead, after 6 seconds of inactivity, it stops adding that link to the switch after it sends a packet. That prevents the actual connection from stopping, which gives things more time to recover in light of things like TCP exponential backoff.

This patch changes two things in link:
1. When we receive a packet (with size > 0), we start a timer. If we send a packet back, we cancel the timer. If the timer fires, it means we're idle, and we send a 0-sized keep-alive packet back. This timer is currently hard-coded at 1 second.
2. When we send a packet (with size > 0, so not a keep-alive / ack), we start a timer. If we receive a packet from the other node, we cancel the timer. If the timer fires, we stop re-inserting the node into the switch after sending packets to it. So basically, we assume they're OK unless they're idle *and we were expecting a response of some kind*. This timeout is currently hard coded at 6 second.

Things to do:
1. We should still add some kind of hard timeout, after which we close the connection. I'm not sure if this should happen in `link.go`, or if each transport should be responsible for it. If it's in `link.go`, then we could start a longer read timer and call `intf.msgIO.close()` if it fires. If we want the transports to be responsible, then we could do something like call [TCPConn.SetKeepAlive(true)](https://golang.org/pkg/net/#TCPConn.SetKeepAlive) and give it a duration of maybe a couple of minutes (longer than time time it takes the switch to give up internally and remove them from the table).
2. We should either remove `ReadTimeout` or use `ReadTimeout` for something. This could maybe be the timeout mentioned above, or instead of the hard-coded 6-second timeout for adding links back into the switch.
3. This `needs testing` to make sure that it will really work after we remove the current 4-second keep-alive traffic. That means commenting out the `send(nil)` "legacy" case and checking that two nodes don't remove eachother from their switches, and come up with some kind of useful benchmarks to run. The idea being that we would remove this behavior in v0.4.0 or later, after existing nodes have had plenty of time to upgrade. This technically only needs to happen before v0.4.0, but I figure testing it before we merge into `master` (or even `develop`) is a good idea, so I'll try to get to that soon (unless @neilalexander beats me to it--I honestly don't know what good tests would be, other than connecting 2 nodes and generally seeing that things work). I don't think it's worth delaying a merge into `link`, but if it's not too inconvenient to wait, then it makes sense to test it first.