### PR TITLE
Fail build script if building of any target fails

### DIFF
--- a/build
+++ b/build
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -ef
+
 PKGSRC=${PKGSRC:-github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil}
 PKGNAME=${PKGNAME:-$(sh contrib/semver/name.sh)}
 PKGVER=${PKGVER:-$(sh contrib/semver/version.sh --bare)}


### PR DESCRIPTION
E.g, I had a build error of yggdrasil, but ./build returned exit code 0:

+ ./build -t -l -linkmode=external
Building: yggdrasil
github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil
/home/user/go/src/github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil/multicast.go:39:9: undefined: net.ListenConfig
Building: yggdrasilctl
+ exit 0