### PR TITLE
Fix allocations found in profiling

### DIFF
--- a/misc/run-schannel-netns
+++ b/misc/run-schannel-netns
@@ -51,12 +51,12 @@ ip netns exec node4 ip link set lo up
 ip netns exec node5 ip link set lo up
 ip netns exec node6 ip link set lo up
 
-ip netns exec node1 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
-ip netns exec node2 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
-ip netns exec node3 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
-ip netns exec node4 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
-ip netns exec node5 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
-ip netns exec node6 env PPROFLISTEN=localhost:6060 ./run --autoconf &> /dev/null &
+echo '{AdminListen: "none"}' | ip netns exec node1 env PPROFLISTEN=localhost:6060 ./yggdrasil --useconf &> /dev/null &
+echo '{AdminListen: "none"}' | ip netns exec node2 env PPROFLISTEN=localhost:6060 ./yggdrasil --useconf &> /dev/null &
+echo '{AdminListen: "none"}' | ip netns exec node3 env PPROFLISTEN=localhost:6060 ./yggdrasil --useconf &> /dev/null &
+echo '{AdminListen: "none"}' | ip netns exec node4 env PPROFLISTEN=localhost:6060 ./yggdrasil --useconf &> /dev/null &
+echo '{AdminListen: "none"}' | ip netns exec node5 env PPROFLISTEN=localhost:6060 ./yggdrasil --useconf &> /dev/null &
+echo '{AdminListen: "none"}' | ip netns exec node6 env PPROFLISTEN=localhost:6060 ./yggdrasil --useconf &> /dev/null &
 
 echo "Started, to continue you should (possibly w/ sudo):"
 echo "kill" $(jobs -p)

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -388,7 +388,11 @@ func (a *admin) start() error {
 
 // cleans up when stopping
 func (a *admin) close() error {
-	return a.listener.Close()
+	if a.listener != nil {
+		return a.listener.Close()
+	} else {
+		return nil
+	}
 }
 
 // listen is run by start and manages API connections.


### PR DESCRIPTION
3 things:
1. Fix the netns test script (disable admin socket, we don't need it for that test).
2. Fix a nil pointer deref when shutting down if using `"none"` for the admin socket.
3. Remove some unwanted memory allocations that were found by running iperf3 benchmarks between instances running in different netns (particularly allocations that affect intermediate switch nodes).