### PR TITLE
fix bug in switch time

### DIFF
--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -415,6 +415,7 @@ func (t *switchTable) unlockedHandleMsg(msg *switchMsg, fromPort switchPort, rep
 	// Update the matrix of peer "faster" thresholds
 	if reprocessing {
 		sender.faster = oldSender.faster
+		sender.time = oldSender.time
 	} else {
 		sender.faster = make(map[switchPort]uint64, len(oldSender.faster))
 		for port, peer := range t.data.peers {


### PR DESCRIPTION
If time isn't kept set at the old value when reprocessing existing messages, then it keeps things alive (but in a state where the root is timed out), which seems to break things when leaving hibernate or when the connection between two nodes stops working but never gets closed for some reason.