### PR TITLE
Switch improvements(?)

### DIFF
--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -6,13 +6,15 @@ import "os"
 import "strings"
 import "strconv"
 import "time"
-import "log"
 
 import "runtime"
 import "runtime/pprof"
 import "flag"
 
+import "github.com/gologme/log"
+
 import . "github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil"
+import . "github.com/yggdrasil-network/yggdrasil-go/src/crypto"
 
 ////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Reworks the switch logic.

Previously, if there was more than one node equally close to the destination, then it would break ties arbitrarily by preferring to forward to whichever node it looked at first (random, due to random go map iteration order).

Now, if two nodes are equally close, then prefer to the one with shorter `coords`, as this should tend to favor approaching from the parent side of a node rather than via one of their children. Since nodes select their parents, but not their children, this should (hopefully) give more consistent behavior. If two nodes are *also* have equal length `coords`, then break ties consistently based on whichever peer has the lowest port number.

Technically, we could forward to *any* node that's closer to the destination than we are, not necessarily the one that's closest by the tree metric, so there's some flexibility in how we do this. The approach here should avoid breaking anything that isn't always broken, I think, but it would still forward via a descendant if we know a shortcut that results in fewer total hops at the switch level. I'm not sure what the correct behavior is in that case (we don't want to accidentally trick it into always routing by the tree, otherwise a lot of things will break down).

Still to do: test on nodes with many peers, see if it makes sense to relax the forwarding rules any more than we already have.