### PR TITLE
Remove ReadTimeout configuration option

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -77,6 +77,7 @@ func readConfig(useconf *bool, useconffile *string, normaliseconf *bool) *nodeCo
 	// names have changed recently.
 	changes := map[string]string{
 		"Multicast":      "",
+		"ReadTimeout":    "",
 		"LinkLocal":      "MulticastInterfaces",
 		"BoxPub":         "EncryptionPublicKey",
 		"BoxPriv":        "EncryptionPrivateKey",
@@ -89,11 +90,11 @@ func readConfig(useconf *bool, useconffile *string, normaliseconf *bool) *nodeCo
 		if _, ok := dat[from]; ok {
 			if to == "" {
 				if !*normaliseconf {
-					log.Println("Warning: Deprecated config option", from, "- please remove")
+					log.Println("Warning: Config option", from, "is deprecated")
 				}
 			} else {
 				if !*normaliseconf {
-					log.Println("Warning: Deprecated config option", from, "- please rename to", to)
+					log.Println("Warning: Config option", from, "has been renamed - please change to", to)
 				}
 				// If the configuration file doesn't already contain a line with the
 				// new name then set it to the old value. This makes sure that we

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -16,7 +16,6 @@ type NodeConfig struct {
 	AdminListen                 string                 `comment:"Listen address for admin connections. Default is to listen for local\nconnections either on TCP/9001 or a UNIX socket depending on your\nplatform. Use this value for yggdrasilctl -endpoint=X. To disable\nthe admin socket, use the value \"none\" instead."`
 	Peers                       []string               `comment:"List of connection strings for static peers in URI format, e.g.\ntcp://a.b.c.d:e or socks://a.b.c.d:e/f.g.h.i:j."`
 	InterfacePeers              map[string][]string    `comment:"List of connection strings for static peers in URI format, arranged\nby source interface, e.g. { \"eth0\": [ tcp://a.b.c.d:e ] }. Note that\nSOCKS peerings will NOT be affected by this option and should go in\nthe \"Peers\" section instead."`
-	ReadTimeout                 int32                  `comment:"Read timeout for connections, specified in milliseconds. If less\nthan 6000 and not negative, 6000 (the default) is used. If negative,\nreads won't time out."`
 	AllowedEncryptionPublicKeys []string               `comment:"List of peer encryption public keys to allow or incoming TCP\nconnections from. If left empty/undefined then all connections\nwill be allowed by default."`
 	EncryptionPublicKey         string                 `comment:"Your public encryption key. Your peers may ask you for this to put\ninto their AllowedEncryptionPublicKeys configuration."`
 	EncryptionPrivateKey        string                 `comment:"Your private encryption key. DO NOT share this with anyone!"`

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -36,7 +36,6 @@ type tcpInterface struct {
 	reconfigure chan chan error
 	serv        net.Listener
 	stop        chan bool
-	timeout     time.Duration
 	addr        string
 	mutex       sync.Mutex // Protecting the below
 	calls       map[string]struct{}
@@ -106,12 +105,7 @@ func (iface *tcpInterface) listen() error {
 
 	iface.core.configMutex.RLock()
 	iface.addr = iface.core.config.Listen
-	iface.timeout = time.Duration(iface.core.config.ReadTimeout) * time.Millisecond
 	iface.core.configMutex.RUnlock()
-
-	if iface.timeout >= 0 && iface.timeout < default_timeout {
-		iface.timeout = default_timeout
-	}
 
 	ctx := context.Background()
 	lc := net.ListenConfig{


### PR DESCRIPTION
This removes the `ReadTimeout` configuration option as it is no longer relevant following recent switch changes in #322.

This PR also will:

1. Remove the `ReadTimeout` option from the configuration during `-normaliseconf` (which happens automatically during upgrade on some platforms like macOS and Debian)
1. Warn the user in `stdout` that the option has been deprecated if it hasn't been removed from the config by normalisation