### PR TITLE
Bugfix

### DIFF
--- a/misc/run-twolink-test
+++ b/misc/run-twolink-test
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Connects nodes in two namespaces by two links with different bandwidth (10mbit and 100mbit)
+
+ip netns add node1
+ip netns add node2
+
+ip link add veth11 type veth peer name veth21
+ip link set veth11 netns node1 up
+ip link set veth21 netns node2 up
+
+ip link add veth12 type veth peer name veth22
+ip link set veth12 netns node1 up
+ip link set veth22 netns node2 up
+
+ip netns exec node1 tc qdisc add dev veth11 root tbf rate 10mbit burst 8192 latency 1ms
+ip netns exec node2 tc qdisc add dev veth21 root tbf rate 10mbit burst 8192 latency 1ms
+
+ip netns exec node1 tc qdisc add dev veth12 root tbf rate 100mbit burst 8192 latency 1ms
+ip netns exec node2 tc qdisc add dev veth22 root tbf rate 100mbit burst 8192 latency 1ms
+
+echo '{AdminListen: "unix://node1.sock"}' | ip netns exec node1 env PPROFLISTEN=localhost:6060 ./yggdrasil -logging "info,warn,error,debug" -useconf &> node1.log &
+echo '{AdminListen: "unix://node2.sock"}' | ip netns exec node2 env PPROFLISTEN=localhost:6060 ./yggdrasil -logging "info,warn,error,debug" -useconf &> node2.log &
+
+echo "Started, to continue you should (possibly w/ sudo):"
+echo "kill" $(jobs -p)
+wait
+
+ip netns delete node1
+ip netns delete node2
+
+ip link delete veth11
+ip link delete veth12

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -780,6 +780,7 @@ func (t *switchTable) doWorker() {
 	t.queues.bufs = make(map[string]switch_buffer) // Packets per PacketStreamID (string)
 	idle := make(map[switchPort]struct{})          // this is to deduplicate things
 	for {
+		t.core.log.Debugf("Switch state: idle = %d, buffers = %d", len(idle), len(t.queues.bufs))
 		select {
 		case bytes := <-t.packetIn:
 			// Try to send it somewhere (or drop it if it's corrupt or at a dead end)


### PR DESCRIPTION
Work in progress to check for an fix any bugs I can find in `develop`, before we merge to master.

Bugs found so far:
1. When connected to the same network by more than one interface, you'll end up with redundant connections to yourself. I don't think this is actually that harmful, it's just ugly, and it uses a little idle bandwidth to send some protocol traffic between those links.
2. There were some issues with the ugly state machine that exists in `link.go` and `switch.go`, which makes sure that unresponsive links aren't used by the switch to forward traffic. Due to some bugs, it was possible for the `link.go` side to remove a link from the switch and never re-insert it when the link comes back online. I'm not 100% sure I've really fixed this, but I'm no longer able to reproduce the issue in my tests (and by eye, some things are more symmetric now, which is usually a good sign). Some `debug` logging lines were added during this fix, which can be removed later if/when we're happy that things work as intended.