### PR TITLE
Fixes

### DIFF
--- a/misc/sim/treesim.go
+++ b/misc/sim/treesim.go
@@ -6,13 +6,15 @@ import "os"
 import "strings"
 import "strconv"
 import "time"
-import "log"
 
 import "runtime"
 import "runtime/pprof"
 import "flag"
 
+import "github.com/gologme/log"
+
 import . "github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil"
+import . "github.com/yggdrasil-network/yggdrasil-go/src/crypto"
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -56,3 +56,23 @@ func TimerStop(t *time.Timer) bool {
 	}
 	return true
 }
+
+// Run a blocking function with a timeout.
+// Returns true if the function returns.
+// Returns false if the timer fires.
+// The blocked function remains blocked--the caller is responsible for somehow killing it.
+func FuncTimeout(f func(), timeout time.Duration) bool {
+	success := make(chan struct{})
+	go func() {
+		defer close(success)
+		f()
+	}()
+	timer := time.NewTimer(timeout)
+	defer TimerStop(timer)
+	select {
+	case <-success:
+		return true
+	case <-timer.C:
+		return false
+	}
+}

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -116,7 +116,7 @@ func (intf *linkInterface) handler() error {
 	}
 	// Check if we're authorized to connect to this key / IP
 	if !intf.incoming && !intf.force && !intf.link.core.peers.isAllowedEncryptionPublicKey(&meta.box) {
-		intf.link.core.log.Debugf("%s connection to %s forbidden: AllowedEncryptionPublicKeys does not contain key %s",
+		intf.link.core.log.Warnf("%s connection to %s forbidden: AllowedEncryptionPublicKeys does not contain key %s",
 			strings.ToUpper(intf.info.linkType), intf.info.remote, hex.EncodeToString(meta.box[:]))
 		intf.msgIO.close()
 		return nil

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -216,8 +216,8 @@ func (intf *linkInterface) handler() error {
 				case signalReady <- struct{}{}:
 				default:
 				}
-				intf.link.core.log.Debugf("Sending packet to %s: %s, source %s",
-					strings.ToUpper(intf.info.linkType), themString, intf.info.local)
+				//intf.link.core.log.Debugf("Sending packet to %s: %s, source %s",
+				//	strings.ToUpper(intf.info.linkType), themString, intf.info.local)
 			}
 		}
 	}()
@@ -237,9 +237,9 @@ func (intf *linkInterface) handler() error {
 		recvTimer := time.NewTimer(recvTime)
 		defer util.TimerStop(recvTimer)
 		for {
-			intf.link.core.log.Debugf("State of %s: %s, source %s :: isAlive %t isReady %t sendTimerRunning %t recvTimerRunning %t",
-				strings.ToUpper(intf.info.linkType), themString, intf.info.local,
-				isAlive, isReady, sendTimerRunning, recvTimerRunning)
+			//intf.link.core.log.Debugf("State of %s: %s, source %s :: isAlive %t isReady %t sendTimerRunning %t recvTimerRunning %t",
+			//	strings.ToUpper(intf.info.linkType), themString, intf.info.local,
+			//	isAlive, isReady, sendTimerRunning, recvTimerRunning)
 			select {
 			case gotMsg, ok := <-signalAlive:
 				if !ok {

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -66,7 +66,7 @@ func (r *router) init(core *Core) {
 	r.reconfigure = make(chan chan error, 1)
 	r.addr = *address.AddrForNodeID(&r.core.dht.nodeID)
 	r.subnet = *address.SubnetForNodeID(&r.core.dht.nodeID)
-	in := make(chan []byte, 32) // TODO something better than this...
+	in := make(chan []byte, 1) // TODO something better than this...
 	p := r.core.peers.newPeer(&r.core.boxPub, &r.core.sigPub, &crypto.BoxSharedKey{}, "(self)", nil)
 	p.out = func(packet []byte) { in <- packet }
 	r.in = in
@@ -322,9 +322,6 @@ func (r *router) sendPacket(bs []byte) {
 			// Don't continue - drop the packet
 			return
 		}
-
-		sinfo.doSend(bs)
-		return
 		sinfo.send <- bs
 	}
 }
@@ -404,8 +401,6 @@ func (r *router) handleTraffic(packet []byte) {
 	if !isIn {
 		return
 	}
-	sinfo.doRecv(&p)
-	return
 	sinfo.recv <- &p
 }
 

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -304,7 +304,7 @@ func (ss *sessions) createSession(theirPermKey *crypto.BoxPubKey) *sessionInfo {
 	sinfo.theirSubnet = *address.SubnetForNodeID(crypto.GetNodeID(&sinfo.theirPermPub))
 	sinfo.send = make(chan []byte, 32)
 	sinfo.recv = make(chan *wire_trafficPacket, 32)
-	go sinfo.doWorker()
+	//go sinfo.doWorker()
 	ss.sinfos[sinfo.myHandle] = &sinfo
 	ss.byMySes[sinfo.mySesPub] = &sinfo.myHandle
 	ss.byTheirPerm[sinfo.theirPermPub] = &sinfo.myHandle
@@ -625,6 +625,8 @@ func (sinfo *sessionInfo) doRecv(p *wire_trafficPacket) {
 	sinfo.updateNonce(&p.Nonce)
 	sinfo.time = time.Now()
 	sinfo.bytesRecvd += uint64(len(bs))
+	sinfo.core.router.recvPacket(bs, sinfo)
+	return
 	select {
 	case sinfo.core.router.toRecv <- router_recvPacket{bs, sinfo}:
 	default: // avoid deadlocks, maybe do this somewhere else?...

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -304,7 +304,7 @@ func (ss *sessions) createSession(theirPermKey *crypto.BoxPubKey) *sessionInfo {
 	sinfo.theirSubnet = *address.SubnetForNodeID(crypto.GetNodeID(&sinfo.theirPermPub))
 	sinfo.send = make(chan []byte, 32)
 	sinfo.recv = make(chan *wire_trafficPacket, 32)
-	//go sinfo.doWorker()
+	go sinfo.doWorker()
 	ss.sinfos[sinfo.myHandle] = &sinfo
 	ss.byMySes[sinfo.mySesPub] = &sinfo.myHandle
 	ss.byTheirPerm[sinfo.theirPermPub] = &sinfo.myHandle
@@ -525,17 +525,36 @@ func (ss *sessions) resetInits() {
 // It handles calling the relatively expensive crypto operations.
 // It's also responsible for checking nonces and dropping out-of-date/duplicate packets, or else calling the function to update nonces if the packet is OK.
 func (sinfo *sessionInfo) doWorker() {
+	send := make(chan []byte, 32)
+	defer close(send)
+	go func() {
+		for bs := range send {
+			sinfo.doSend(bs)
+		}
+	}()
+	recv := make(chan *wire_trafficPacket, 32)
+	defer close(recv)
+	go func() {
+		for p := range recv {
+			sinfo.doRecv(p)
+		}
+	}()
 	for {
 		select {
 		case p, ok := <-sinfo.recv:
 			if ok {
-				sinfo.doRecv(p)
+				select {
+				case recv <- p:
+				default:
+					// We need something to not block, and it's best to drop it before we decrypt
+					util.PutBytes(p.Payload)
+				}
 			} else {
 				return
 			}
 		case bs, ok := <-sinfo.send:
 			if ok {
-				sinfo.doSend(bs)
+				send <- bs
 			} else {
 				return
 			}
@@ -625,10 +644,5 @@ func (sinfo *sessionInfo) doRecv(p *wire_trafficPacket) {
 	sinfo.updateNonce(&p.Nonce)
 	sinfo.time = time.Now()
 	sinfo.bytesRecvd += uint64(len(bs))
-	sinfo.core.router.recvPacket(bs, sinfo)
-	return
-	select {
-	case sinfo.core.router.toRecv <- router_recvPacket{bs, sinfo}:
-	default: // avoid deadlocks, maybe do this somewhere else?...
-	}
+	sinfo.core.router.toRecv <- router_recvPacket{bs, sinfo}
 }

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -570,23 +570,23 @@ func (t *switchTable) start() error {
 	return nil
 }
 
-// Check if a packet should go to the self node
-// This means there's no node closer to the destination than us
-// This is mainly used to identify packets addressed to us, or that hit a blackhole
-func (t *switchTable) selfIsClosest(dest []byte) bool {
+// Return a map of ports onto distance, keeping only ports closer to the destination than this node
+// If the map is empty (or nil), then no peer is closer
+func (t *switchTable) getCloser(dest []byte) map[switchPort]int {
 	table := t.getTable()
 	myDist := table.self.dist(dest)
 	if myDist == 0 {
 		// Skip the iteration step if it's impossible to be closer
-		return true
+		return nil
 	}
+	closer := make(map[switchPort]int, len(table.elems))
 	for _, info := range table.elems {
 		dist := info.locator.dist(dest)
 		if dist < myDist {
-			return false
+			closer[info.port] = dist
 		}
 	}
-	return true
+	return closer
 }
 
 // Returns true if the peer is closer to the destination than ourself
@@ -640,25 +640,45 @@ func (t *switchTable) bestPortForCoords(coords []byte) switchPort {
 func (t *switchTable) handleIn(packet []byte, idle map[switchPort]struct{}) bool {
 	coords := switch_getPacketCoords(packet)
 	ports := t.core.peers.getPorts()
-	if t.selfIsClosest(coords) {
+	closer := t.getCloser(coords)
+	if len(closer) == 0 {
 		// TODO? call the router directly, and remove the whole concept of a self peer?
 		ports[0].sendPacket(packet)
 		return true
 	}
 	table := t.getTable()
-	myDist := table.self.dist(coords)
 	var best *peer
-	bestDist := myDist
-	for port := range idle {
-		if to := ports[port]; to != nil {
-			if info, isIn := table.elems[to.port]; isIn {
-				dist := info.locator.dist(coords)
-				if !(dist < bestDist) {
-					continue
-				}
-				best = to
-				bestDist = dist
-			}
+	var bestDist int
+	var bestCoordLen int
+	for port, dist := range closer {
+		to := ports[port]
+		_, isIdle := idle[port]
+		coordLen := len(table.elems[port].locator.coords)
+		var update bool
+		switch {
+		case to == nil:
+			//nothing
+		case !isIdle:
+			//nothing
+		case best == nil:
+			update = true
+		case dist < bestDist:
+			update = true
+		case dist > bestDist:
+			//nothing
+		case coordLen < bestCoordLen:
+			update = true
+		case coordLen > bestCoordLen:
+			//nothing
+		case port < best.port:
+			update = true
+		default:
+			//nothing
+		}
+		if update {
+			best = to
+			bestDist = dist
+			bestCoordLen = coordLen
 		}
 	}
 	if best != nil {
@@ -697,7 +717,7 @@ func (b *switch_buffers) cleanup(t *switchTable) {
 		// Remove queues for which we have no next hop
 		packet := buf.packets[0]
 		coords := switch_getPacketCoords(packet.bytes)
-		if t.selfIsClosest(coords) {
+		if len(t.getCloser(coords)) == 0 {
 			for _, packet := range buf.packets {
 				util.PutBytes(packet.bytes)
 			}

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -668,10 +668,12 @@ func (t *switchTable) handleIn(packet []byte, idle map[switchPort]struct{}) bool
 			//nothing
 		case coordLen < bestCoordLen:
 			update = true
-		case coordLen > bestCoordLen:
-			//nothing
-		case port < best.port:
-			update = true
+			/*
+				case coordLen > bestCoordLen:
+					//nothing
+				case port < best.port:
+					update = true
+			*/
 		default:
 			//nothing
 		}
@@ -800,7 +802,7 @@ func (t *switchTable) doWorker() {
 	t.queues.bufs = make(map[string]switch_buffer) // Packets per PacketStreamID (string)
 	idle := make(map[switchPort]struct{})          // this is to deduplicate things
 	for {
-		t.core.log.Debugf("Switch state: idle = %d, buffers = %d", len(idle), len(t.queues.bufs))
+		//t.core.log.Debugf("Switch state: idle = %d, buffers = %d", len(idle), len(t.queues.bufs))
 		select {
 		case bytes := <-t.packetIn:
 			// Try to send it somewhere (or drop it if it's corrupt or at a dead end)


### PR DESCRIPTION
Fixes some issues that have come to my attention after 0.3.3 (or non-critical things that I noticed right before). Work in progress, just putting this here so the progress is tracked publicly while I think about what to do with the couple of remaining issues.

1. Supersedes #328 with a subset of these changes. Among other things, this involves fewer distance calculations per packet at the switch level, so it should reduce CPU usage under load (a little) for nodes with many peers. It also breaks ties by routing to the node closest to the root, under the assumption that this is closer to the "core" region of the network and therefore more likely to know a useful shortcut / be low latency. We'll need to see how that assumption works out in practice... in the event that things tie, it still forwards to a random peer, since forcing it to be deterministic was getting some really weird results on my network, so I'd rather let the safe-seeming parts merge first and re-enable/debug the rest later.
 
2. Fixes some issues with when/where packets are dropped. As part of a workaround to a deadlock, packets could be dropped when moving to/from the crypto worker goroutine for each session. That worker has been temporarily disabled and workarounds have been added for *most* of the places where a packet would have either needed to drop or would cause a deadlock. ~~Still to do: the switch can block waiting for the router, so this needs some kind of buffer that intelligently allows packets to drop (FIFO, drop from head). After that, I think we can safely re-enable the per-session workers.~~

3. If a connection is idle for too long, detect this and close it from within `link.go` instead of making the switch do it. This is *very* important in case a connection starts but no switch info is ever transmitted, as then the switch would never learn about the peer and know to close the connection if it stops responding. Also, improves logging, so the reason for a disconnection is printed if you're the side that's closing it.

4. In the `linkInterface.handler()` code, detect if the metadata exchange lags for too long, and return an error if it does. The caller (`tcp.go`) is still responsible for closing the connection, or otherwise doing cleanup, just like for any other error returned by the link code.

5. Also in `linkInterface.handler()`, correctly permit *outgoing* connections to nodes that aren't in the `AllowedEncryptionPublicKeys`, since presumably you know what you're doing if you're the one trying to connect to someone else. Something to consider: `tcp://address:port/key` syntax to (optionally?) specify the key that the remote end should have, in the case of non-local connections.

As far as I can tell, this doesn't break anything that isn't currently broken, and it fixes some issues, so I think this is good to review and/or merge now.