### PR TITLE
Wake AWDL for multicast peering on macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@
 # Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
-  build:
+  build-linux:
     docker:
       - image: circleci/golang:1.11
 
@@ -44,16 +44,96 @@ jobs:
               mv *.deb /tmp/upload/
 
       - run:
+          name: Build for EdgeRouter
+          command: |
+              rm -f {yggdrasil,yggdrasilctl}
+              git clone https://github.com/neilalexander/vyatta-yggdrasil /tmp/vyatta-yggdrasil;
+              cd /tmp/vyatta-yggdrasil;
+              BUILDDIR_YGG=$CIRCLE_WORKING_DIRECTORY ./build-edgerouter-x $CIRCLE_BRANCH;
+              BUILDDIR_YGG=$CIRCLE_WORKING_DIRECTORY ./build-edgerouter-lite $CIRCLE_BRANCH;
+              mv *.deb /tmp/upload;
+
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - upload
+
+  build-macos:
+    macos:
+      xcode: "10.0.0"
+
+    working_directory: ~/go/src/github.com/yggdrasil-network/yggdrasil-go
+
+    steps:
+      - checkout
+
+      - run:
+          name: Create artifact upload directory and set variables
+          command: |
+              mkdir /tmp/upload
+              echo 'export CINAME=$(sh contrib/semver/name.sh)' >> $BASH_ENV
+              echo 'export CIVERSION=$(sh contrib/semver/version.sh --bare)' >> $BASH_ENV
+              echo 'export PATH=$PATH:/usr/local/go/bin:~/go/bin' >> $BASH_ENV
+              git config --global user.email "$(git log --format='%ae' HEAD -1)";
+              git config --global user.name "$(git log --format='%an' HEAD -1)";
+              echo -e "Host *\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+
+      - run:
+          name: Install Go 1.11
+          command: |
+              cd /tmp
+              curl -LO https://dl.google.com/go/go1.11.5.darwin-amd64.pkg
+              sudo installer -pkg /tmp/go1.11.5.darwin-amd64.pkg -target /
+
+      - run:
+          name: Install Gomobile
+          command: |
+              GO111MODULE=off go get golang.org/x/mobile/cmd/gomobile
+              gomobile init
+
+      - run:
           name: Build for macOS
           command: |
               rm -f {yggdrasil,yggdrasilctl}
-              GOOS=darwin GOARCH=amd64 ./build && mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-darwin-amd64 && mv yggdrasilctl /tmp/upload/$CINAME-$CIVERSION-yggdrasilctl-darwin-amd64;
+              GO111MODULE=on GOOS=darwin GOARCH=amd64 ./build
+              mv yggdrasil /tmp/upload/$CINAME-$CIVERSION-darwin-amd64
+              mv yggdrasilctl /tmp/upload/$CINAME-$CIVERSION-yggdrasilctl-darwin-amd64;
 
       - run:
           name: Build for macOS (.pkg format)
           command: |
               rm -rf {yggdrasil,yggdrasilctl}
-              GOOS=darwin GOARCH=amd64 ./build && PKGARCH=amd64 sh contrib/macos/create-pkg.sh && mv *.pkg /tmp/upload/
+              PKGARCH=amd64 sh contrib/macos/create-pkg.sh
+              mv *.pkg /tmp/upload/
+
+      #- run:
+      #    name: Build framework for iOS (.framework format)
+      #    command: |
+      #        sudo GO111MODULE=off go get -v github.com/yggdrasil-network/yggdrasil-go/cmd/...
+      #        sudo GO111MODULE=off go get -v github.com/yggdrasil-network/yggdrasil-go/src/...
+      #        GO111MODULE=off ./build -i
+      #        mv *.framework /tmp/upload
+
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - upload
+
+  build-other:
+    docker:
+      - image: circleci/golang:1.11
+
+    steps:
+      - checkout
+
+      - run:
+          name: Create artifact upload directory and set variables
+          command: |
+              mkdir /tmp/upload
+              echo 'export CINAME=$(sh contrib/semver/name.sh)' >> $BASH_ENV
+              echo 'export CIVERSION=$(sh contrib/semver/version.sh --bare)' >> $BASH_ENV
+              git config --global user.email "$(git log --format='%ae' HEAD -1)";
+              git config --global user.name "$(git log --format='%an' HEAD -1)";
 
       - run:
           name: Build for OpenBSD
@@ -83,16 +163,31 @@ jobs:
               GOOS=windows GOARCH=amd64 ./build && mv yggdrasil.exe /tmp/upload/$CINAME-$CIVERSION-windows-amd64.exe && mv yggdrasilctl.exe /tmp/upload/$CINAME-$CIVERSION-yggdrasilctl-windows-amd64.exe;
               GOOS=windows GOARCH=386 ./build && mv yggdrasil.exe /tmp/upload/$CINAME-$CIVERSION-windows-i386.exe && mv yggdrasilctl.exe /tmp/upload/$CINAME-$CIVERSION-yggdrasilctl-windows-i386.exe;
 
-      - run:
-          name: Build for EdgeRouter
-          command: |
-              rm -f {yggdrasil,yggdrasilctl}
-              git clone https://github.com/neilalexander/vyatta-yggdrasil /tmp/vyatta-yggdrasil;
-              cd /tmp/vyatta-yggdrasil;
-              BUILDDIR_YGG=$CIRCLE_WORKING_DIRECTORY ./build-edgerouter-x $CIRCLE_BRANCH;
-              BUILDDIR_YGG=$CIRCLE_WORKING_DIRECTORY ./build-edgerouter-lite $CIRCLE_BRANCH;
-              mv *.deb /tmp/upload;
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - upload
+
+  upload:
+    machine: true
+
+    steps:
+      - attach_workspace:
+          at: /tmp
 
       - store_artifacts:
           path: /tmp/upload
           destination: /
+
+workflows:
+  version: 2
+  build-all:
+    jobs:
+      - build-linux
+      - build-macos
+      - build-other
+      - upload:
+          requires:
+            - build-linux
+            - build-macos
+            - build-other

--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -50,7 +50,7 @@ func (m *multicast) start() error {
 		}
 		listenString := fmt.Sprintf("[::]:%v", addr.Port)
 		lc := net.ListenConfig{
-			Control: multicastReuse,
+			Control: m.multicastReuse,
 		}
 		conn, err := lc.ListenPacket(context.Background(), "udp6", listenString)
 		if err != nil {
@@ -61,6 +61,7 @@ func (m *multicast) start() error {
 			// Windows can't set this flag, so we need to handle it in other ways
 		}
 
+		m.multicastWake()
 		go m.listen()
 		go m.announce()
 	}

--- a/src/yggdrasil/multicast_darwin.go
+++ b/src/yggdrasil/multicast_darwin.go
@@ -7,7 +7,6 @@ package yggdrasil
 #cgo LDFLAGS: -framework Foundation
 #import <Foundation/Foundation.h>
 void WakeUpAWDL() {
-	id delegateObject; // Assume this exists.
 	NSNetServiceBrowser *serviceBrowser;
 
 	serviceBrowser = [[NSNetServiceBrowser alloc] init];

--- a/src/yggdrasil/multicast_darwin.go
+++ b/src/yggdrasil/multicast_darwin.go
@@ -2,10 +2,33 @@
 
 package yggdrasil
 
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation
+#import <Foundation/Foundation.h>
+void WakeUpAWDL() {
+	id delegateObject; // Assume this exists.
+	NSNetServiceBrowser *serviceBrowser;
+
+	serviceBrowser = [[NSNetServiceBrowser alloc] init];
+	serviceBrowser.includesPeerToPeer = YES;
+	[serviceBrowser searchForServicesOfType:@"_yggdrasil._tcp" inDomain:@""];
+}
+*/
+import "C"
 import "syscall"
 import "golang.org/x/sys/unix"
 
-func multicastReuse(network string, address string, c syscall.RawConn) error {
+func (m *multicast) multicastWake() {
+	for _, intf := range m.interfaces() {
+		if intf.Name == "awdl0" {
+			m.core.log.Infoln("Multicast discovery is waking up AWDL")
+			C.WakeUpAWDL()
+		}
+	}
+}
+
+func (m *multicast) multicastReuse(network string, address string, c syscall.RawConn) error {
 	var control error
 	var reuseport error
 	var recvanyif error

--- a/src/yggdrasil/multicast_other.go
+++ b/src/yggdrasil/multicast_other.go
@@ -4,6 +4,10 @@ package yggdrasil
 
 import "syscall"
 
-func multicastReuse(network string, address string, c syscall.RawConn) error {
+func (m *multicast) multicastWake() {
+
+}
+
+func (m *multicast) multicastReuse(network string, address string, c syscall.RawConn) error {
 	return nil
 }

--- a/src/yggdrasil/multicast_unix.go
+++ b/src/yggdrasil/multicast_unix.go
@@ -5,7 +5,11 @@ package yggdrasil
 import "syscall"
 import "golang.org/x/sys/unix"
 
-func multicastReuse(network string, address string, c syscall.RawConn) error {
+func (m *multicast) multicastWake() {
+
+}
+
+func (m *multicast) multicastReuse(network string, address string, c syscall.RawConn) error {
 	var control error
 	var reuseport error
 

--- a/src/yggdrasil/multicast_windows.go
+++ b/src/yggdrasil/multicast_windows.go
@@ -5,7 +5,11 @@ package yggdrasil
 import "syscall"
 import "golang.org/x/sys/windows"
 
-func multicastReuse(network string, address string, c syscall.RawConn) error {
+func (m *multicast) multicastWake() {
+
+}
+
+func (m *multicast) multicastReuse(network string, address string, c syscall.RawConn) error {
 	var control error
 	var reuseaddr error
 


### PR DESCRIPTION
This wakes up AWDL for multicast peer discovery when the `awdl0` multicast interface is enabled. This allows Macs to directly peer with one another, even if they are on different Wi-Fi networks or not even connected to Wi-Fi at all. 