### PR TITLE
Try to clean up UNIX admin socket

### DIFF
--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -402,7 +402,18 @@ func (a *admin) listen() {
 		switch strings.ToLower(u.Scheme) {
 		case "unix":
 			if _, err := os.Stat(a.listenaddr[7:]); err == nil {
-				a.core.log.Warnln("WARNING:", a.listenaddr[7:], "already exists and may be in use by another process")
+				a.core.log.Debugln("Admin socket", a.listenaddr[7:], "already exists, trying to clean up")
+				if _, err := net.Dial("unix", a.listenaddr[7:]); err == nil {
+					a.core.log.Errorln("Admin socket", a.listenaddr[7:], "is already in use by another process")
+					os.Exit(1)
+				} else {
+					if err := os.Remove(a.listenaddr[7:]); err == nil {
+						a.core.log.Debugln(a.listenaddr[7:], "was cleaned up")
+					} else {
+						a.core.log.Errorln(a.listenaddr[7:], "already exists and was not cleaned up:", err)
+						os.Exit(1)
+					}
+				}
 			}
 			a.listener, err = net.Listen("unix", a.listenaddr[7:])
 			if err == nil {

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -404,7 +404,7 @@ func (a *admin) listen() {
 			if _, err := os.Stat(a.listenaddr[7:]); err == nil {
 				a.core.log.Debugln("Admin socket", a.listenaddr[7:], "already exists, trying to clean up")
 				if _, err := net.Dial("unix", a.listenaddr[7:]); err == nil {
-					a.core.log.Errorln("Admin socket", a.listenaddr[7:], "is already in use by another process")
+					a.core.log.Errorln("Admin socket", a.listenaddr[7:], "already exists and is in use by another process")
 					os.Exit(1)
 				} else {
 					if err := os.Remove(a.listenaddr[7:]); err == nil {


### PR DESCRIPTION
If the UNIX admin socket already exists, Yggdrasil will attempt to connect to it. If it responds and connects then the process errors out and exits as the socket is in use. If it doesn't answer then it is assumed that no process is using the path anymore (e.g. because of a crash), therefore we will try to remove it before running `net.Listen`.