### PR TITLE
Support for multiple listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - in case of vulnerabilities.
 -->
 
-## [0.3.3] - 2018-02-18
+## [0.3.3] - 2019-02-18
 ### Added
 - Dynamic reconfiguration, which allows reloading the configuration file to make changes during runtime by sending a `SIGHUP` signal (note: this only works with `-useconffile` and not `-useconf` and currently reconfiguring TUN/TAP is not supported)
 - Support for building Yggdrasil as an iOS or Android framework if the appropriate tools (e.g. `gomobile`/`gobind` + SDKs) are available

--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -134,12 +134,20 @@ func readConfig(useconf *bool, useconffile *string, normaliseconf *bool) *nodeCo
 			}
 		}
 	}
+	// Do a quick check for old-format Listen statement so that mapstructure
+	// doesn't fail and crash
+	if listen, ok := dat["Listen"].(string); ok {
+		if strings.HasPrefix(listen, "tcp://") {
+			dat["Listen"] = []string{listen}
+		} else {
+			dat["Listen"] = []string{"tcp://" + listen}
+		}
+	}
 	// Overlay our newly mapped configuration onto the autoconf node config that
 	// we generated above.
 	if err = mapstructure.Decode(dat, &cfg); err != nil {
 		panic(err)
 	}
-
 	return cfg
 }
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -12,7 +12,7 @@ import (
 
 // NodeConfig defines all configuration values needed to run a signle yggdrasil node
 type NodeConfig struct {
-	Listen                      string                 `comment:"Listen address for peer connections. Default is to listen for all\nTCP connections over IPv4 and IPv6 with a random port."`
+	Listen                      []string               `comment:"Listen address for peer connections. Default is to listen for all\nTCP connections over IPv4 and IPv6 with a random port."`
 	AdminListen                 string                 `comment:"Listen address for admin connections. Default is to listen for local\nconnections either on TCP/9001 or a UNIX socket depending on your\nplatform. Use this value for yggdrasilctl -endpoint=X. To disable\nthe admin socket, use the value \"none\" instead."`
 	Peers                       []string               `comment:"List of connection strings for static peers in URI format, e.g.\ntcp://a.b.c.d:e or socks://a.b.c.d:e/f.g.h.i:j."`
 	InterfacePeers              map[string][]string    `comment:"List of connection strings for static peers in URI format, arranged\nby source interface, e.g. { \"eth0\": [ tcp://a.b.c.d:e ] }. Note that\nSOCKS peerings will NOT be affected by this option and should go in\nthe \"Peers\" section instead."`
@@ -79,10 +79,10 @@ func GenerateConfig(isAutoconf bool) *NodeConfig {
 	// Create a node configuration and populate it.
 	cfg := NodeConfig{}
 	if isAutoconf {
-		cfg.Listen = "[::]:0"
+		cfg.Listen = []string{"tcp://[::]:0"}
 	} else {
 		r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
-		cfg.Listen = fmt.Sprintf("[::]:%d", r1.Intn(65534-32768)+32768)
+		cfg.Listen = []string{fmt.Sprintf("[::]:%d", r1.Intn(65534-32768)+32768)}
 	}
 	cfg.AdminListen = defaults.GetDefaults().DefaultAdminListen
 	cfg.EncryptionPublicKey = hex.EncodeToString(bpub[:])

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -12,7 +12,7 @@ import (
 
 // NodeConfig defines all configuration values needed to run a signle yggdrasil node
 type NodeConfig struct {
-	Listen                      []string               `comment:"Listen address for peer connections. Default is to listen for all\nTCP connections over IPv4 and IPv6 with a random port."`
+	Listen                      []string               `comment:"Listen addresses for peer connections. Default is to listen for all\nTCP connections over IPv4 and IPv6 with a random port."`
 	AdminListen                 string                 `comment:"Listen address for admin connections. Default is to listen for local\nconnections either on TCP/9001 or a UNIX socket depending on your\nplatform. Use this value for yggdrasilctl -endpoint=X. To disable\nthe admin socket, use the value \"none\" instead."`
 	Peers                       []string               `comment:"List of connection strings for static peers in URI format, e.g.\ntcp://a.b.c.d:e or socks://a.b.c.d:e/f.g.h.i:j."`
 	InterfacePeers              map[string][]string    `comment:"List of connection strings for static peers in URI format, arranged\nby source interface, e.g. { \"eth0\": [ tcp://a.b.c.d:e ] }. Note that\nSOCKS peerings will NOT be affected by this option and should go in\nthe \"Peers\" section instead."`
@@ -30,13 +30,6 @@ type NodeConfig struct {
 	SwitchOptions               SwitchOptions          `comment:"Advanced options for tuning the switch. Normally you will not need\nto edit these options."`
 	NodeInfoPrivacy             bool                   `comment:"By default, nodeinfo contains some defaults including the platform,\narchitecture and Yggdrasil version. These can help when surveying\nthe network and diagnosing network routing problems. Enabling\nnodeinfo privacy prevents this, so that only items specified in\n\"NodeInfo\" are sent back if specified."`
 	NodeInfo                    map[string]interface{} `comment:"Optional node info. This must be a { \"key\": \"value\", ... } map\nor set as null. This is entirely optional but, if set, is visible\nto the whole network on request."`
-	//Net                         NetConfig `comment:"Extended options for connecting to peers over other networks."`
-}
-
-// NetConfig defines network/proxy related configuration values
-type NetConfig struct {
-	Tor TorConfig `comment:"Experimental options for configuring peerings over Tor."`
-	I2P I2PConfig `comment:"Experimental options for configuring peerings over I2P."`
 }
 
 // SessionFirewall controls the session firewall configuration
@@ -71,8 +64,6 @@ type SwitchOptions struct {
 // isAutoconf is that the TCP and UDP ports will likely end up with different
 // port numbers.
 func GenerateConfig(isAutoconf bool) *NodeConfig {
-	// Create a new core.
-	//core := Core{}
 	// Generate encryption keys.
 	bpub, bpriv := crypto.NewBoxKeys()
 	spub, spriv := crypto.NewSigKeys()

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -82,7 +82,7 @@ func GenerateConfig(isAutoconf bool) *NodeConfig {
 		cfg.Listen = []string{"tcp://[::]:0"}
 	} else {
 		r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
-		cfg.Listen = []string{fmt.Sprintf("[::]:%d", r1.Intn(65534-32768)+32768)}
+		cfg.Listen = []string{fmt.Sprintf("tcp://[::]:%d", r1.Intn(65534-32768)+32768)}
 	}
 	cfg.AdminListen = defaults.GetDefaults().DefaultAdminListen
 	cfg.EncryptionPublicKey = hex.EncodeToString(bpub[:])

--- a/src/config/i2p.go
+++ b/src/config/i2p.go
@@ -1,8 +1,0 @@
-package config
-
-// I2PConfig is the configuration structure for i2p related configuration
-type I2PConfig struct {
-	Keyfile string // private key file or empty string for ephemeral keys
-	Addr    string // address of i2p api connector
-	Enabled bool
-}

--- a/src/config/tor.go
+++ b/src/config/tor.go
@@ -1,8 +1,0 @@
-package config
-
-// TorConfig is the configuration structure for Tor Proxy related values
-type TorConfig struct {
-	OnionKeyfile string // hidden service private key for ADD_ONION (currently unimplemented)
-	ControlAddr  string // tor control port address
-	Enabled      bool
-}

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -87,7 +87,7 @@ func Difference(a, b []string) []string {
 		mb[x] = true
 	}
 	for _, x := range a {
-		if _, ok := mb[x]; !ok {
+		if !mb[x] {
 			ab = append(ab, x)
 		}
 	}

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -76,3 +76,20 @@ func FuncTimeout(f func(), timeout time.Duration) bool {
 		return false
 	}
 }
+
+// This calculates the difference between two arrays and returns items
+// that appear in A but not in B - useful somewhat when reconfiguring
+// and working out what configuration items changed
+func Difference(a, b []string) []string {
+	ab := []string{}
+	mb := map[string]bool{}
+	for _, x := range b {
+		mb[x] = true
+	}
+	for _, x := range a {
+		if _, ok := mb[x]; !ok {
+			ab = append(ab, x)
+		}
+	}
+	return ab
+}

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -577,9 +577,9 @@ func (a *admin) addPeer(addr string, sintf string) error {
 	if err == nil {
 		switch strings.ToLower(u.Scheme) {
 		case "tcp":
-			a.core.tcp.connect(u.Host, sintf)
+			a.core.link.tcp.connect(u.Host, sintf)
 		case "socks":
-			a.core.tcp.connectSOCKS(u.Host, u.Path[1:])
+			a.core.link.tcp.connectSOCKS(u.Host, u.Path[1:])
 		default:
 			return errors.New("invalid peer: " + addr)
 		}

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -573,18 +573,9 @@ func (a *admin) printInfos(infos []admin_nodeInfo) string {
 
 // addPeer triggers a connection attempt to a node.
 func (a *admin) addPeer(addr string, sintf string) error {
-	u, err := url.Parse(addr)
-	if err == nil {
-		switch strings.ToLower(u.Scheme) {
-		case "tcp":
-			a.core.link.tcp.connect(u.Host, sintf)
-		case "socks":
-			a.core.link.tcp.connectSOCKS(u.Host, u.Path[1:])
-		default:
-			return errors.New("invalid peer: " + addr)
-		}
-	} else {
-		return errors.New("invalid peer: " + addr)
+	err := a.core.link.call(addr, sintf)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -676,7 +676,7 @@ func (a *admin) getData_getPeers() []admin_nodeInfo {
 			{"bytes_sent", atomic.LoadUint64(&p.bytesSent)},
 			{"bytes_recvd", atomic.LoadUint64(&p.bytesRecvd)},
 			{"proto", p.intf.info.linkType},
-			{"endpoint", p.intf.info.remote},
+			{"endpoint", p.intf.name},
 			{"box_pub_key", hex.EncodeToString(p.box[:])},
 		}
 		peerInfos = append(peerInfos, info)

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -666,7 +666,8 @@ func (a *admin) getData_getPeers() []admin_nodeInfo {
 			{"uptime", int(time.Since(p.firstSeen).Seconds())},
 			{"bytes_sent", atomic.LoadUint64(&p.bytesSent)},
 			{"bytes_recvd", atomic.LoadUint64(&p.bytesRecvd)},
-			{"endpoint", p.endpoint},
+			{"proto", p.intf.info.linkType},
+			{"endpoint", p.intf.info.remote},
 			{"box_pub_key", hex.EncodeToString(p.box[:])},
 		}
 		peerInfos = append(peerInfos, info)
@@ -692,7 +693,8 @@ func (a *admin) getData_getSwitchPeers() []admin_nodeInfo {
 			{"port", elem.port},
 			{"bytes_sent", atomic.LoadUint64(&peer.bytesSent)},
 			{"bytes_recvd", atomic.LoadUint64(&peer.bytesRecvd)},
-			{"endpoint", peer.endpoint},
+			{"proto", peer.intf.info.linkType},
+			{"endpoint", peer.intf.info.remote},
 			{"box_pub_key", hex.EncodeToString(peer.box[:])},
 		}
 		peerInfos = append(peerInfos, info)

--- a/src/yggdrasil/awdl.go
+++ b/src/yggdrasil/awdl.go
@@ -7,9 +7,10 @@ import (
 )
 
 type awdl struct {
-	link       *link
-	mutex      sync.RWMutex // protects interfaces below
-	interfaces map[string]*awdlInterface
+	link        *link
+	reconfigure chan chan error
+	mutex       sync.RWMutex // protects interfaces below
+	interfaces  map[string]*awdlInterface
 }
 
 type awdlInterface struct {
@@ -49,7 +50,15 @@ func (a *awdl) init(l *link) error {
 	a.link = l
 	a.mutex.Lock()
 	a.interfaces = make(map[string]*awdlInterface)
+	a.reconfigure = make(chan chan error, 1)
 	a.mutex.Unlock()
+
+	go func() {
+		for {
+			e := <-a.reconfigure
+			e <- nil
+		}
+	}()
 
 	return nil
 }

--- a/src/yggdrasil/awdl.go
+++ b/src/yggdrasil/awdl.go
@@ -54,8 +54,7 @@ func (a *awdl) init(l *link) error {
 	a.mutex.Unlock()
 
 	go func() {
-		for {
-			e := <-a.reconfigure
+		for e := range a.reconfigure {
 			e <- nil
 		}
 	}()

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -44,7 +44,6 @@ type Core struct {
 	admin       admin
 	searches    searches
 	multicast   multicast
-	tcp         tcpInterface
 	link        link
 	log         *log.Logger
 }
@@ -144,7 +143,7 @@ func (c *Core) UpdateConfig(config *config.NodeConfig) {
 		c.router.tun.reconfigure,
 		c.router.cryptokey.reconfigure,
 		c.switchTable.reconfigure,
-		c.tcp.reconfigure,
+		//	c.link.reconfigure,
 		c.multicast.reconfigure,
 	}
 
@@ -204,11 +203,6 @@ func (c *Core) Start(nc *config.NodeConfig, log *log.Logger) error {
 	c.configMutex.Unlock()
 
 	c.init()
-
-	if err := c.tcp.init(c); err != nil {
-		c.log.Errorln("Failed to start TCP interface")
-		return err
-	}
 
 	if err := c.link.init(c); err != nil {
 		c.log.Errorln("Failed to start link interfaces")

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -143,7 +143,7 @@ func (c *Core) UpdateConfig(config *config.NodeConfig) {
 		c.router.tun.reconfigure,
 		c.router.cryptokey.reconfigure,
 		c.switchTable.reconfigure,
-		//	c.link.reconfigure,
+		c.link.reconfigure,
 		c.multicast.reconfigure,
 	}
 

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -97,7 +97,15 @@ func (c *Core) DEBUG_getPeers() *peers {
 }
 
 func (ps *peers) DEBUG_newPeer(box crypto.BoxPubKey, sig crypto.SigPubKey, link crypto.BoxSharedKey) *peer {
-	return ps.newPeer(&box, &sig, &link, "(simulator)", nil)
+	sim := linkInterface{
+		name: "(simulator)",
+		info: linkInfo{
+			local:    "(simulator)",
+			remote:   "(simulator)",
+			linkType: "sim",
+		},
+	}
+	return ps.newPeer(&box, &sig, &link, &sim, nil)
 }
 
 /*

--- a/src/yggdrasil/debug.go
+++ b/src/yggdrasil/debug.go
@@ -449,19 +449,19 @@ func (c *Core) DEBUG_addSOCKSConn(socksaddr, peeraddr string) {
 
 //*
 func (c *Core) DEBUG_setupAndStartGlobalTCPInterface(addrport string) {
-	c.config.Listen = addrport
-	if err := c.tcp.init(c /*, addrport, 0*/); err != nil {
-		c.log.Println("Failed to start TCP interface:", err)
+	c.config.Listen = []string{addrport}
+	if err := c.link.init(c); err != nil {
+		c.log.Println("Failed to start interfaces:", err)
 		panic(err)
 	}
 }
 
 func (c *Core) DEBUG_getGlobalTCPAddr() *net.TCPAddr {
-	return c.tcp.serv.Addr().(*net.TCPAddr)
+	return c.link.tcp.getAddr()
 }
 
 func (c *Core) DEBUG_addTCPConn(saddr string) {
-	c.tcp.call(saddr, nil, "")
+	c.link.tcp.call(saddr, nil, "")
 }
 
 //*/

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -261,11 +261,11 @@ func (intf *linkInterface) handler() error {
 			// Now block until something is ready or the timer triggers keepalive traffic
 			select {
 			case <-tcpTimer.C:
-				intf.link.core.log.Debugf("Sending (legacy) keep-alive to %s: %s, source %s",
+				intf.link.core.log.Tracef("Sending (legacy) keep-alive to %s: %s, source %s",
 					strings.ToUpper(intf.info.linkType), themString, intf.info.local)
 				send(nil)
 			case <-sendAck:
-				intf.link.core.log.Debugf("Sending ack to %s: %s, source %s",
+				intf.link.core.log.Tracef("Sending ack to %s: %s, source %s",
 					strings.ToUpper(intf.info.linkType), themString, intf.info.local)
 				send(nil)
 			case msg := <-intf.peer.linkOut:
@@ -280,7 +280,7 @@ func (intf *linkInterface) handler() error {
 				case signalReady <- struct{}{}:
 				default:
 				}
-				//intf.link.core.log.Debugf("Sending packet to %s: %s, source %s",
+				//intf.link.core.log.Tracef("Sending packet to %s: %s, source %s",
 				//	strings.ToUpper(intf.info.linkType), themString, intf.info.local)
 			}
 		}
@@ -331,7 +331,7 @@ func (intf *linkInterface) handler() error {
 					sendTimerRunning = true
 				}
 				if !gotMsg {
-					intf.link.core.log.Debugf("Received ack from %s: %s, source %s",
+					intf.link.core.log.Tracef("Received ack from %s: %s, source %s",
 						strings.ToUpper(intf.info.linkType), themString, intf.info.local)
 				}
 			case sentMsg, ok := <-signalSent:

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -173,7 +173,7 @@ func (intf *linkInterface) handler() error {
 	intf.link.mutex.Unlock()
 	// Create peer
 	shared := crypto.GetSharedKey(myLinkPriv, &meta.link)
-	intf.peer = intf.link.core.peers.newPeer(&meta.box, &meta.sig, shared, intf.name, func() { intf.msgIO.close() })
+	intf.peer = intf.link.core.peers.newPeer(&meta.box, &meta.sig, shared, intf, func() { intf.msgIO.close() })
 	if intf.peer == nil {
 		return errors.New("failed to create peer")
 	}

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -119,7 +119,8 @@ func (l *link) listen(uri string) error {
 	}
 	switch u.Scheme {
 	case "tcp":
-		return l.tcp.listen(u.Host)
+		_, err := l.tcp.listen(u.Host)
+		return err
 	default:
 		return errors.New("unknown listen scheme: " + u.Scheme)
 	}

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -105,7 +105,7 @@ func (l *link) call(uri string, sintf string) error {
 	case "tcp":
 		l.tcp.call(u.Host, nil, sintf)
 	case "socks":
-		l.tcp.call(pathtokens[0], &u.Host, sintf)
+		l.tcp.call(pathtokens[0], u.Host, sintf)
 	default:
 		return errors.New("unknown call scheme: " + u.Scheme)
 	}

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -22,7 +22,6 @@ type link struct {
 	reconfigure chan chan error
 	mutex       sync.RWMutex // protects interfaces below
 	interfaces  map[linkInfo]*linkInterface
-	handlers    map[string]linkListener
 	awdl        awdl // AWDL interface support
 	tcp         tcp  // TCP interface support
 	// TODO timeout (to remove from switch), read from config.ReadTimeout
@@ -34,10 +33,6 @@ type linkInfo struct {
 	linkType string           // Type of link, e.g. TCP, AWDL
 	local    string           // Local name or address
 	remote   string           // Remote name or address
-}
-
-type linkListener interface {
-	init(*link) error
 }
 
 type linkInterfaceMsgIO interface {

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -21,8 +21,9 @@ type link struct {
 	core       *Core
 	mutex      sync.RWMutex // protects interfaces below
 	interfaces map[linkInfo]*linkInterface
-	awdl       awdl         // AWDL interface support
-	tcp        tcpInterface // TCP interface support
+	handlers   map[string]linkListener
+	awdl       awdl // AWDL interface support
+	tcp        tcp  // TCP interface support
 	// TODO timeout (to remove from switch), read from config.ReadTimeout
 }
 
@@ -32,6 +33,10 @@ type linkInfo struct {
 	linkType string           // Type of link, e.g. TCP, AWDL
 	local    string           // Local name or address
 	remote   string           // Remote name or address
+}
+
+type linkListener interface {
+	init(*link) error
 }
 
 type linkInterfaceMsgIO interface {

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -76,14 +76,17 @@ func (l *link) init(c *Core) error {
 	go func() {
 		for {
 			e := <-l.reconfigure
-			response := make(chan error)
-			l.tcp.reconfigure <- response
-			if err := <-response; err != nil {
+			tcpresponse := make(chan error)
+			awdlresponse := make(chan error)
+			l.tcp.reconfigure <- tcpresponse
+			if err := <-tcpresponse; err != nil {
 				e <- err
+				continue
 			}
-			l.awdl.reconfigure <- response
-			if err := <-response; err != nil {
+			l.awdl.reconfigure <- awdlresponse
+			if err := <-awdlresponse; err != nil {
 				e <- err
+				continue
 			}
 			e <- nil
 		}

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+
 	//"sync/atomic"
 	"time"
 
@@ -20,7 +21,8 @@ type link struct {
 	core       *Core
 	mutex      sync.RWMutex // protects interfaces below
 	interfaces map[linkInfo]*linkInterface
-	awdl       awdl // AWDL interface support
+	awdl       awdl         // AWDL interface support
+	tcp        tcpInterface // TCP interface support
 	// TODO timeout (to remove from switch), read from config.ReadTimeout
 }
 
@@ -57,6 +59,11 @@ func (l *link) init(c *Core) error {
 	l.mutex.Lock()
 	l.interfaces = make(map[linkInfo]*linkInterface)
 	l.mutex.Unlock()
+
+	if err := l.tcp.init(l); err != nil {
+		c.log.Errorln("Failed to start TCP interface")
+		return err
+	}
 
 	if err := l.awdl.init(l); err != nil {
 		l.core.log.Errorln("Failed to start AWDL interface")

--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -149,11 +149,11 @@ func (m *multicast) announce() {
 				if l, ok := m.listeners[iface.Name]; !ok || l.listener == nil {
 					// No listener was found - let's create one
 					listenaddr := fmt.Sprintf("[%s%%%s]:0", addrIP, iface.Name)
-					if l, err := m.core.link.tcp.listen(listenaddr); err == nil {
+					if li, err := m.core.link.tcp.listen(listenaddr); err == nil {
 						m.core.log.Debugln("Started multicasting on", iface.Name)
 						// Store the listener so that we can stop it later if needed
-						m.listeners[iface.Name] = l
-						listener = l
+						m.listeners[iface.Name] = li
+						listener = li
 					}
 				} else {
 					// An existing listener was found

--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -27,7 +27,7 @@ func (m *multicast) init(core *Core) {
 		for {
 			e := <-m.reconfigure
 			m.myAddrMutex.Lock()
-			m.myAddr = m.core.tcp.getAddr()
+			m.myAddr = m.core.link.tcp.getAddr()
 			m.myAddrMutex.Unlock()
 			e <- nil
 		}
@@ -109,7 +109,7 @@ func (m *multicast) interfaces() []net.Interface {
 func (m *multicast) announce() {
 	var anAddr net.TCPAddr
 	m.myAddrMutex.Lock()
-	m.myAddr = m.core.tcp.getAddr()
+	m.myAddr = m.core.link.tcp.getAddr()
 	m.myAddrMutex.Unlock()
 	groupAddr, err := net.ResolveUDPAddr("udp6", m.groupAddr)
 	if err != nil {
@@ -183,6 +183,6 @@ func (m *multicast) listen() {
 		}
 		addr.Zone = from.Zone
 		saddr := addr.String()
-		m.core.tcp.connect(saddr, addr.Zone)
+		m.core.link.tcp.connect(saddr, addr.Zone)
 	}
 }

--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -153,6 +153,7 @@ func (m *multicast) announce() {
 						m.core.log.Debugln("Started multicasting on", iface.Name)
 						// Store the listener so that we can stop it later if needed
 						m.listeners[iface.Name] = l
+						listener = l
 					}
 				} else {
 					// An existing listener was found
@@ -171,9 +172,8 @@ func (m *multicast) announce() {
 				}
 				break
 			}
-			time.Sleep(time.Second)
 		}
-		time.Sleep(time.Second * 5)
+		time.Sleep(time.Second * 15)
 	}
 }
 

--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -183,6 +183,6 @@ func (m *multicast) listen() {
 		}
 		addr.Zone = from.Zone
 		saddr := addr.String()
-		m.core.link.tcp.connect(saddr, addr.Zone)
+		m.core.link.call("tcp://"+saddr, addr.Zone)
 	}
 }

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -67,7 +67,15 @@ func (r *router) init(core *Core) {
 	r.addr = *address.AddrForNodeID(&r.core.dht.nodeID)
 	r.subnet = *address.SubnetForNodeID(&r.core.dht.nodeID)
 	in := make(chan []byte, 1) // TODO something better than this...
-	p := r.core.peers.newPeer(&r.core.boxPub, &r.core.sigPub, &crypto.BoxSharedKey{}, "(self)", nil)
+	self := linkInterface{
+		name: "(self)",
+		info: linkInfo{
+			local:    "(self)",
+			remote:   "(self)",
+			linkType: "self",
+		},
+	}
+	p := r.core.peers.newPeer(&r.core.boxPub, &r.core.sigPub, &crypto.BoxSharedKey{}, &self, nil)
 	p.out = func(packet []byte) { in <- packet }
 	r.in = in
 	out := make(chan []byte, 32)

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -155,8 +155,14 @@ func (t *tcp) listener(l *tcpListener, listenaddr string) {
 	}
 	// Track the listener so that we can find it again in future
 	t.mutex.Lock()
-	t.listeners[listenaddr] = l
-	t.mutex.Unlock()
+	if _, isIn := t.listeners[listenaddr]; isIn {
+		t.mutex.Unlock()
+		l.listener.Close()
+		return
+	} else {
+		t.listeners[listenaddr] = l
+		t.mutex.Unlock()
+	}
 	// And here we go!
 	accepted := make(chan bool)
 	defer func() {

--- a/src/yggdrasil/tcp_darwin.go
+++ b/src/yggdrasil/tcp_darwin.go
@@ -10,7 +10,7 @@ import (
 
 // WARNING: This context is used both by net.Dialer and net.Listen in tcp.go
 
-func (iface *tcpInterface) tcpContext(network, address string, c syscall.RawConn) error {
+func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
 	var control error
 	var recvanyif error
 

--- a/src/yggdrasil/tcp_other.go
+++ b/src/yggdrasil/tcp_other.go
@@ -8,6 +8,6 @@ import (
 
 // WARNING: This context is used both by net.Dialer and net.Listen in tcp.go
 
-func (iface *tcpInterface) tcpContext(network, address string, c syscall.RawConn) error {
+func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
 	return nil
 }


### PR DESCRIPTION
This adds support for multiple listeners, e.g. more than one TCP listen address, or in theory mixed types of listeners (e.g. regular TCP sockets, UNIX domain sockets, etc):

1. The `Listen` configuration item is now an array. If it is currently a string then we attempt to convert it to an array either at startup or when running `-normaliseconf`
1. `tcpInterface` is now just `tcp`, in keeping with `awdl`/`awdlInterface`, and it now belongs to `link` rather than `Core`
1. `link` now has a `reconfigure` channel, and it cascades down to `tcp`, `awdl` etc.
1. `tcp` now supports holding and opening multiple listeners
1. The `Listen` configuration item can now be completely empty (e.g. not listening on any globally routable addresses) without affecting link-local multicast (see below)
1. `multicast.go` has been adapted so that it creates new TCP listeners for each interface (based on found link-local addresses) as this allows multicasting to work properly even when `Listen` addresses are not wildcard
1. Sets a static multicast interval of 15 seconds and reevaluates the available multicast interfaces upon each interval
1. Cleans up multicast listeners for interfaces that are no longer up or eligible (e.g. no multicast flag)