### PR TITLE
Fix bugs from multilink branch (#360)

### DIFF
--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -166,6 +166,7 @@ func (m *multicast) announce() {
 				// Get the listener details and construct the multicast beacon
 				lladdr := listener.listener.Addr().String()
 				if a, err := net.ResolveTCPAddr("tcp6", lladdr); err == nil {
+					a.Zone = ""
 					destAddr.Zone = iface.Name
 					msg := []byte(a.String())
 					m.sock.WriteTo(msg, nil, destAddr)
@@ -208,8 +209,9 @@ func (m *multicast) listen() {
 		if addr.IP.String() != from.IP.String() {
 			continue
 		}
-		addr.Zone = from.Zone
-		saddr := addr.String()
-		m.core.link.call("tcp://"+saddr, addr.Zone)
+		addr.Zone = ""
+		if err := m.core.link.call("tcp://"+addr.String(), from.Zone); err != nil {
+			m.core.log.Debugln("Call from multicast failed:", err)
+		}
 	}
 }


### PR DESCRIPTION
This fixes two bugs:

1. The multicast beacons were leaking the interface name from the source machine - although this was irrelevant to the receiver, we now don't leak them
1. The zone was not always being set properly when dialling link-local addresses from multicast, which was resulting in multicast not working when all machines were running the latest `develop` with `multilink` fixes included