### PR TITLE
Add AppArmor profile

### DIFF
--- a/contrib/apparmor/usr.bin.yggdrasil
+++ b/contrib/apparmor/usr.bin.yggdrasil
@@ -7,11 +7,12 @@
   capability net_admin,
 
   network inet stream,
+  network inet dgram,
   network inet6 dgram,
   network inet6 stream,
   network netlink raw,
 
-  /lib/x86_64-linux-gnu/ld-*.so mr,
+  /lib/@{multiarch}/ld-*.so mr,
   /proc/sys/net/core/somaxconn r,
   /dev/net/tun rw,
 

--- a/contrib/apparmor/usr.bin.yggdrasil
+++ b/contrib/apparmor/usr.bin.yggdrasil
@@ -1,0 +1,22 @@
+# Last Modified: Sat Mar  9 06:08:02 2019
+#include <tunables/global>
+
+/usr/bin/yggdrasil {
+  #include <abstractions/base>
+
+  capability net_admin,
+
+  network inet stream,
+  network inet6 dgram,
+  network inet6 stream,
+  network netlink raw,
+
+  /lib/x86_64-linux-gnu/ld-*.so mr,
+  /proc/sys/net/core/somaxconn r,
+  /dev/net/tun rw,
+
+  /usr/bin/yggdrasil mr,
+  /etc/yggdrasil.conf rw,
+  /run/yggdrasil.sock rw,
+
+}


### PR DESCRIPTION
This PR adds a profile which can be used to harden yggdrasil setup with a Linux kernel security module [AppArmor](https://en.wikipedia.org/wiki/AppArmor).