### PR TITLE
More switch/link fixes

### DIFF
--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -677,12 +677,12 @@ func (t *switchTable) handleIn(packet []byte, idle map[switchPort]struct{}) bool
 			//nothing
 		case coordLen < bestCoordLen:
 			update = true
-			/*
-				case coordLen > bestCoordLen:
-					//nothing
-				case port < best.port:
-					update = true
-			*/
+		/*
+			case coordLen > bestCoordLen:
+				//nothing
+			case port < best.port:
+				update = true
+		*/
 		default:
 			//nothing
 		}


### PR DESCRIPTION
Mark a peer as blocked in the switch if the link's `writeMsg()` call blocks too long.