### PR TITLE
AWDL fixes for macOS

### DIFF
--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -57,7 +57,7 @@ func (m *multicast) start() error {
 			// Windows can't set this flag, so we need to handle it in other ways
 		}
 
-		m.multicastWake()
+		go m.multicastStarted()
 		go m.listen()
 		go m.announce()
 	}

--- a/src/yggdrasil/multicast_other.go
+++ b/src/yggdrasil/multicast_other.go
@@ -4,7 +4,7 @@ package yggdrasil
 
 import "syscall"
 
-func (m *multicast) multicastWake() {
+func (m *multicast) multicastStarted() {
 
 }
 

--- a/src/yggdrasil/multicast_unix.go
+++ b/src/yggdrasil/multicast_unix.go
@@ -5,7 +5,7 @@ package yggdrasil
 import "syscall"
 import "golang.org/x/sys/unix"
 
-func (m *multicast) multicastWake() {
+func (m *multicast) multicastStarted() {
 
 }
 

--- a/src/yggdrasil/multicast_windows.go
+++ b/src/yggdrasil/multicast_windows.go
@@ -5,7 +5,7 @@ package yggdrasil
 import "syscall"
 import "golang.org/x/sys/windows"
 
-func (m *multicast) multicastWake() {
+func (m *multicast) multicastStarted() {
 
 }
 


### PR DESCRIPTION
This fixes AWDL on macOS, which would occasionally not start properly at macOS startup if running as a launchd service. It would also not ever restart AWDL if it was switched off for some reason (e.g. system sleep). We would also keep AWDL awake even if the `awdl0` multicast interface had been removed during runtime.

This now will launch a goroutine on macOS to reevaluate this every minute. We will delete and re-add the browser every minute, which will make sure that AWDL stays alive (it does not switch off straight away when the browser is removed). If `awdl0` is removed from `MulticastInterfaces` then we will not re-awaken AWDL.