### PR TITLE
Re-order config, update default Listen

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -62,7 +62,7 @@ func readConfig(useconf *bool, useconffile *string, normaliseconf *bool) *nodeCo
 	// then parse the configuration we loaded above on top of it. The effect
 	// of this is that any configuration item that is missing from the provided
 	// configuration will use a sane default.
-	cfg := config.GenerateConfig(false)
+	cfg := config.GenerateConfig()
 	var dat map[string]interface{}
 	if err := hjson.Unmarshal(conf, &dat); err != nil {
 		panic(err)
@@ -154,7 +154,7 @@ func readConfig(useconf *bool, useconffile *string, normaliseconf *bool) *nodeCo
 // Generates a new configuration and returns it in HJSON format. This is used
 // with -genconf.
 func doGenconf(isjson bool) string {
-	cfg := config.GenerateConfig(false)
+	cfg := config.GenerateConfig()
 	var bs []byte
 	var err error
 	if isjson {
@@ -191,7 +191,7 @@ func main() {
 	case *autoconf:
 		// Use an autoconf-generated config, this will give us random keys and
 		// port numbers, and will use an automatically selected TUN/TAP interface.
-		cfg = config.GenerateConfig(true)
+		cfg = config.GenerateConfig()
 	case *useconffile != "" || *useconf:
 		// Read the configuration from either stdin or from the filesystem
 		cfg = readConfig(useconf, useconffile, normaliseconf)

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -61,7 +61,7 @@ type SwitchOptions struct {
 // or whether to generate a random port number. The only side effect of setting
 // isAutoconf is that the TCP and UDP ports will likely end up with different
 // port numbers.
-func GenerateConfig(isAutoconf bool) *NodeConfig {
+func GenerateConfig() *NodeConfig {
 	// Generate encryption keys.
 	bpub, bpriv := crypto.NewBoxKeys()
 	spub, spriv := crypto.NewSigKeys()

--- a/src/yggdrasil/mobile.go
+++ b/src/yggdrasil/mobile.go
@@ -45,7 +45,7 @@ func (c *Core) addStaticPeers(cfg *config.NodeConfig) {
 func (c *Core) StartAutoconfigure() error {
 	mobilelog := MobileLogger{}
 	logger := log.New(mobilelog, "", 0)
-	nc := config.GenerateConfig(true)
+	nc := config.GenerateConfig()
 	nc.IfName = "dummy"
 	nc.AdminListen = "tcp://localhost:9001"
 	nc.Peers = []string{}
@@ -64,7 +64,7 @@ func (c *Core) StartAutoconfigure() error {
 func (c *Core) StartJSON(configjson []byte) error {
 	mobilelog := MobileLogger{}
 	logger := log.New(mobilelog, "", 0)
-	nc := config.GenerateConfig(false)
+	nc := config.GenerateConfig()
 	var dat map[string]interface{}
 	if err := hjson.Unmarshal(configjson, &dat); err != nil {
 		return err
@@ -82,7 +82,7 @@ func (c *Core) StartJSON(configjson []byte) error {
 
 // Generates mobile-friendly configuration in JSON format.
 func GenerateConfigJSON() []byte {
-	nc := config.GenerateConfig(false)
+	nc := config.GenerateConfig()
 	nc.IfName = "dummy"
 	if json, err := json.Marshal(nc); err == nil {
 		return json


### PR DESCRIPTION
This makes some changes to the `config` package, including updating the default config so that no `Listen` entries are specified by default.