### PR TITLE
Multicast fix

### DIFF
--- a/src/yggdrasil/multicast.go
+++ b/src/yggdrasil/multicast.go
@@ -186,7 +186,6 @@ func (m *multicast) announce() {
 				msg := []byte(a.String())
 				m.sock.WriteTo(msg, nil, destAddr)
 			}
-			break
 		}
 		time.Sleep(time.Second * 15)
 	}


### PR DESCRIPTION
Previously, if an interface remained up but an address was changed, then we would continue to keep the old listener open and advertise its old listen address. This fails if, for example, a node assigns new random link-local IPv6 addresses when switching wifi networks.

The change indexes listeners by the string representation of a `net.IPAddr`, which includes a `Zone` field with the interface name, instead of trying to index by interface name alone.

The catch is that, if you have more than one link-local address, then it may open and advertise more than one listener per interface, which could lead to duplicate connections. I'm not sure what the best way is to get around that... I figured I should commit what I have in case @neilalexander sees an obvious way to fix the multiple address issue (something like a `map[iface.Name]map[address]listener` maybe...).