### PR TITLE
Peer lookup by SRV or TXT records

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -108,10 +108,13 @@ func readConfig(useconf *bool, useconffile *string, normaliseconf *bool) *nodeCo
 	// Check to see if the peers are in a parsable format, if not then default
 	// them to the TCP scheme
 	if peers, ok := dat["Peers"].([]interface{}); ok {
+	peerloop:
 		for index, peer := range peers {
 			uri := peer.(string)
-			if strings.HasPrefix(uri, "tcp://") || strings.HasPrefix(uri, "socks://") {
-				continue
+			for _, prefix := range []string{"tcp://", "socks://", "srv://", "txt://"} {
+				if strings.HasPrefix(uri, prefix) {
+					continue peerloop
+				}
 			}
 			if strings.HasPrefix(uri, "tcp:") {
 				uri = uri[4:]
@@ -121,11 +124,14 @@ func readConfig(useconf *bool, useconffile *string, normaliseconf *bool) *nodeCo
 	}
 	// Now do the same with the interface peers
 	if interfacepeers, ok := dat["InterfacePeers"].(map[string]interface{}); ok {
+	interfacepeerloop:
 		for intf, peers := range interfacepeers {
 			for index, peer := range peers.([]interface{}) {
 				uri := peer.(string)
-				if strings.HasPrefix(uri, "tcp://") || strings.HasPrefix(uri, "socks://") {
-					continue
+				for _, prefix := range []string{"tcp://", "socks://", "srv://", "txt://"} {
+					if strings.HasPrefix(uri, prefix) {
+						continue interfacepeerloop
+					}
 				}
 				if strings.HasPrefix(uri, "tcp:") {
 					uri = uri[4:]

--- a/src/yggdrasil/admin.go
+++ b/src/yggdrasil/admin.go
@@ -591,7 +591,11 @@ func (a *admin) printInfos(infos []admin_nodeInfo) string {
 
 // addPeer triggers a connection attempt to a node.
 func (a *admin) addPeer(addr string, sintf string) error {
-	err := a.core.link.call(addr, sintf)
+	entry, err := a.core.resolvePeerEntry(addr, sintf)
+	if err != nil {
+		return err
+	}
+	err = a.core.link.call(entry.uri, entry.sintf)
 	if err != nil {
 		return err
 	}

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -404,12 +404,14 @@ func (c *Core) resolvePeerEntry(uri, sintf string) (peerEntry, error) {
 		if records, err := net.LookupTXT(recordname); err == nil {
 			for _, record := range records {
 				c.log.Traceln("Found TXT record:", record)
-				if !strings.HasPrefix(record, "txt://") {
-					return peerEntry{
-						uri:   fmt.Sprintf("%s", record),
-						sintf: sintf,
-					}, nil
+				if strings.HasPrefix(record, "txt://") {
+					// Prevents an infinite loop
+					continue
 				}
+				return peerEntry{
+					uri:   fmt.Sprintf("%s", record),
+					sintf: sintf,
+				}, nil
 			}
 		} else {
 			c.log.Debugln("TXT lookup failed:", err)

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -102,33 +102,6 @@ func (l *link) call(uri string, sintf string) error {
 	}
 	pathtokens := strings.Split(strings.Trim(u.Path, "/"), "/")
 	switch u.Scheme {
-	case "srv":
-		for _, proto := range []string{"tcp"} {
-			if cname, srv, err := net.LookupSRV("yggdrasil", proto, u.Host); err == nil {
-				for _, record := range srv {
-					l.core.log.Debugln("SRV lookup for", u.Host, "found:", cname, record.Target, record.Port)
-					switch proto {
-					case "tcp":
-						saddr := fmt.Sprintf("%s:%d", record.Target, record.Port)
-						l.tcp.call(saddr, nil, sintf)
-					}
-				}
-			} else {
-				l.core.log.Debugln("SRV lookup for", u.Host, "failed:", err)
-			}
-		}
-	case "txt":
-		recordname := fmt.Sprintf("_yggdrasil.%s", u.Host)
-		if records, err := net.LookupTXT(recordname); err == nil {
-			for _, record := range records {
-				l.core.log.Debugln("Found TXT record:", record)
-				if !strings.HasPrefix(record, "txt://") {
-					l.call(record, sintf)
-				}
-			}
-		} else {
-			l.core.log.Debugln("TXT lookup failed:", err)
-		}
 	case "tcp":
 		l.tcp.call(u.Host, nil, sintf)
 	case "socks":

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -102,6 +102,33 @@ func (l *link) call(uri string, sintf string) error {
 	}
 	pathtokens := strings.Split(strings.Trim(u.Path, "/"), "/")
 	switch u.Scheme {
+	case "srv":
+		for _, proto := range []string{"tcp"} {
+			if cname, srv, err := net.LookupSRV("yggdrasil", proto, u.Host); err == nil {
+				for _, record := range srv {
+					l.core.log.Debugln("SRV lookup for", u.Host, "found:", cname, record.Target, record.Port)
+					switch proto {
+					case "tcp":
+						saddr := fmt.Sprintf("%s:%d", record.Target, record.Port)
+						l.tcp.call(saddr, nil, sintf)
+					}
+				}
+			} else {
+				l.core.log.Debugln("SRV lookup for", u.Host, "failed:", err)
+			}
+		}
+	case "txt":
+		recordname := fmt.Sprintf("_yggdrasil.%s", u.Host)
+		if records, err := net.LookupTXT(recordname); err == nil {
+			for _, record := range records {
+				l.core.log.Debugln("Found TXT record:", record)
+				if !strings.HasPrefix(record, "txt://") {
+					l.call(record, sintf)
+				}
+			}
+		} else {
+			l.core.log.Debugln("TXT lookup failed:", err)
+		}
 	case "tcp":
 		l.tcp.call(u.Host, nil, sintf)
 	case "socks":


### PR DESCRIPTION
This adds support for two types of URLs:

- `srv://domain.com` (where it looks up SRV record `_yggdrasil._tcp.domain.com`)
- `txt://domain.com` (where it looks up TXT record `_yggdrasil.domain.com` where the TXT record contains a normal peer URI, e.g. `tcp://a.b.c.d:e`)

I'm not entirely sure I'm happy with this PR yet. It doesn't really respect priority fields or anything like that – it adds only the first record found in a SRV case to the peer list, although this *should* be the highest priority record. It doesn't attempt to fail over to lesser priority nodes, as we don't really have the machinery in place to allow this.

It does add a new dimension of configuration into `core.go` so that `srv://` and `txt://` peers are resolved only either at startup or during reconfiguration – I'm not sure if this is messy or can be done better. The problem it solves is that otherwise we'll hammer DNS with repeated requests as Go does not cache them.

That said, we do already probably hammer DNS a bit as it is if `tcp://` DNS peers are configured, particularly where the peers are not connected. We may want to look at that as well.