### PR TITLE
Don't indefinitely block TUN/TAP reader goroutine after conn error

### DIFF
--- a/src/yggdrasil/conn.go
+++ b/src/yggdrasil/conn.go
@@ -207,7 +207,7 @@ func (c *Conn) Read(b []byte) (int, error) {
 			defer close(done)
 			// If the nonce is bad then drop the packet and return an error
 			if !sinfo.nonceIsOK(&p.Nonce) {
-				err = errors.New("packet dropped due to invalid nonce")
+				err = ConnError{errors.New("packet dropped due to invalid nonce"), false, true, 0}
 				return
 			}
 			// Decrypt the packet


### PR DESCRIPTION
There were cases where an error returned by a conn `Read` (e.g. decryption error, invalid nonce) would result in the indefinite blocking of the TUN/TAP reader goroutine since the `read` channel was never written to in those cases.

This PR fixes that, and also stops the connection reader/writer for a given session if the error returned is for a permanent condition. 