### PR TITLE
Fix panic when determining if CKR is enabled

### DIFF
--- a/src/tuntap/ckr.go
+++ b/src/tuntap/ckr.go
@@ -115,12 +115,13 @@ func (c *cryptokey) configure() error {
 
 // Enable or disable crypto-key routing.
 func (c *cryptokey) setEnabled(enabled bool) {
-	c.enabled.Store(true)
+	c.enabled.Store(enabled)
 }
 
 // Check if crypto-key routing is enabled.
 func (c *cryptokey) isEnabled() bool {
-	return c.enabled.Load().(bool)
+	enabled, ok := c.enabled.Load().(bool)
+	return ok && enabled
 }
 
 // Check whether the given address (with the address length specified in bytes)


### PR DESCRIPTION
This should fix a crash which @Mikaela reported trying to determine if CKR is enabled. The panic was as a result of a cast from an atomic load sometimes failing:
```
touko 30 17:10:51 relpda yggdrasil[588]: panic: interface conversion: interface {} is nil, not bool
touko 30 17:10:51 relpda yggdrasil[588]: goroutine 37 [running]:
touko 30 17:10:51 relpda yggdrasil[588]: github.com/yggdrasil-network/yggdrasil-go/src/tuntap.(*cryptokey).isEnabled(...)
touko 30 17:10:51 relpda yggdrasil[588]:         /home/circleci/project/src/tuntap/ckr.go:123
touko 30 17:10:51 relpda yggdrasil[588]: github.com/yggdrasil-network/yggdrasil-go/src/tuntap.(*cryptokey).isValidSource(0xc000099c88, 0x0, 0x0, 0x10, 0x0)
touko 30 17:10:51 relpda yggdrasil[588]:         /home/circleci/project/src/tuntap/ckr.go:148 +0x38c
touko 30 17:10:51 relpda yggdrasil[588]: github.com/yggdrasil-network/yggdrasil-go/src/tuntap.(*TunAdapter).reader(0xc000099c48, 0x0, 0xc0000164e0)
touko 30 17:10:51 relpda yggdrasil[588]:         /home/circleci/project/src/tuntap/iface.go:181 +0x29c
touko 30 17:10:51 relpda yggdrasil[588]: created by github.com/yggdrasil-network/yggdrasil-go/src/tuntap.(*TunAdapter).Start
touko 30 17:10:51 relpda yggdrasil[588]:         /home/circleci/project/src/tuntap/tun.go:175 +0x602
```