### PR TITLE
fix issue with sessions dying and never being fixed

### DIFF
--- a/src/yggdrasil/conn.go
+++ b/src/yggdrasil/conn.go
@@ -274,6 +274,10 @@ func (c *Conn) Write(b []byte) (bytesWritten int, err error) {
 			c.writebuf = c.writebuf[1:]
 		}
 		return len(b), nil
+	} else {
+		// This triggers some session keepalive traffic
+		// FIXME this desparately needs to be refactored, since the ping case needlessly goes through the router goroutine just to have it pass a function to the session worker when it determines that a session already exists.
+		c.core.router.doAdmin(c.startSearch)
 	}
 	var packet []byte
 	done := make(chan struct{})


### PR DESCRIPTION
I think this fixes the issue where sessions mysteriously stop working, due to some keep-alive ping/search traffic that was never being sent. If the fix works, then we should refactor `startSession` a bit so we can directly pass the relevant part to the session worker without going through the router goroutine, since that causes pointless contention. That *shouldn't* be difficult to do, but I'd prefer to deploy a quick fix first and then worry about refactoring.