### PR TITLE
Add multicast interfaces to platform-specific defaults

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -102,7 +102,7 @@ func GenerateConfig() *NodeConfig {
 	cfg.Peers = []string{}
 	cfg.InterfacePeers = map[string][]string{}
 	cfg.AllowedEncryptionPublicKeys = []string{}
-	cfg.MulticastInterfaces = []string{".*"}
+	cfg.MulticastInterfaces = defaults.GetDefaults().DefaultMulticastInterfaces
 	cfg.IfName = defaults.GetDefaults().DefaultIfName
 	cfg.IfMTU = defaults.GetDefaults().DefaultIfMTU
 	cfg.IfTAPMode = defaults.GetDefaults().DefaultIfTAPMode

--- a/src/defaults/defaults.go
+++ b/src/defaults/defaults.go
@@ -10,6 +10,9 @@ type platformDefaultParameters struct {
 	// Configuration (used for yggdrasilctl)
 	DefaultConfigFile string
 
+	// Multicast interfaces
+	DefaultMulticastInterfaces []string
+
 	// TUN/TAP
 	MaximumIfMTU     int
 	DefaultIfMTU     int

--- a/src/defaults/defaults_darwin.go
+++ b/src/defaults/defaults_darwin.go
@@ -12,6 +12,12 @@ func GetDefaults() platformDefaultParameters {
 		// Configuration (used for yggdrasilctl)
 		DefaultConfigFile: "/etc/yggdrasil.conf",
 
+		// Multicast interfaces
+		DefaultMulticastInterfaces: []string{
+			"en*",
+			"bridge*",
+		},
+
 		// TUN/TAP
 		MaximumIfMTU:     65535,
 		DefaultIfMTU:     65535,

--- a/src/defaults/defaults_darwin.go
+++ b/src/defaults/defaults_darwin.go
@@ -14,8 +14,8 @@ func GetDefaults() platformDefaultParameters {
 
 		// Multicast interfaces
 		DefaultMulticastInterfaces: []string{
-			"en*",
-			"bridge*",
+			"en.*",
+			"bridge.*",
 		},
 
 		// TUN/TAP

--- a/src/defaults/defaults_freebsd.go
+++ b/src/defaults/defaults_freebsd.go
@@ -12,6 +12,11 @@ func GetDefaults() platformDefaultParameters {
 		// Configuration (used for yggdrasilctl)
 		DefaultConfigFile: "/etc/yggdrasil.conf",
 
+		// Multicast interfaces
+		DefaultMulticastInterfaces: []string{
+			".*",
+		},
+
 		// TUN/TAP
 		MaximumIfMTU:     32767,
 		DefaultIfMTU:     32767,

--- a/src/defaults/defaults_linux.go
+++ b/src/defaults/defaults_linux.go
@@ -12,6 +12,14 @@ func GetDefaults() platformDefaultParameters {
 		// Configuration (used for yggdrasilctl)
 		DefaultConfigFile: "/etc/yggdrasil.conf",
 
+		// Multicast interfaces
+		DefaultMulticastInterfaces: []string{
+			"en*",
+			"eth*",
+			"wlan*",
+			"br*",
+		},
+
 		// TUN/TAP
 		MaximumIfMTU:     65535,
 		DefaultIfMTU:     65535,

--- a/src/defaults/defaults_linux.go
+++ b/src/defaults/defaults_linux.go
@@ -14,10 +14,7 @@ func GetDefaults() platformDefaultParameters {
 
 		// Multicast interfaces
 		DefaultMulticastInterfaces: []string{
-			"en*",
-			"eth*",
-			"wlan*",
-			"br*",
+			".*",
 		},
 
 		// TUN/TAP

--- a/src/defaults/defaults_netbsd.go
+++ b/src/defaults/defaults_netbsd.go
@@ -12,6 +12,11 @@ func GetDefaults() platformDefaultParameters {
 		// Configuration (used for yggdrasilctl)
 		DefaultConfigFile: "/etc/yggdrasil.conf",
 
+		// Multicast interfaces
+		DefaultMulticastInterfaces: []string{
+			".*",
+		},
+
 		// TUN/TAP
 		MaximumIfMTU:     9000,
 		DefaultIfMTU:     9000,

--- a/src/defaults/defaults_openbsd.go
+++ b/src/defaults/defaults_openbsd.go
@@ -12,6 +12,11 @@ func GetDefaults() platformDefaultParameters {
 		// Configuration (used for yggdrasilctl)
 		DefaultConfigFile: "/etc/yggdrasil.conf",
 
+		// Multicast interfaces
+		DefaultMulticastInterfaces: []string{
+			".*",
+		},
+
 		// TUN/TAP
 		MaximumIfMTU:     16384,
 		DefaultIfMTU:     16384,

--- a/src/defaults/defaults_other.go
+++ b/src/defaults/defaults_other.go
@@ -12,6 +12,11 @@ func GetDefaults() platformDefaultParameters {
 		// Configuration (used for yggdrasilctl)
 		DefaultConfigFile: "/etc/yggdrasil.conf",
 
+		// Multicast interfaces
+		DefaultMulticastInterfaces: []string{
+			".*",
+		},
+
 		// TUN/TAP
 		MaximumIfMTU:     65535,
 		DefaultIfMTU:     65535,

--- a/src/defaults/defaults_windows.go
+++ b/src/defaults/defaults_windows.go
@@ -12,6 +12,11 @@ func GetDefaults() platformDefaultParameters {
 		// Configuration (used for yggdrasilctl)
 		DefaultConfigFile: "C:\\Program Files\\Yggdrasil\\yggdrasil.conf",
 
+		// Multicast interfaces
+		DefaultMulticastInterfaces: []string{
+			".*",
+		},
+
 		// TUN/TAP
 		MaximumIfMTU:     65535,
 		DefaultIfMTU:     65535,


### PR DESCRIPTION
This changes the defaults to include a platform-specific `MulticastInterfaces` option. This mostly allows us to pick some sane defaults for interfaces we will want to multicast on out-of-the-box.

This mostly arose because using `.*` on macOS includes `awdl0`, which results in waking up the AWDL adapter and dropping other wireless performance somewhat. For someone who isn't aware of what's going on, that could be frustrating.

I don't know the naming conventions for all platforms but this seemed like the least bad way to solve the problem for macOS at least, rather than having specific exceptions for `awdl0` in the config parser.