### PR TITLE
Implement session gatekeeper functions

### DIFF
--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -395,6 +395,18 @@ func (c *Core) GetNodeInfo(keyString, coordString string, nocache bool) (NodeInf
 	return NodeInfoPayload{}, errors.New(fmt.Sprintf("getNodeInfo timeout: %s", keyString))
 }
 
+// SetSessionGatekeeper allows you to configure a handler function for deciding
+// whether a session should be allowed or not. The default session firewall is
+// implemented in this way. The function receives the public key of the remote
+// side, and a boolean which is true if we initiated the session or false if we
+// received an incoming session request.
+func (c *Core) SetSessionGatekeeper(f func(pubkey *crypto.BoxPubKey, initiator bool) bool) {
+	c.sessions.isAllowedMutex.Lock()
+	defer c.sessions.isAllowedMutex.Unlock()
+
+	c.sessions.isAllowedHandler = f
+}
+
 // SetLogger sets the output logger of the Yggdrasil node after startup. This
 // may be useful if you want to redirect the output later.
 func (c *Core) SetLogger(log *log.Logger) {

--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -398,8 +398,9 @@ func (c *Core) GetNodeInfo(keyString, coordString string, nocache bool) (NodeInf
 // SetSessionGatekeeper allows you to configure a handler function for deciding
 // whether a session should be allowed or not. The default session firewall is
 // implemented in this way. The function receives the public key of the remote
-// side, and a boolean which is true if we initiated the session or false if we
-// received an incoming session request.
+// side and a boolean which is true if we initiated the session or false if we
+// received an incoming session request. The function should return true to
+// allow the session or false to reject it.
 func (c *Core) SetSessionGatekeeper(f func(pubkey *crypto.BoxPubKey, initiator bool) bool) {
 	c.sessions.isAllowedMutex.Lock()
 	defer c.sessions.isAllowedMutex.Unlock()

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -219,6 +219,7 @@ func (ss *sessions) getByTheirSubnet(snet *address.Subnet) (*sessionInfo, bool) 
 // includse initializing session info to sane defaults (e.g. lowest supported
 // MTU).
 func (ss *sessions) createSession(theirPermKey *crypto.BoxPubKey) *sessionInfo {
+	// TODO: this check definitely needs to be moved
 	if !ss.isSessionAllowed(theirPermKey, true) {
 		return nil
 	}
@@ -393,6 +394,7 @@ func (ss *sessions) handlePing(ping *sessionPing) {
 	// Get the corresponding session (or create a new session)
 	sinfo, isIn := ss.getByTheirPerm(&ping.SendPermPub)
 	// Check if the session is allowed
+	// TODO: this check may need to be moved
 	if !isIn && !ss.isSessionAllowed(&ping.SendPermPub, false) {
 		return
 	}


### PR DESCRIPTION
This adds a new API function `SetSessionGatekeeper` which takes a function of type `func(pubkey *crypto.BoxPubKey, initiator bool) bool`. 

The gatekeeper function is called each time a new session is initiated, either incoming or outgoing. The `pubkey` parameter contains the permanent public key of the remote host and the `initiator` function returns `true` if we were the ones to initiate the connection (false otherwise). The function should return `true` if it wants to allow the session or `false` if it wants to reject it.

In addition to this, the session firewall is now implemented in `cmd/yggdrasil` using this new API. This means that `session.go` is a bit leaner now and more complex behaviour can be implemented if required. 