### PR TITLE
Add error text on invalid admin command

### DIFF
--- a/src/admin/admin.go
+++ b/src/admin/admin.go
@@ -446,6 +446,8 @@ func (a *AdminSocket) handleRequest(conn net.Conn) {
 					send["response"] = response
 				}
 			}
+		} else { // Command not found in []a.handlers
+			send["error"] = "Command does not exist. Run \'yggdrasilctl list\' to get a list of commands."
 		}
 
 		// Send the response back


### PR DESCRIPTION
Adds an error message if the requested admin command doesn't exist.
_Note: I have not test-compiled the code or run it through gofmt yet!_