### PR TITLE
Try and solidify multicast interface behavior

### DIFF
--- a/src/multicast/admin.go
+++ b/src/multicast/admin.go
@@ -5,7 +5,7 @@ import "github.com/yggdrasil-network/yggdrasil-go/src/admin"
 func (m *Multicast) SetupAdminHandlers(a *admin.AdminSocket) {
 	a.AddHandler("getMulticastInterfaces", []string{}, func(in admin.Info) (admin.Info, error) {
 		var intfs []string
-		for _, v := range m.GetInterfaces() {
+		for _, v := range m.Interfaces() {
 			intfs = append(intfs, v.Name)
 		}
 		return admin.Info{"multicast_interfaces": intfs}, nil

--- a/src/multicast/admin.go
+++ b/src/multicast/admin.go
@@ -5,7 +5,7 @@ import "github.com/yggdrasil-network/yggdrasil-go/src/admin"
 func (m *Multicast) SetupAdminHandlers(a *admin.AdminSocket) {
 	a.AddHandler("getMulticastInterfaces", []string{}, func(in admin.Info) (admin.Info, error) {
 		var intfs []string
-		for _, v := range m.interfaces() {
+		for _, v := range m.GetInterfaces() {
 			intfs = append(intfs, v.Name)
 		}
 		return admin.Info{"multicast_interfaces": intfs}, nil

--- a/src/multicast/multicast_darwin.go
+++ b/src/multicast/multicast_darwin.go
@@ -38,8 +38,8 @@ func (m *Multicast) multicastStarted() {
 	awdlGoroutineStarted = true
 	for {
 		C.StopAWDLBrowsing()
-		for _, intf := range m.GetInterfaces() {
-			if intf.Name == "awdl0" {
+		for intf := range m.Interfaces() {
+			if intf == "awdl0" {
 				m.log.Infoln("Multicast discovery is using AWDL discovery")
 				C.StartAWDLBrowsing()
 				break

--- a/src/multicast/multicast_darwin.go
+++ b/src/multicast/multicast_darwin.go
@@ -35,12 +35,12 @@ func (m *Multicast) multicastStarted() {
 	if awdlGoroutineStarted {
 		return
 	}
-	m.log.Infoln("Multicast discovery will wake up AWDL if required")
 	awdlGoroutineStarted = true
 	for {
 		C.StopAWDLBrowsing()
-		for _, intf := range m.interfaces() {
+		for _, intf := range m.GetInterfaces() {
 			if intf.Name == "awdl0" {
+				m.log.Infoln("Multicast discovery is using AWDL discovery")
 				C.StartAWDLBrowsing()
 				break
 			}


### PR DESCRIPTION
This PR updates the `multicast` module to try and be a bit more robust. This should hopefully fix #405 too.

We now try to re-evaluate the available multicast interfaces every minute or on reconfiguration by SIGHUP into a mutexed list of interfaces. We now pay attention to this both when sending and when receiving multicasts, so we don't accidentally hear multicasts and act upon them like we may have done in the past.

I still don't love this module but it'll do for now until we're willing to break protocol and write something better.