### PR TITLE
Add support for logging to file or syslog instead of stdout

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"log/syslog"
 	"os"
 	"os/signal"
 	"strings"
@@ -16,6 +15,7 @@ import (
 	"golang.org/x/text/encoding/unicode"
 
 	"github.com/gologme/log"
+	gsyslog "github.com/hashicorp/go-syslog"
 	"github.com/hjson/hjson-go"
 	"github.com/kardianos/minwinsvc"
 	"github.com/mitchellh/mapstructure"
@@ -168,8 +168,8 @@ func main() {
 	case "stdout":
 		logger = log.New(os.Stdout, "", log.Flags())
 	case "syslog":
-		if syslogwriter, err := syslog.New(syslog.LOG_INFO, yggdrasil.BuildName()); err == nil {
-			logger = log.New(syslogwriter, "", log.Flags())
+		if syslogger, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, "DAEMON", yggdrasil.BuildName()); err == nil {
+			logger = log.New(syslogger, "", log.Flags())
 		}
 	default:
 		if logfd, err := os.Create(*logto); err == nil {

--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -232,7 +232,7 @@ func (c *Core) GetSessions() []Session {
 // from git, or returns "unknown" otherwise.
 func BuildName() string {
 	if buildName == "" {
-		return "unknown"
+		return "yggdrasil"
 	}
 	return buildName
 }


### PR DESCRIPTION
This PR allows you to specify `-logto /path/to/file.log`, `-logto syslog` or `-logto stdout` on the command line, and mostly fixes #396.

This currently doesn't capture the output of panics—I don't know the most elegant to handle that.