### PR TITLE
Dial

### DIFF
--- a/src/tuntap/tun.go
+++ b/src/tuntap/tun.go
@@ -49,6 +49,7 @@ type TunAdapter struct {
 	mutex        sync.RWMutex // Protects the below
 	addrToConn   map[address.Address]*tunConn
 	subnetToConn map[address.Subnet]*tunConn
+	dials        map[crypto.NodeID][][]byte // Buffer of packets to send after dialing finishes
 	isOpen       bool
 }
 
@@ -113,6 +114,7 @@ func (tun *TunAdapter) Init(config *config.NodeState, log *log.Logger, listener 
 	tun.dialer = dialer
 	tun.addrToConn = make(map[address.Address]*tunConn)
 	tun.subnetToConn = make(map[address.Subnet]*tunConn)
+	tun.dials = make(map[crypto.NodeID][][]byte)
 }
 
 // Start the setup process for the TUN/TAP adapter. If successful, starts the

--- a/src/tuntap/tun.go
+++ b/src/tuntap/tun.go
@@ -237,6 +237,7 @@ func (tun *TunAdapter) wrap(conn *yggdrasil.Conn) (c *tunConn, err error) {
 		stop:  make(chan struct{}),
 		alive: make(chan struct{}, 1),
 	}
+	c = &s
 	// Get the remote address and subnet of the other side
 	remoteNodeID := conn.RemoteAddr()
 	s.addr = *address.AddrForNodeID(&remoteNodeID)

--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -517,21 +517,14 @@ func (c *Core) DHTPing(keyString, coordString, targetString string) (DHTRes, err
 	rq := dhtReqKey{info.key, target}
 	sendPing := func() {
 		c.dht.addCallback(&rq, func(res *dhtRes) {
-			defer func() { recover() }()
-			select {
-			case resCh <- res:
-			default:
-			}
+			resCh <- res
 		})
 		c.dht.ping(&info, &target)
 	}
 	c.router.doAdmin(sendPing)
-	go func() {
-		time.Sleep(6 * time.Second)
-		close(resCh)
-	}()
 	// TODO: do something better than the below...
-	for res := range resCh {
+	res := <-resCh
+	if res != nil {
 		r := DHTRes{
 			Coords: append([]byte{}, res.Coords...),
 		}

--- a/src/yggdrasil/conn.go
+++ b/src/yggdrasil/conn.go
@@ -128,7 +128,7 @@ func (c *Conn) startSearch() {
 			c.core.log.Debugf("%s DHT search started: %p", c.String(), sinfo)
 		}
 		// Continue the search
-		c.core.searches.continueSearch(sinfo)
+		sinfo.continueSearch()
 	}
 	// Take a copy of the session object, in case it changes later
 	c.mutex.RLock()

--- a/src/yggdrasil/conn.go
+++ b/src/yggdrasil/conn.go
@@ -215,7 +215,7 @@ func (c *Conn) Write(b []byte) (bytesWritten int, err error) {
 		}
 		switch {
 		case !sinfo.init:
-			doSearch()
+			sinfo.core.sessions.ping(sinfo)
 		case time.Since(sinfo.time) > 6*time.Second:
 			if sinfo.time.Before(sinfo.pingTime) && time.Since(sinfo.pingTime) > 6*time.Second {
 				// TODO double check that the above condition is correct

--- a/src/yggdrasil/conn.go
+++ b/src/yggdrasil/conn.go
@@ -45,23 +45,18 @@ type Conn struct {
 	mutex         sync.RWMutex
 	closed        bool
 	session       *sessionInfo
-	readDeadline  atomic.Value  // time.Time // TODO timer
-	writeDeadline atomic.Value  // time.Time // TODO timer
-	searching     atomic.Value  // bool
-	searchwait    chan struct{} // Never reset this, it's only used for the initial search
-	writebuf      [][]byte      // Packets to be sent if/when the search finishes
+	readDeadline  atomic.Value // time.Time // TODO timer
+	writeDeadline atomic.Value // time.Time // TODO timer
 }
 
 // TODO func NewConn() that initializes additional fields as needed
 func newConn(core *Core, nodeID *crypto.NodeID, nodeMask *crypto.NodeID, session *sessionInfo) *Conn {
 	conn := Conn{
-		core:       core,
-		nodeID:     nodeID,
-		nodeMask:   nodeMask,
-		session:    session,
-		searchwait: make(chan struct{}),
+		core:     core,
+		nodeID:   nodeID,
+		nodeMask: nodeMask,
+		session:  session,
 	}
-	conn.searching.Store(false)
 	return &conn
 }
 
@@ -69,91 +64,38 @@ func (c *Conn) String() string {
 	return fmt.Sprintf("conn=%p", c)
 }
 
-// This method should only be called from the router goroutine
-func (c *Conn) startSearch() {
-	// The searchCompleted callback is given to the search
-	searchCompleted := func(sinfo *sessionInfo, err error) {
-		defer c.searching.Store(false)
-		// If the search failed for some reason, e.g. it hit a dead end or timed
-		// out, then do nothing
-		if err != nil {
-			c.core.log.Debugln(c.String(), "DHT search failed:", err)
-			return
-		}
-		// Take the connection mutex
-		c.mutex.Lock()
-		defer c.mutex.Unlock()
-		// Were we successfully given a sessionInfo pointer?
-		if sinfo != nil {
-			// Store it, and update the nodeID and nodeMask (which may have been
-			// wildcarded before now) with their complete counterparts
-			c.core.log.Debugln(c.String(), "DHT search completed")
-			c.session = sinfo
-			c.nodeID = crypto.GetNodeID(&sinfo.theirPermPub)
-			for i := range c.nodeMask {
-				c.nodeMask[i] = 0xFF
+// This should only be called from the router goroutine
+func (c *Conn) search() error {
+	sinfo, isIn := c.core.searches.searches[*c.nodeID]
+	if !isIn {
+		done := make(chan struct{}, 1)
+		var sess *sessionInfo
+		var err error
+		searchCompleted := func(sinfo *sessionInfo, e error) {
+			sess = sinfo
+			err = e
+			// FIXME close can be called multiple times, do a non-blocking send instead
+			select {
+			case done <- struct{}{}:
+			default:
 			}
-			// Make sure that any blocks on read/write operations are lifted
-			defer func() { recover() }() // So duplicate searches don't panic
-			close(c.searchwait)
-		} else {
-			// No session was returned - this shouldn't really happen because we
-			// should always return an error reason if we don't return a session
-			panic("DHT search didn't return an error or a sessionInfo")
 		}
-		if c.closed {
-			// Things were closed before the search returned
-			// Go ahead and close it again to make sure the session is cleaned up
-			go c.Close()
-		} else {
-			// Send any messages we may have buffered
-			var msgs [][]byte
-			msgs, c.writebuf = c.writebuf, nil
-			go func() {
-				for _, msg := range msgs {
-					c.Write(msg)
-					util.PutBytes(msg)
-				}
-			}()
-		}
-	}
-	// doSearch will be called below in response to one or more conditions
-	doSearch := func() {
-		c.searching.Store(true)
-		// Check to see if there is a search already matching the destination
-		sinfo, isIn := c.core.searches.searches[*c.nodeID]
-		if !isIn {
-			// Nothing was found, so create a new search
-			sinfo = c.core.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
-			c.core.log.Debugf("%s DHT search started: %p", c.String(), sinfo)
-		}
-		// Continue the search
+		sinfo = c.core.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
 		sinfo.continueSearch()
-	}
-	// Take a copy of the session object, in case it changes later
-	c.mutex.RLock()
-	sinfo := c.session
-	c.mutex.RUnlock()
-	if c.session == nil {
-		// No session object is present so previous searches, if we ran any, have
-		// not yielded a useful result (dead end, remote host not found)
-		doSearch()
-	} else {
-		sinfo.worker <- func() {
-			switch {
-			case !sinfo.init:
-				doSearch()
-			case time.Since(sinfo.time) > 6*time.Second:
-				if sinfo.time.Before(sinfo.pingTime) && time.Since(sinfo.pingTime) > 6*time.Second {
-					// TODO double check that the above condition is correct
-					doSearch()
-				} else {
-					c.core.sessions.ping(sinfo)
-				}
-			default: // Don't do anything, to keep traffic throttled
-			}
+		<-done
+		c.session = sess
+		if c.session == nil && err == nil {
+			panic("search failed but returend no error")
 		}
+		c.nodeID = crypto.GetNodeID(&c.session.theirPermPub)
+		for i := range c.nodeMask {
+			c.nodeMask[i] = 0xFF
+		}
+		return err
+	} else {
+		return errors.New("search already exists")
 	}
+	return nil
 }
 
 func getDeadlineTimer(value *atomic.Value) *time.Timer {
@@ -167,30 +109,9 @@ func getDeadlineTimer(value *atomic.Value) *time.Timer {
 
 func (c *Conn) Read(b []byte) (int, error) {
 	// Take a copy of the session object
-	c.mutex.RLock()
 	sinfo := c.session
-	c.mutex.RUnlock()
 	timer := getDeadlineTimer(&c.readDeadline)
 	defer util.TimerStop(timer)
-	// If there is a search in progress then wait for the result
-	if sinfo == nil {
-		// Wait for the search to complete
-		select {
-		case <-c.searchwait:
-		case <-timer.C:
-			return 0, ConnError{errors.New("timeout"), true, false, 0}
-		}
-		// Retrieve our session info again
-		c.mutex.RLock()
-		sinfo = c.session
-		c.mutex.RUnlock()
-		// If sinfo is still nil at this point then the search failed and the
-		// searchwait channel has been recreated, so might as well give up and
-		// return an error code
-		if sinfo == nil {
-			return 0, errors.New("search failed")
-		}
-	}
 	for {
 		// Wait for some traffic to come through from the session
 		select {
@@ -253,32 +174,7 @@ func (c *Conn) Read(b []byte) (int, error) {
 }
 
 func (c *Conn) Write(b []byte) (bytesWritten int, err error) {
-	c.mutex.RLock()
 	sinfo := c.session
-	c.mutex.RUnlock()
-	// If the session doesn't exist, or isn't initialised (which probably means
-	// that the search didn't complete successfully) then we may need to wait for
-	// the search to complete or start the search again
-	if sinfo == nil || !sinfo.init {
-		// Is a search already taking place?
-		if searching, sok := c.searching.Load().(bool); !sok || (sok && !searching) {
-			// No search was already taking place so start a new one
-			c.core.router.doAdmin(c.startSearch)
-		}
-		// Buffer the packet to be sent if/when the search is finished
-		c.mutex.Lock()
-		defer c.mutex.Unlock()
-		c.writebuf = append(c.writebuf, append(util.GetBytes(), b...))
-		for len(c.writebuf) > 32 {
-			util.PutBytes(c.writebuf[0])
-			c.writebuf = c.writebuf[1:]
-		}
-		return len(b), nil
-	} else {
-		// This triggers some session keepalive traffic
-		// FIXME this desparately needs to be refactored, since the ping case needlessly goes through the router goroutine just to have it pass a function to the session worker when it determines that a session already exists.
-		c.core.router.doAdmin(c.startSearch)
-	}
 	var packet []byte
 	done := make(chan struct{})
 	written := len(b)
@@ -301,6 +197,34 @@ func (c *Conn) Write(b []byte) (bytesWritten int, err error) {
 		}
 		packet = p.encode()
 		sinfo.bytesSent += uint64(len(b))
+		// The rest of this work is session keep-alive traffic
+		doSearch := func() {
+			routerWork := func() {
+				// Check to see if there is a search already matching the destination
+				sinfo, isIn := c.core.searches.searches[*c.nodeID]
+				if !isIn {
+					// Nothing was found, so create a new search
+					searchCompleted := func(sinfo *sessionInfo, e error) {}
+					sinfo = c.core.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
+					c.core.log.Debugf("%s DHT search started: %p", c.String(), sinfo)
+				}
+				// Continue the search
+				sinfo.continueSearch()
+			}
+			go func() { c.core.router.admin <- routerWork }()
+		}
+		switch {
+		case !sinfo.init:
+			doSearch()
+		case time.Since(sinfo.time) > 6*time.Second:
+			if sinfo.time.Before(sinfo.pingTime) && time.Since(sinfo.pingTime) > 6*time.Second {
+				// TODO double check that the above condition is correct
+				doSearch()
+			} else {
+				sinfo.core.sessions.ping(sinfo)
+			}
+		default: // Don't do anything, to keep traffic throttled
+		}
 	}
 	// Set up a timer so this doesn't block forever
 	timer := getDeadlineTimer(&c.writeDeadline)
@@ -327,7 +251,6 @@ func (c *Conn) Close() error {
 	if c.session != nil {
 		// Close the session, if it hasn't been closed already
 		c.session.close()
-		c.session = nil
 	}
 	// This can't fail yet - TODO?
 	c.closed = true

--- a/src/yggdrasil/dialer.go
+++ b/src/yggdrasil/dialer.go
@@ -14,6 +14,8 @@ type Dialer struct {
 	core *Core
 }
 
+// TODO DialContext that allows timeouts/cancellation, Dial should just call this with no timeout set in the context
+
 // Dial opens a session to the given node. The first paramter should be "nodeid"
 // and the second parameter should contain a hexadecimal representation of the
 // target node ID.
@@ -58,5 +60,8 @@ func (d *Dialer) Dial(network, address string) (*Conn, error) {
 // NodeID parameters.
 func (d *Dialer) DialByNodeIDandMask(nodeID, nodeMask *crypto.NodeID) (*Conn, error) {
 	conn := newConn(d.core, nodeID, nodeMask, nil)
+	if err := conn.search(); err != nil {
+		return nil, err
+	}
 	return conn, nil
 }

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -141,7 +141,7 @@ func (sinfo *searchInfo) doSearchStep() {
 	if len(sinfo.toVisit) == 0 {
 		// Dead end, do cleanup
 		delete(sinfo.core.searches.searches, sinfo.dest)
-		go sinfo.callback(nil, errors.New("search reached dead end"))
+		sinfo.callback(nil, errors.New("search reached dead end"))
 		return
 	}
 	// Send to the next search target
@@ -205,7 +205,7 @@ func (sinfo *searchInfo) checkDHTRes(res *dhtRes) bool {
 		sess = sinfo.core.sessions.createSession(&res.Key)
 		if sess == nil {
 			// nil if the DHT search finished but the session wasn't allowed
-			go sinfo.callback(nil, errors.New("session not allowed"))
+			sinfo.callback(nil, errors.New("session not allowed"))
 			return true
 		}
 		_, isIn := sinfo.core.sessions.getByTheirPerm(&res.Key)
@@ -217,7 +217,7 @@ func (sinfo *searchInfo) checkDHTRes(res *dhtRes) bool {
 	sess.coords = res.Coords
 	sess.packet = sinfo.packet
 	sinfo.core.sessions.ping(sess)
-	go sinfo.callback(sess, nil)
+	sinfo.callback(sess, nil)
 	// Cleanup
 	delete(sinfo.core.searches.searches, res.Dest)
 	return true

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -37,7 +37,6 @@ type searchInfo struct {
 	dest     crypto.NodeID
 	mask     crypto.NodeID
 	time     time.Time
-	packet   []byte
 	toVisit  []*dhtInfo
 	visited  map[crypto.NodeID]bool
 	callback func(*sessionInfo, error)
@@ -215,7 +214,6 @@ func (sinfo *searchInfo) checkDHTRes(res *dhtRes) bool {
 	}
 	// FIXME (!) replay attacks could mess with coords? Give it a handle (tstamp)?
 	sess.coords = res.Coords
-	sess.packet = sinfo.packet
 	sinfo.core.sessions.ping(sess)
 	sinfo.callback(sess, nil)
 	// Cleanup

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -118,12 +118,8 @@ type sessions struct {
 	isAllowedHandler func(pubkey *crypto.BoxPubKey, initiator bool) bool // Returns true or false if session setup is allowed
 	isAllowedMutex   sync.RWMutex                                        // Protects the above
 	permShared       map[crypto.BoxPubKey]*crypto.BoxSharedKey           // Maps known permanent keys to their shared key, used by DHT a lot
-	sinfos           map[crypto.Handle]*sessionInfo                      // Maps (secret) handle onto session info
-	conns            map[crypto.Handle]*Conn                             // Maps (secret) handle onto connections
-	byMySes          map[crypto.BoxPubKey]*crypto.Handle                 // Maps mySesPub onto handle
+	sinfos           map[crypto.Handle]*sessionInfo                      // Maps handle onto session info
 	byTheirPerm      map[crypto.BoxPubKey]*crypto.Handle                 // Maps theirPermPub onto handle
-	addrToPerm       map[address.Address]*crypto.BoxPubKey
-	subnetToPerm     map[address.Subnet]*crypto.BoxPubKey
 }
 
 // Initializes the session struct.
@@ -149,10 +145,7 @@ func (ss *sessions) init(core *Core) {
 	}()
 	ss.permShared = make(map[crypto.BoxPubKey]*crypto.BoxSharedKey)
 	ss.sinfos = make(map[crypto.Handle]*sessionInfo)
-	ss.byMySes = make(map[crypto.BoxPubKey]*crypto.Handle)
 	ss.byTheirPerm = make(map[crypto.BoxPubKey]*crypto.Handle)
-	ss.addrToPerm = make(map[address.Address]*crypto.BoxPubKey)
-	ss.subnetToPerm = make(map[address.Subnet]*crypto.BoxPubKey)
 	ss.lastCleanup = time.Now()
 }
 
@@ -175,16 +168,6 @@ func (ss *sessions) getSessionForHandle(handle *crypto.Handle) (*sessionInfo, bo
 	return sinfo, isIn
 }
 
-// Gets a session corresponding to an ephemeral session key used by this node.
-func (ss *sessions) getByMySes(key *crypto.BoxPubKey) (*sessionInfo, bool) {
-	h, isIn := ss.byMySes[*key]
-	if !isIn {
-		return nil, false
-	}
-	sinfo, isIn := ss.getSessionForHandle(h)
-	return sinfo, isIn
-}
-
 // Gets a session corresponding to a permanent key used by the remote node.
 func (ss *sessions) getByTheirPerm(key *crypto.BoxPubKey) (*sessionInfo, bool) {
 	h, isIn := ss.byTheirPerm[*key]
@@ -192,26 +175,6 @@ func (ss *sessions) getByTheirPerm(key *crypto.BoxPubKey) (*sessionInfo, bool) {
 		return nil, false
 	}
 	sinfo, isIn := ss.getSessionForHandle(h)
-	return sinfo, isIn
-}
-
-// Gets a session corresponding to an IPv6 address used by the remote node.
-func (ss *sessions) getByTheirAddr(addr *address.Address) (*sessionInfo, bool) {
-	p, isIn := ss.addrToPerm[*addr]
-	if !isIn {
-		return nil, false
-	}
-	sinfo, isIn := ss.getByTheirPerm(p)
-	return sinfo, isIn
-}
-
-// Gets a session corresponding to an IPv6 /64 subnet used by the remote node/network.
-func (ss *sessions) getByTheirSubnet(snet *address.Subnet) (*sessionInfo, bool) {
-	p, isIn := ss.subnetToPerm[*snet]
-	if !isIn {
-		return nil, false
-	}
-	sinfo, isIn := ss.getByTheirPerm(p)
 	return sinfo, isIn
 }
 
@@ -263,10 +226,7 @@ func (ss *sessions) createSession(theirPermKey *crypto.BoxPubKey) *sessionInfo {
 	sinfo.worker = make(chan func(), 1)
 	sinfo.recv = make(chan *wire_trafficPacket, 32)
 	ss.sinfos[sinfo.myHandle] = &sinfo
-	ss.byMySes[sinfo.mySesPub] = &sinfo.myHandle
 	ss.byTheirPerm[sinfo.theirPermPub] = &sinfo.myHandle
-	ss.addrToPerm[sinfo.theirAddr] = &sinfo.theirPermPub
-	ss.subnetToPerm[sinfo.theirSubnet] = &sinfo.theirPermPub
 	go sinfo.workerMain()
 	return &sinfo
 }
@@ -291,36 +251,18 @@ func (ss *sessions) cleanup() {
 		sinfos[k] = v
 	}
 	ss.sinfos = sinfos
-	byMySes := make(map[crypto.BoxPubKey]*crypto.Handle, len(ss.byMySes))
-	for k, v := range ss.byMySes {
-		byMySes[k] = v
-	}
-	ss.byMySes = byMySes
 	byTheirPerm := make(map[crypto.BoxPubKey]*crypto.Handle, len(ss.byTheirPerm))
 	for k, v := range ss.byTheirPerm {
 		byTheirPerm[k] = v
 	}
 	ss.byTheirPerm = byTheirPerm
-	addrToPerm := make(map[address.Address]*crypto.BoxPubKey, len(ss.addrToPerm))
-	for k, v := range ss.addrToPerm {
-		addrToPerm[k] = v
-	}
-	ss.addrToPerm = addrToPerm
-	subnetToPerm := make(map[address.Subnet]*crypto.BoxPubKey, len(ss.subnetToPerm))
-	for k, v := range ss.subnetToPerm {
-		subnetToPerm[k] = v
-	}
-	ss.subnetToPerm = subnetToPerm
 	ss.lastCleanup = time.Now()
 }
 
 // Closes a session, removing it from sessions maps and killing the worker goroutine.
 func (sinfo *sessionInfo) close() {
 	delete(sinfo.core.sessions.sinfos, sinfo.myHandle)
-	delete(sinfo.core.sessions.byMySes, sinfo.mySesPub)
 	delete(sinfo.core.sessions.byTheirPerm, sinfo.theirPermPub)
-	delete(sinfo.core.sessions.addrToPerm, sinfo.theirAddr)
-	delete(sinfo.core.sessions.subnetToPerm, sinfo.theirSubnet)
 	close(sinfo.worker)
 }
 


### PR DESCRIPTION
Work in progress. Changes `Dial` to block until a search finishes, then return either the (almost) ready-to-use `Conn` or an error. The remaining issue is that, even though the search has returned, the session hasn't been fully set up yet (a ping has been sent but a response hasn't generally come back yet). This means the first few `Write`s to the `Conn` can still fail, so that's not ideal...

Edit: Thinking about it more, the way I would want to fix the dropped packet issue is to make sure the initial session ping/pong handshake finishes before `Dial` ends, which means it'd be best to do that as part of adding `DialContext`, and I think I want to leave that for a later PR.

One thing to note: I left a FIXME comment in iface.go where in TAP mode a buffer would be improperly used and eventually shrink down to 0 bytes / cause a slice out-of-bounds if I'm reading the code right. Unfortunately, it seems TAP mode doesn't work for me at all right now, so I'll open a separate issue for that, I just mention it because I think the comment points out where a part of the problem may be.