### PR TITLE
Bug fixes

### DIFF
--- a/src/tuntap/iface.go
+++ b/src/tuntap/iface.go
@@ -98,6 +98,9 @@ func (tun *TunAdapter) writer() error {
 			util.PutBytes(b)
 		}
 		if err != nil {
+			if !tun.isOpen {
+				return err
+			}
 			tun.log.Errorln("TUN/TAP iface write error:", err)
 			continue
 		}
@@ -114,6 +117,9 @@ func (tun *TunAdapter) reader() error {
 		// Wait for a packet to be delivered to us through the TUN/TAP adapter
 		n, err := tun.iface.Read(bs)
 		if err != nil {
+			if !tun.isOpen {
+				return err
+			}
 			panic(err)
 		}
 		if n == 0 {

--- a/src/tuntap/tun.go
+++ b/src/tuntap/tun.go
@@ -181,6 +181,16 @@ func (tun *TunAdapter) Start() error {
 	return nil
 }
 
+// Start the setup process for the TUN/TAP adapter. If successful, starts the
+// read/write goroutines to handle packets on that interface.
+func (tun *TunAdapter) Stop() error {
+	tun.isOpen = false
+	// TODO: we have nothing that cleanly stops all the various goroutines opened
+	// by TUN/TAP, e.g. readers/writers, sessions
+	tun.iface.Close()
+	return nil
+}
+
 // UpdateConfig updates the TUN/TAP module with the provided config.NodeConfig
 // and then signals the various module goroutines to reconfigure themselves if
 // needed.

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -88,14 +88,14 @@ func (c *Core) addPeerLoop() {
 
 		// Add peers from the Peers section
 		for _, peer := range current.Peers {
-			c.AddPeer(peer, "")
+			go c.AddPeer(peer, "")
 			time.Sleep(time.Second)
 		}
 
 		// Add peers from the InterfacePeers section
 		for intf, intfpeers := range current.InterfacePeers {
 			for _, peer := range intfpeers {
-				c.AddPeer(peer, intf)
+				go c.AddPeer(peer, intf)
 				time.Sleep(time.Second)
 			}
 		}


### PR DESCRIPTION
Fixes:
- #450 - the log file is no longer deleted and recreated on each start
- #451 - peer connections are now created even when one of the peers is unreachable/timing out

There are also some tweaks in this for the Windows service handler but it doesn't appear to have fixed the problem yet.