### PR TITLE
Cancellation

### DIFF
--- a/src/util/cancellation.go
+++ b/src/util/cancellation.go
@@ -1,0 +1,83 @@
+package util
+
+import (
+  "errors"
+  "sync"
+  "time"
+  "runtime"
+)
+
+type Cancellation interface {
+  Finished() <-chan struct{}
+  Cancel(error) error
+  Error() error
+}
+
+func CancellationFinalizer(c Cancellation) {
+  c.Cancel(errors.New("finalizer called"))
+}
+
+type cancellation struct {
+  signal chan error
+  cancel chan struct{}
+  errMtx sync.RWMutex
+  err error
+}
+
+func (c *cancellation) worker() {
+    // Launch this in a separate goroutine when creating a cancellation
+    err := <-c.signal
+    c.errMtx.Lock()
+    c.err = err
+    c.errMtx.Unlock()
+    close(c.cancel)
+}
+
+func NewCancellation() Cancellation {
+  c := cancellation{
+    signal: make(chan error),
+    cancel: make(chan struct{}),
+  }
+  runtime.SetFinalizer(&c, CancellationFinalizer)
+  go c.worker()
+  return &c
+}
+
+func (c *cancellation) Finished() <-chan struct{} {
+  return c.cancel
+}
+
+func (c *cancellation) Cancel(err error) error {
+  select {
+  case c.signal<-err:
+    return nil
+  case <-c.cancel:
+    return c.Error()
+  }
+}
+
+func (c *cancellation) Error() error {
+  c.errMtx.RLock()
+  err := c.err
+  c.errMtx.RUnlock()
+  return err
+}
+
+func CancellationWithTimeout(parent Cancellation, timeout time.Duration) Cancellation {
+  child := NewCancellation()
+  go func() {
+    timer := time.NewTimer(timeout)
+    defer TimerStop(timer)
+    select {
+    case <-parent.Finished():
+      child.Cancel(parent.Error())
+    case <-timer.C:
+      child.Cancel(errors.New("timeout"))
+    }
+  }()
+  return child
+}
+
+func CancellationWithDeadline(parent Cancellation, deadline time.Time) Cancellation {
+  return CancellationWithTimeout(parent, deadline.Sub(time.Now()))
+}

--- a/src/util/cancellation.go
+++ b/src/util/cancellation.go
@@ -75,6 +75,8 @@ func CancellationChild(parent Cancellation) Cancellation {
 	return child
 }
 
+var CancellationTimeoutError = errors.New("timeout")
+
 func CancellationWithTimeout(parent Cancellation, timeout time.Duration) Cancellation {
 	child := CancellationChild(parent)
 	go func() {
@@ -83,7 +85,7 @@ func CancellationWithTimeout(parent Cancellation, timeout time.Duration) Cancell
 		select {
 		case <-child.Finished():
 		case <-timer.C:
-			child.Cancel(errors.New("timeout"))
+			child.Cancel(CancellationTimeoutError)
 		}
 	}()
 	return child

--- a/src/util/cancellation.go
+++ b/src/util/cancellation.go
@@ -1,83 +1,94 @@
 package util
 
 import (
-  "errors"
-  "sync"
-  "time"
-  "runtime"
+	"errors"
+	"runtime"
+	"sync"
+	"time"
 )
 
 type Cancellation interface {
-  Finished() <-chan struct{}
-  Cancel(error) error
-  Error() error
+	Finished() <-chan struct{}
+	Cancel(error) error
+	Error() error
 }
 
 func CancellationFinalizer(c Cancellation) {
-  c.Cancel(errors.New("finalizer called"))
+	c.Cancel(errors.New("finalizer called"))
 }
 
 type cancellation struct {
-  signal chan error
-  cancel chan struct{}
-  errMtx sync.RWMutex
-  err error
+	signal chan error
+	cancel chan struct{}
+	errMtx sync.RWMutex
+	err    error
 }
 
 func (c *cancellation) worker() {
-    // Launch this in a separate goroutine when creating a cancellation
-    err := <-c.signal
-    c.errMtx.Lock()
-    c.err = err
-    c.errMtx.Unlock()
-    close(c.cancel)
+	// Launch this in a separate goroutine when creating a cancellation
+	err := <-c.signal
+	c.errMtx.Lock()
+	c.err = err
+	c.errMtx.Unlock()
+	close(c.cancel)
 }
 
 func NewCancellation() Cancellation {
-  c := cancellation{
-    signal: make(chan error),
-    cancel: make(chan struct{}),
-  }
-  runtime.SetFinalizer(&c, CancellationFinalizer)
-  go c.worker()
-  return &c
+	c := cancellation{
+		signal: make(chan error),
+		cancel: make(chan struct{}),
+	}
+	runtime.SetFinalizer(&c, CancellationFinalizer)
+	go c.worker()
+	return &c
 }
 
 func (c *cancellation) Finished() <-chan struct{} {
-  return c.cancel
+	return c.cancel
 }
 
 func (c *cancellation) Cancel(err error) error {
-  select {
-  case c.signal<-err:
-    return nil
-  case <-c.cancel:
-    return c.Error()
-  }
+	select {
+	case c.signal <- err:
+		return nil
+	case <-c.cancel:
+		return c.Error()
+	}
 }
 
 func (c *cancellation) Error() error {
-  c.errMtx.RLock()
-  err := c.err
-  c.errMtx.RUnlock()
-  return err
+	c.errMtx.RLock()
+	err := c.err
+	c.errMtx.RUnlock()
+	return err
+}
+
+func CancellationChild(parent Cancellation) Cancellation {
+	child := NewCancellation()
+	go func() {
+		select {
+		case <-child.Finished():
+		case <-parent.Finished():
+			child.Cancel(parent.Error())
+		}
+	}()
+	return child
 }
 
 func CancellationWithTimeout(parent Cancellation, timeout time.Duration) Cancellation {
-  child := NewCancellation()
-  go func() {
-    timer := time.NewTimer(timeout)
-    defer TimerStop(timer)
-    select {
-    case <-parent.Finished():
-      child.Cancel(parent.Error())
-    case <-timer.C:
-      child.Cancel(errors.New("timeout"))
-    }
-  }()
-  return child
+	child := CancellationChild(parent)
+	go func() {
+		timer := time.NewTimer(timeout)
+		defer TimerStop(timer)
+		select {
+		case <-child.Finished():
+		case <-timer.C:
+			child.Cancel(errors.New("timeout"))
+		}
+	}()
+	return child
 }
 
 func CancellationWithDeadline(parent Cancellation, deadline time.Time) Cancellation {
-  return CancellationWithTimeout(parent, deadline.Sub(time.Now()))
+	return CancellationWithTimeout(parent, deadline.Sub(time.Now()))
 }


### PR DESCRIPTION
Since I don't like using the buggy go timers directly, but the go experts want to emphasize that [context isn't for cancellation](https://dave.cheney.net/2017/08/20/context-isnt-for-cancellation), I added a `Cancellation` interface type and a struct with the relevant behaviors to the `util` package. It's more or less like the subset of functions needed for cancellation in with a `context.Context`, except it saves and reports back what `error` (if any) was the reason why it was cancelled, which makes it easier to signal the difference between a timeout and an intentionally closed session.

The `Conn.Read`, `Conn.Write`, and `Conn.Close` functions have all been updated to use this instead of the old `Conn.close` channel. There may be a few deferred `recover()` lines that could safely be removed now, I'm not sure. Nothing died in my quick tests, and I don't *think* it will leak memory or anything like that, so I'd prefer to merge it immediately and fix any bugs as part of the remaining bugfixes we were planning to do anyway.