### PR TITLE
Update build script

### DIFF
--- a/build
+++ b/build
@@ -7,24 +7,26 @@ PKGNAME=${PKGNAME:-$(sh contrib/semver/name.sh)}
 PKGVER=${PKGVER:-$(sh contrib/semver/version.sh --bare)}
 
 LDFLAGS="-X $PKGSRC.buildName=$PKGNAME -X $PKGSRC.buildVersion=$PKGVER"
+ARGS="-v"
 
-while getopts "udaitc:l:r" option
+while getopts "uaitc:l:dro:" option
 do
-  case "${option}"
+  case "$option"
   in
   u) UPX=true;;
-  d) DEBUG=true;;
   i) IOS=true;;
   a) ANDROID=true;;
   t) TABLES=true;;
   c) GCFLAGS="$GCFLAGS $OPTARG";;
   l) LDFLAGS="$LDFLAGS $OPTARG";;
-  r) RACE="-race";;
+  d) ARGS="$ARGS -tags debug";;
+  r) ARGS="$ARGS -race";;
+  o) ARGS="$ARGS -o $OPTARG";;
   esac
 done
 
 if [ -z $TABLES ]; then
-  STRIP="-s -w"
+  LDFLAGS="$LDFLAGS -s -w"
 fi
 
 if [ $IOS ]; then
@@ -42,12 +44,8 @@ elif [ $ANDROID ]; then
 else
   for CMD in `ls cmd/` ; do
     echo "Building: $CMD"
+    go build $ARGS -ldflags="$LDFLAGS" -gcflags="$GCFLAGS" ./cmd/$CMD
 
-    if [ $DEBUG ]; then
-      go build $RACE -ldflags="$LDFLAGS" -gcflags="$GCFLAGS" -tags debug -v ./cmd/$CMD
-    else
-      go build $RACE -ldflags="$LDFLAGS $STRIP" -gcflags="$GCFLAGS" -v ./cmd/$CMD
-    fi
     if [ $UPX ]; then
       upx --brute $CMD
     fi

--- a/build
+++ b/build
@@ -19,16 +19,14 @@ do
   t) TABLES=true;;
   c) GCFLAGS="$GCFLAGS $OPTARG";;
   l) LDFLAGS="$LDFLAGS $OPTARG";;
-  d) ARGS="$ARGS -tags debug";;
+  d) ARGS="$ARGS -tags debug" DEBUG=true;;
   r) ARGS="$ARGS -race";;
   o) ARGS="$ARGS -o $OPTARG";;
   esac
 done
 
-if [ -z $TABLES ]; then
-  if [ "$ARGS" == "${ARGS/-tags debug/}" ]; then
-    LDFLAGS="$LDFLAGS -s -w"
-  fi
+if [ -z $TABLES ] && [ -z $DEBUG ]; then
+  LDFLAGS="$LDFLAGS -s -w"
 fi
 
 if [ $IOS ]; then

--- a/build
+++ b/build
@@ -26,7 +26,9 @@ do
 done
 
 if [ -z $TABLES ]; then
-  LDFLAGS="$LDFLAGS -s -w"
+  if [ "$ARGS" == "${ARGS/-tags debug/}" ]; then
+    LDFLAGS="$LDFLAGS -s -w"
+  fi
 fi
 
 if [ $IOS ]; then


### PR DESCRIPTION
This just cleans up the `build` script a little bit and adds a passthrough for the `-o` option to `go build`, which may come in useful in packaging scenarios.