### PR TITLE
Speedup

### DIFF
--- a/src/crypto/crypto.go
+++ b/src/crypto/crypto.go
@@ -172,7 +172,6 @@ func BoxOpen(shared *BoxSharedKey,
 	boxed []byte,
 	nonce *BoxNonce) ([]byte, bool) {
 	out := util.GetBytes()
-	//return append(out, boxed...), true //FIXME disabled crypto for benchmarking
 	s := (*[BoxSharedKeyLen]byte)(shared)
 	n := (*[BoxNonceLen]byte)(nonce)
 	unboxed, success := box.OpenAfterPrecomputation(out, boxed, n, s)
@@ -185,7 +184,6 @@ func BoxSeal(shared *BoxSharedKey, unboxed []byte, nonce *BoxNonce) ([]byte, *Bo
 	}
 	nonce.Increment()
 	out := util.GetBytes()
-	//return append(out, unboxed...), nonce // FIXME disabled crypto for benchmarking
 	s := (*[BoxSharedKeyLen]byte)(shared)
 	n := (*[BoxNonceLen]byte)(nonce)
 	boxed := box.SealAfterPrecomputation(out, unboxed, n, s)

--- a/src/crypto/crypto.go
+++ b/src/crypto/crypto.go
@@ -172,7 +172,7 @@ func BoxOpen(shared *BoxSharedKey,
 	boxed []byte,
 	nonce *BoxNonce) ([]byte, bool) {
 	out := util.GetBytes()
-	return append(out, boxed...), true
+	return append(out, boxed...), true //FIXME disabled crypto for benchmarking
 	s := (*[BoxSharedKeyLen]byte)(shared)
 	n := (*[BoxNonceLen]byte)(nonce)
 	unboxed, success := box.OpenAfterPrecomputation(out, boxed, n, s)
@@ -185,7 +185,7 @@ func BoxSeal(shared *BoxSharedKey, unboxed []byte, nonce *BoxNonce) ([]byte, *Bo
 	}
 	nonce.Increment()
 	out := util.GetBytes()
-	return append(out, unboxed...), nonce
+	return append(out, unboxed...), nonce // FIXME disabled crypto for benchmarking
 	s := (*[BoxSharedKeyLen]byte)(shared)
 	n := (*[BoxNonceLen]byte)(nonce)
 	boxed := box.SealAfterPrecomputation(out, unboxed, n, s)

--- a/src/crypto/crypto.go
+++ b/src/crypto/crypto.go
@@ -172,6 +172,7 @@ func BoxOpen(shared *BoxSharedKey,
 	boxed []byte,
 	nonce *BoxNonce) ([]byte, bool) {
 	out := util.GetBytes()
+	return append(out, boxed...), true
 	s := (*[BoxSharedKeyLen]byte)(shared)
 	n := (*[BoxNonceLen]byte)(nonce)
 	unboxed, success := box.OpenAfterPrecomputation(out, boxed, n, s)
@@ -184,6 +185,7 @@ func BoxSeal(shared *BoxSharedKey, unboxed []byte, nonce *BoxNonce) ([]byte, *Bo
 	}
 	nonce.Increment()
 	out := util.GetBytes()
+	return append(out, unboxed...), nonce
 	s := (*[BoxSharedKeyLen]byte)(shared)
 	n := (*[BoxNonceLen]byte)(nonce)
 	boxed := box.SealAfterPrecomputation(out, unboxed, n, s)

--- a/src/crypto/crypto.go
+++ b/src/crypto/crypto.go
@@ -172,7 +172,7 @@ func BoxOpen(shared *BoxSharedKey,
 	boxed []byte,
 	nonce *BoxNonce) ([]byte, bool) {
 	out := util.GetBytes()
-	return append(out, boxed...), true //FIXME disabled crypto for benchmarking
+	//return append(out, boxed...), true //FIXME disabled crypto for benchmarking
 	s := (*[BoxSharedKeyLen]byte)(shared)
 	n := (*[BoxNonceLen]byte)(nonce)
 	unboxed, success := box.OpenAfterPrecomputation(out, boxed, n, s)
@@ -185,7 +185,7 @@ func BoxSeal(shared *BoxSharedKey, unboxed []byte, nonce *BoxNonce) ([]byte, *Bo
 	}
 	nonce.Increment()
 	out := util.GetBytes()
-	return append(out, unboxed...), nonce // FIXME disabled crypto for benchmarking
+	//return append(out, unboxed...), nonce // FIXME disabled crypto for benchmarking
 	s := (*[BoxSharedKeyLen]byte)(shared)
 	n := (*[BoxNonceLen]byte)(nonce)
 	boxed := box.SealAfterPrecomputation(out, unboxed, n, s)

--- a/src/tuntap/conn.go
+++ b/src/tuntap/conn.go
@@ -72,11 +72,7 @@ func (s *tunConn) reader() (err error) {
 			}
 		} else if n > 0 {
 			bs := append(util.GetBytes(), b[:n]...)
-			select {
-			case s.tun.send <- bs:
-			default:
-				util.PutBytes(bs)
-			}
+			s.tun.send <- bs
 			s.stillAlive()
 		}
 	}

--- a/src/tuntap/conn.go
+++ b/src/tuntap/conn.go
@@ -54,13 +54,13 @@ func (s *tunConn) reader() (err error) {
 	s.tun.log.Debugln("Starting conn reader for", s.conn.String())
 	defer s.tun.log.Debugln("Stopping conn reader for", s.conn.String())
 	var n int
-	b := make([]byte, 65535)
 	for {
 		select {
 		case <-s.stop:
 			return nil
 		default:
 		}
+		b := util.ResizeBytes(util.GetBytes(), 65535)
 		if n, err = s.conn.Read(b); err != nil {
 			if e, eok := err.(yggdrasil.ConnError); eok && !e.Temporary() {
 				if e.Closed() {
@@ -71,9 +71,10 @@ func (s *tunConn) reader() (err error) {
 				return e
 			}
 		} else if n > 0 {
-			bs := append(util.GetBytes(), b[:n]...)
-			s.tun.send <- bs
+			s.tun.send <- b[:n]
 			s.stillAlive()
+		} else {
+			util.PutBytes(b)
 		}
 	}
 }

--- a/src/tuntap/conn.go
+++ b/src/tuntap/conn.go
@@ -53,15 +53,14 @@ func (s *tunConn) reader() (err error) {
 	}
 	s.tun.log.Debugln("Starting conn reader for", s.conn.String())
 	defer s.tun.log.Debugln("Stopping conn reader for", s.conn.String())
-	var n int
 	for {
 		select {
 		case <-s.stop:
 			return nil
 		default:
 		}
-		b := util.ResizeBytes(util.GetBytes(), 65535)
-		if n, err = s.conn.Read(b); err != nil {
+		var bs []byte
+		if bs, err = s.conn.ReadNoCopy(); err != nil {
 			if e, eok := err.(yggdrasil.ConnError); eok && !e.Temporary() {
 				if e.Closed() {
 					s.tun.log.Debugln(s.conn.String(), "TUN/TAP conn read debug:", err)
@@ -70,11 +69,11 @@ func (s *tunConn) reader() (err error) {
 				}
 				return e
 			}
-		} else if n > 0 {
-			s.tun.send <- b[:n]
+		} else if len(bs) > 0 {
+			s.tun.send <- bs
 			s.stillAlive()
 		} else {
-			util.PutBytes(b)
+			util.PutBytes(bs)
 		}
 	}
 }
@@ -93,12 +92,12 @@ func (s *tunConn) writer() error {
 		select {
 		case <-s.stop:
 			return nil
-		case b, ok := <-s.send:
+		case bs, ok := <-s.send:
 			if !ok {
 				return errors.New("send closed")
 			}
 			// TODO write timeout and close
-			if _, err := s.conn.Write(b); err != nil {
+			if err := s.conn.WriteNoCopy(bs); err != nil {
 				if e, eok := err.(yggdrasil.ConnError); !eok {
 					if e.Closed() {
 						s.tun.log.Debugln(s.conn.String(), "TUN/TAP generic write debug:", err)
@@ -109,9 +108,9 @@ func (s *tunConn) writer() error {
 					// TODO: This currently isn't aware of IPv4 for CKR
 					ptb := &icmp.PacketTooBig{
 						MTU:  int(e.PacketMaximumSize()),
-						Data: b[:900],
+						Data: bs[:900],
 					}
-					if packet, err := CreateICMPv6(b[8:24], b[24:40], ipv6.ICMPTypePacketTooBig, 0, ptb); err == nil {
+					if packet, err := CreateICMPv6(bs[8:24], bs[24:40], ipv6.ICMPTypePacketTooBig, 0, ptb); err == nil {
 						s.tun.send <- packet
 					}
 				} else {
@@ -124,7 +123,6 @@ func (s *tunConn) writer() error {
 			} else {
 				s.stillAlive()
 			}
-			util.PutBytes(b)
 		}
 	}
 }

--- a/src/tuntap/iface.go
+++ b/src/tuntap/iface.go
@@ -260,11 +260,8 @@ func (tun *TunAdapter) readerPacketHandler(ch chan []byte) {
 				tun.mutex.Unlock()
 				if tc != nil {
 					for _, packet := range packets {
-						select {
-						case tc.send <- packet:
-						default:
-							util.PutBytes(packet)
-						}
+						p := packet // Possibly required because of how range
+						tc.send <- p
 					}
 				}
 			}()
@@ -274,11 +271,7 @@ func (tun *TunAdapter) readerPacketHandler(ch chan []byte) {
 		}
 		// If we have a connection now, try writing to it
 		if isIn && session != nil {
-			select {
-			case session.send <- bs:
-			default:
-				util.PutBytes(bs)
-			}
+			session.send <- bs
 		}
 	}
 }

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -22,27 +22,16 @@ func UnlockThread() {
 }
 
 // This is used to buffer recently used slices of bytes, to prevent allocations in the hot loops.
-var byteStoreMutex sync.Mutex
-var byteStore [][]byte
+var byteStore = sync.Pool{New: func() interface{} { return []byte(nil) }}
 
 // Gets an empty slice from the byte store.
 func GetBytes() []byte {
-	byteStoreMutex.Lock()
-	defer byteStoreMutex.Unlock()
-	if len(byteStore) > 0 {
-		var bs []byte
-		bs, byteStore = byteStore[len(byteStore)-1][:0], byteStore[:len(byteStore)-1]
-		return bs
-	} else {
-		return nil
-	}
+	return byteStore.Get().([]byte)[:0]
 }
 
 // Puts a slice in the store.
 func PutBytes(bs []byte) {
-	byteStoreMutex.Lock()
-	defer byteStoreMutex.Unlock()
-	byteStore = append(byteStore, bs)
+	byteStore.Put(bs)
 }
 
 // This is a workaround to go's broken timer implementation

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -34,6 +34,15 @@ func PutBytes(bs []byte) {
 	byteStore.Put(bs)
 }
 
+// Gets a slice of the appropriate length, reusing existing slice capacity when possible
+func ResizeBytes(bs []byte, length int) []byte {
+	if cap(bs) >= length {
+		return bs[:length]
+	} else {
+		return make([]byte, length)
+	}
+}
+
 // This is a workaround to go's broken timer implementation
 func TimerStop(t *time.Timer) bool {
 	stopped := t.Stop()

--- a/src/util/workerpool.go
+++ b/src/util/workerpool.go
@@ -1,0 +1,29 @@
+package util
+
+import "runtime"
+
+var workerPool chan func()
+
+func init() {
+	maxProcs := runtime.GOMAXPROCS(0)
+	if maxProcs < 1 {
+		maxProcs = 1
+	}
+	workerPool = make(chan func(), maxProcs)
+	for idx := 0; idx < maxProcs; idx++ {
+		go func() {
+			for f := range workerPool {
+				f()
+			}
+		}()
+	}
+}
+
+// WorkerGo submits a job to a pool of GOMAXPROCS worker goroutines.
+// This is meant for short non-blocking functions f() where you could just go f(),
+// but you want some kind of backpressure to prevent spawning endless goroutines.
+// WorkerGo returns as soon as the function is queued to run, not when it finishes.
+// In Yggdrasil, these workers are used for certain cryptographic operations.
+func WorkerGo(f func()) {
+	workerPool <- f
+}

--- a/src/yggdrasil/dialer.go
+++ b/src/yggdrasil/dialer.go
@@ -69,6 +69,7 @@ func (d *Dialer) DialByNodeIDandMask(nodeID, nodeMask *crypto.NodeID) (*Conn, er
 	defer t.Stop()
 	select {
 	case <-conn.session.init:
+		conn.session.startWorkers(conn.cancel)
 		return conn, nil
 	case <-t.C:
 		conn.Close()

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -166,8 +166,8 @@ func (r *router) handleTraffic(packet []byte) {
 		return
 	}
 	select {
-	case sinfo.fromRouter <- &p: // FIXME ideally this should be front drop
-	default:
+	case sinfo.fromRouter <- &p:
+	case <-sinfo.cancel.Finished():
 		util.PutBytes(p.Payload)
 	}
 }

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -127,7 +127,6 @@ func (r *router) mainLoop() {
 				r.core.switchTable.doMaintenance()
 				r.core.dht.doMaintenance()
 				r.core.sessions.cleanup()
-				util.GetBytes() // To slowly drain things
 			}
 		case f := <-r.admin:
 			f()

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -166,7 +166,7 @@ func (r *router) handleTraffic(packet []byte) {
 		return
 	}
 	select {
-	case sinfo.recv <- &p: // FIXME ideally this should be front drop
+	case sinfo.fromRouter <- &p: // FIXME ideally this should be front drop
 	default:
 		util.PutBytes(p.Payload)
 	}

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -227,7 +227,7 @@ func (ss *sessions) createSession(theirPermKey *crypto.BoxPubKey) *sessionInfo {
 	sinfo.myHandle = *crypto.NewHandle()
 	sinfo.theirAddr = *address.AddrForNodeID(crypto.GetNodeID(&sinfo.theirPermPub))
 	sinfo.theirSubnet = *address.SubnetForNodeID(crypto.GetNodeID(&sinfo.theirPermPub))
-	sinfo.fromRouter = make(chan *wire_trafficPacket, 32)
+	sinfo.fromRouter = make(chan *wire_trafficPacket, 1)
 	sinfo.recv = make(chan []byte, 32)
 	sinfo.send = make(chan []byte, 32)
 	ss.sinfos[sinfo.myHandle] = &sinfo

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -463,6 +463,7 @@ func (sinfo *sessionInfo) recvWorker() {
 		ch := make(chan func(), 1)
 		poolFunc := func() {
 			bs, isOK = crypto.BoxOpen(&k, p.Payload, &p.Nonce)
+			util.PutBytes(p.Payload)
 			callback := func() {
 				if !isOK {
 					util.PutBytes(bs)

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -463,8 +463,8 @@ func (sinfo *sessionInfo) recvWorker() {
 		ch := make(chan func(), 1)
 		poolFunc := func() {
 			bs, isOK = crypto.BoxOpen(&k, p.Payload, &p.Nonce)
-			util.PutBytes(p.Payload)
 			callback := func() {
+				util.PutBytes(p.Payload)
 				if !isOK {
 					util.PutBytes(bs)
 					return
@@ -539,11 +539,14 @@ func (sinfo *sessionInfo) sendWorker() {
 			// Encrypt the packet
 			p.Payload, _ = crypto.BoxSeal(&k, bs, &p.Nonce)
 			packet := p.encode()
-			// Cleanup
-			util.PutBytes(bs)
-			util.PutBytes(p.Payload)
 			// The callback will send the packet
-			callback := func() { sinfo.core.router.out(packet) }
+			callback := func() {
+				// Cleanup
+				util.PutBytes(bs)
+				util.PutBytes(p.Payload)
+				// Send the packet
+				sinfo.core.router.out(packet)
+			}
 			ch <- callback
 		}
 		// Send to the worker and wait for it to finish

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -495,6 +495,7 @@ func (sinfo *sessionInfo) sendWorker() {
 			// TODO
 			var packet []byte
 			sessionFunc := func() {
+				defer util.PutBytes(bs)
 				sinfo.bytesSent += uint64(len(bs))
 				payload, nonce := crypto.BoxSeal(&sinfo.sharedSesKey, bs, &sinfo.myNonce)
 				defer util.PutBytes(payload)

--- a/src/yggdrasil/stream.go
+++ b/src/yggdrasil/stream.go
@@ -1,6 +1,7 @@
 package yggdrasil
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -13,10 +14,8 @@ import (
 var _ = linkInterfaceMsgIO(&stream{})
 
 type stream struct {
-	rwc         io.ReadWriteCloser
-	inputBuffer []byte                  // Incoming packet stream
-	frag        [2 * streamMsgSize]byte // Temporary data read off the underlying rwc, on its way to the inputBuffer
-	//outputBuffer [2 * streamMsgSize]byte // Temporary data about to be written to the rwc
+	rwc          io.ReadWriteCloser
+	inputBuffer  *bufio.Reader
 	outputBuffer net.Buffers
 }
 
@@ -32,6 +31,7 @@ func (s *stream) init(rwc io.ReadWriteCloser) {
 	// TODO have this also do the metadata handshake and create the peer struct
 	s.rwc = rwc
 	// TODO call something to do the metadata exchange
+	s.inputBuffer = bufio.NewReaderSize(s.rwc, 2*streamMsgSize)
 }
 
 // writeMsg writes a message with stream padding, and is *not* thread safe.
@@ -62,26 +62,11 @@ func (s *stream) writeMsg(bs []byte) (int, error) {
 // readMsg reads a message from the stream, accounting for stream padding, and is *not* thread safe.
 func (s *stream) readMsg() ([]byte, error) {
 	for {
-		buf := s.inputBuffer
-		msg, ok, err := stream_chopMsg(&buf)
-		switch {
-		case err != nil:
-			// Something in the stream format is corrupt
+		bs, err := s.readMsgFromBuffer()
+		if err != nil {
 			return nil, fmt.Errorf("message error: %v", err)
-		case ok:
-			// Copy the packet into bs, shift the buffer, and return
-			msg = append(util.GetBytes(), msg...)
-			s.inputBuffer = append(s.inputBuffer[:0], buf...)
-			return msg, nil
-		default:
-			// Wait for the underlying reader to return enough info for us to proceed
-			n, err := s.rwc.Read(s.frag[:])
-			if n > 0 {
-				s.inputBuffer = append(s.inputBuffer, s.frag[:n]...)
-			} else if err != nil {
-				return nil, err
-			}
 		}
+		return bs, err
 	}
 }
 
@@ -113,34 +98,30 @@ func (s *stream) _recvMetaBytes() ([]byte, error) {
 	return metaBytes, nil
 }
 
-// This takes a pointer to a slice as an argument. It checks if there's a
-// complete message and, if so, slices out those parts and returns the message,
-// true, and nil. If there's no error, but also no complete message, it returns
-// nil, false, and nil. If there's an error, it returns nil, false, and the
-// error, which the reader then handles (currently, by returning from the
-// reader, which causes the connection to close).
-func stream_chopMsg(bs *[]byte) ([]byte, bool, error) {
-	// Returns msg, ok, err
-	if len(*bs) < len(streamMsg) {
-		return nil, false, nil
+// Reads bytes from the underlying rwc and returns 1 full message
+func (s *stream) readMsgFromBuffer() ([]byte, error) {
+	pad := streamMsg // Copy
+	_, err := io.ReadFull(s.inputBuffer, pad[:])
+	if err != nil {
+		return nil, err
+	} else if pad != streamMsg {
+		return nil, errors.New("bad message")
 	}
-	for idx := range streamMsg {
-		if (*bs)[idx] != streamMsg[idx] {
-			return nil, false, errors.New("bad message")
+	lenSlice := make([]byte, 0, 10)
+	// FIXME this nextByte stuff depends on wire.go format, kind of ugly to have it here
+	nextByte := byte(0xff)
+	for nextByte > 127 {
+		nextByte, err = s.inputBuffer.ReadByte()
+		if err != nil {
+			return nil, err
 		}
+		lenSlice = append(lenSlice, nextByte)
 	}
-	msgLen, msgLenLen := wire_decode_uint64((*bs)[len(streamMsg):])
+	msgLen, _ := wire_decode_uint64(lenSlice)
 	if msgLen > streamMsgSize {
-		return nil, false, errors.New("oversized message")
+		return nil, errors.New("oversized message")
 	}
-	msgBegin := len(streamMsg) + msgLenLen
-	msgEnd := msgBegin + int(msgLen)
-	if msgLenLen == 0 || len(*bs) < msgEnd {
-		// We don't have the full message
-		// Need to buffer this and wait for the rest to come in
-		return nil, false, nil
-	}
-	msg := (*bs)[msgBegin:msgEnd]
-	(*bs) = (*bs)[msgEnd:]
-	return msg, true, nil
+	msg := util.ResizeBytes(util.GetBytes(), int(msgLen))
+	_, err = io.ReadFull(s.inputBuffer, msg)
+	return msg, err
 }

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -820,7 +820,7 @@ func (t *switchTable) doWorker() {
 				select {
 				case bs := <-t.toRouter:
 					buf = append(buf, bs)
-					for len(buf) > 32768 { // FIXME realistically don't drop anything, just for testing
+					for len(buf) > 32 {
 						util.PutBytes(buf[0])
 						buf = buf[1:]
 					}

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -820,7 +820,7 @@ func (t *switchTable) doWorker() {
 				select {
 				case bs := <-t.toRouter:
 					buf = append(buf, bs)
-					for len(buf) > 32 {
+					for len(buf) > 32768 { // FIXME realistically don't drop anything, just for testing
 						util.PutBytes(buf[0])
 						buf = buf[1:]
 					}


### PR DESCRIPTION
Attempt to fix #448, i.e. to speed up the code after v0.3.6 introduced some slowdowns as part of the refactoring to provide a `net.Conn` interface. 

On my machine, this currently improves speed from 3.3 Gbps to about 4.4 Gbps when running iperf3 between two instances of yggdrasil in two different network namespaces.

In theory, this should allow multiple packets associated with the same session to be encrypted and/or decrypted at the same time, without messing up packet order. However, I'm not sure this really happens much in practice, since locks need to be taken in several places. In principle some things could be refactored further to eliminate the lock contention, but I'm not certain if that's really the bottleneck or if there are still problems elsewhere.

Packets should only drop in the switch at this point, either while waiting for somewhere to send or waiting for the self node to have time to decrypt something. I'm also pretty sure this should be deadlock-free, or at least I don't see any places where goroutine cycles can form, but it's possible I may have overlooked something, so we'll want to let it sit in develop and stress test it for a while before we merge to master.