### PR TITLE
Fix the old flowkey stuff so congestion control actually works...

### DIFF
--- a/src/tuntap/conn.go
+++ b/src/tuntap/conn.go
@@ -96,8 +96,11 @@ func (s *tunConn) writer() error {
 			if !ok {
 				return errors.New("send closed")
 			}
-			// TODO write timeout and close
-			if err := s.conn.WriteNoCopy(bs); err != nil {
+			msg := yggdrasil.FlowKeyMessage{
+				FlowKey: util.GetFlowKey(bs),
+				Message: bs,
+			}
+			if err := s.conn.WriteNoCopy(msg); err != nil {
 				if e, eok := err.(yggdrasil.ConnError); !eok {
 					if e.Closed() {
 						s.tun.log.Debugln(s.conn.String(), "TUN/TAP generic write debug:", err)

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -166,7 +166,7 @@ func (r *router) handleTraffic(packet []byte) {
 		return
 	}
 	select {
-	case sinfo.fromRouter <- &p:
+	case sinfo.fromRouter <- p:
 	case <-sinfo.cancel.Finished():
 		util.PutBytes(p.Payload)
 	}


### PR DESCRIPTION
This got lost somewhere in the refactoring. Copied to a util function and added to `Conn.WriteNoCopy`. I'm not a huge fan of the interface, but I'd prefer to deploy the fix as soon as possible, and we an fix the interface later when we come up with a better idea.