### PR TITLE
Transform Listen statement to new format if needed

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -74,6 +74,12 @@ func readConfig(useconf *bool, useconffile *string, normaliseconf *bool) *config
 	if err := hjson.Unmarshal(conf, &dat); err != nil {
 		panic(err)
 	}
+	// Check for fields that have changed type recently, e.g. the Listen config
+	// option is now a []string rather than a string
+	if listen, ok := dat["Listen"].(string); ok {
+		dat["Listen"] = []string{listen}
+	}
+	// Sanitise the config
 	confJson, err := json.Marshal(dat)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
The `Listen` directive was changed to a `[]string` in v0.3.6 but proper parsing wasn't in place for non-array values. This fixes #483 so that now Yggdrasil will start correctly and `-normaliseconf` will do the right thing.