### PR TITLE
Search fixes

### DIFF
--- a/src/yggdrasil/conn.go
+++ b/src/yggdrasil/conn.go
@@ -130,9 +130,9 @@ func (c *Conn) doSearch() {
 			searchCompleted := func(sinfo *sessionInfo, e error) {}
 			sinfo = c.core.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
 			c.core.log.Debugf("%s DHT search started: %p", c.String(), sinfo)
+			// Start the search
+			sinfo.continueSearch()
 		}
-		// Continue the search
-		sinfo.continueSearch()
 	}
 	go func() { c.core.router.admin <- routerWork }()
 }

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -36,7 +36,6 @@ type searchInfo struct {
 	core     *Core
 	dest     crypto.NodeID
 	mask     crypto.NodeID
-	time     time.Time
 	toVisit  []*dhtInfo
 	visited  map[crypto.NodeID]bool
 	callback func(*sessionInfo, error)
@@ -65,17 +64,10 @@ func (s *searches) init(core *Core) {
 
 // Creates a new search info, adds it to the searches struct, and returns a pointer to the info.
 func (s *searches) createSearch(dest *crypto.NodeID, mask *crypto.NodeID, callback func(*sessionInfo, error)) *searchInfo {
-	now := time.Now()
-	//for dest, sinfo := range s.searches {
-	//	if now.Sub(sinfo.time) > time.Minute {
-	//		delete(s.searches, dest)
-	//	}
-	//}
 	info := searchInfo{
 		core:     s.core,
 		dest:     *dest,
 		mask:     *mask,
-		time:     now.Add(-time.Second),
 		callback: callback,
 	}
 	s.searches[*dest] = &info
@@ -154,10 +146,6 @@ func (sinfo *searchInfo) doSearchStep() {
 // If we've recenty sent a ping for this search, do nothing.
 // Otherwise, doSearchStep and schedule another continueSearch to happen after search_RETRY_TIME.
 func (sinfo *searchInfo) continueSearch() {
-	if time.Since(sinfo.time) < search_RETRY_TIME {
-		return
-	}
-	sinfo.time = time.Now()
 	sinfo.doSearchStep()
 	// In case the search dies, try to spawn another thread later
 	// Note that this will spawn multiple parallel searches as time passes
@@ -209,6 +197,8 @@ func (sinfo *searchInfo) checkDHTRes(res *dhtRes) bool {
 		if sess == nil {
 			// nil if the DHT search finished but the session wasn't allowed
 			sinfo.callback(nil, errors.New("session not allowed"))
+			// Cleanup
+			delete(sinfo.core.searches.searches, res.Dest)
 			return true
 		}
 		_, isIn := sinfo.core.sessions.getByTheirPerm(&res.Key)


### PR DESCRIPTION
Not sure if this does anything about #496, since I've been unable to reproduce it, but hopefully it was related the first change.

So the problem here is that searches had 2 ways of exiting without doing proper cleanup:
1. It was plausible that a search may stall if a time variable was checked and found to be slightly too recent (which *shouldn't* happen, with with e.g. instruction reordering etc it's hard to say it can't), so now searches *should* always eventually run the callback with either an error or a success.
2. There was an edge case where a search that failed to set up a session because of a session firewall issue would fail to clean up the old search, which would cause subsequent searches to attempt to continue the old search instead (and ultimately fail).

It also handles ending a search due to a dead-end wait long enough that any dht lookups we sent have a chance to respond first. This should make parallel search attempts play a little nicer with each other.