### PR TITLE
Try to fix leaks in #501

### DIFF
--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -179,7 +179,10 @@ func (intf *linkInterface) handler() error {
 		// That lets them do things like close connections on its own, avoid printing a connection message in the first place, etc.
 		intf.link.core.log.Debugln("DEBUG: found existing interface for", intf.name)
 		intf.msgIO.close()
-		<-oldIntf.closed
+		if !intf.incoming {
+			// Block outgoing connection attempts until the existing connection closes
+			<-oldIntf.closed
+		}
 		return nil
 	} else {
 		intf.closed = make(chan struct{})


### PR DESCRIPTION
This is an attempt to fix the goroutine leak in #501, which involved leaking goroutines from *incoming* connection attempts (note that the goroutine stack begins from the listener accepting an incoming connection).

Now, a goroutine should stick around (blocking further connection attempts) for *outgoing* connections only. Incoming connection attempts shouldn't cause a goroutine leak. There's still some question of why the incoming attempts happen in the first place... perhaps it's nodes running very old/outdated code? I unfortunately don't have a better guess at the moment.

If this continues to leak, then it means we are (for some reason) continuing to attempt outgoing connections when we already have one active. If that happens, then that's a separate bug we should also fix. Duplicate incoming connection attempts imply that there are outgoing connection attempts made from the other side, so that's plausibly still an issue...