### PR TITLE
Switch priority change

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smtodRU+gha3+BeqJ69lRk=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 h1:fHDIZ2oxGnUZRN6WgWFCbYBjH9uqVPRCUVUDhs0wnbA=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20181206074257-70b957f3b65e h1:njOxP/wVblhCLIUhjHXf6X+dzTt5OQ3vMQo9mkOIKIo=
@@ -53,6 +54,7 @@ golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3 h1:4y9KwBHBgBNwDbtu44R5o1fdO
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190812073006-9eafafc0a87e h1:TsjK5I7fXk8f2FQrgu6NS7i5Qih3knl2FL1htyguLRE=
 golang.org/x/sys v0.0.0-20190812073006-9eafafc0a87e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -676,7 +676,8 @@ func (t *switchTable) handleIn(packet []byte, idle map[switchPort]time.Time) boo
 			update = true
 		case cinfo.dist > bestDist:
 			//nothing
-		case thisTime.Before(bestTime):
+		case thisTime.After(bestTime):
+			// Pick the one that was used most recently -- at least this should pick the same link consistently in low-traffic scenarios
 			update = true
 		default:
 			//nothing

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -630,6 +630,16 @@ func switch_getPacketStreamID(packet []byte) string {
 	return string(switch_getPacketCoords(packet))
 }
 
+// Returns the flowlabel from a given set of coords
+func switch_getFlowLabelFromCoords(in []byte) []byte {
+	for i, v := range in {
+		if v == 0 {
+			return in[i+1:]
+		}
+	}
+	return []byte{}
+}
+
 // Find the best port for a given set of coords
 func (t *switchTable) bestPortForCoords(coords []byte) switchPort {
 	table := t.getTable()
@@ -667,20 +677,28 @@ func (t *switchTable) handleIn(packet []byte, idle map[switchPort]time.Time) boo
 		var update bool
 		switch {
 		case to == nil:
-			//nothing
+			// no port was found, ignore it
 		case !isIdle:
-			//nothing
+			// the port is busy, ignore it
 		case best == nil:
+			// this is the first idle port we've found, so select it until we find a
+			// better candidate port to use instead
 			update = true
 		case cinfo.dist < bestDist:
+			// the port takes a shorter path/is more direct than our current
+			// candidate, so select that instead
 			update = true
 		case cinfo.dist > bestDist:
-			//nothing
+			// the port takes a longer path/is less direct than our current candidate,
+			// ignore it
 		case thisTime.After(bestTime):
-			// Pick the one that was used most recently -- at least this should pick the same link consistently in low-traffic scenarios
+			// all else equal, this port was used more recently than our current
+			// candidate, so choose that instead. this should mean that, in low
+			// traffic scenarios, we consistently pick the same link which helps with
+			// packet ordering
 			update = true
 		default:
-			//nothing
+			// the search for a port has finished
 		}
 		if update {
 			best = to
@@ -693,10 +711,9 @@ func (t *switchTable) handleIn(packet []byte, idle map[switchPort]time.Time) boo
 		delete(idle, best.port)
 		best.sendPacket(packet)
 		return true
-	} else {
-		// Didn't find anyone idle to send it to
-		return false
 	}
+	// Didn't find anyone idle to send it to
+	return false
 }
 
 // Info about a buffered packet


### PR DESCRIPTION
When there are multiple next hops that a path could take, and they all appear equally good, use the one that's been idle for the *shortest* amount of time instead of the longest.

This should at least be consistent in however it behaves. Currently, it uses the one that was idle the longest, in a round-robin style, but that leads to a lot of packet reordering.

With this change, it's possible that TCP may not throttle up high enough to kick things from a slow link onto a faster link (that's what the round-robin was for), so this isn't a prefect fix, but maybe it's a better default behavior while we search for an alternative.