### PR TITLE
Deprecate IPv4Sources and IPv6Sources CKR options 

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -76,9 +76,7 @@ type SessionFirewall struct {
 type TunnelRouting struct {
 	Enable           bool              `comment:"Enable or disable tunnel routing."`
 	IPv6Destinations map[string]string `comment:"IPv6 CIDR subnets, mapped to the EncryptionPublicKey to which they\nshould be routed, e.g. { \"aaaa:bbbb:cccc::/e\": \"boxpubkey\", ... }"`
-	IPv6Sources      []string          `comment:"Optional IPv6 source subnets which are allowed to be tunnelled in\naddition to this node's Yggdrasil address/subnet. If not\nspecified, only traffic originating from this node's Yggdrasil\naddress or subnet will be tunnelled."`
 	IPv4Destinations map[string]string `comment:"IPv4 CIDR subnets, mapped to the EncryptionPublicKey to which they\nshould be routed, e.g. { \"a.b.c.d/e\": \"boxpubkey\", ... }"`
-	IPv4Sources      []string          `comment:"IPv4 source subnets which are allowed to be tunnelled. Unlike for\nIPv6, this option is required for bridging IPv4 traffic. Only\ntraffic with a source matching these subnets will be tunnelled."`
 }
 
 // SwitchOptions contains tuning options for the switch

--- a/src/tuntap/admin.go
+++ b/src/tuntap/admin.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"net"
 
 	"github.com/yggdrasil-network/yggdrasil-go/src/admin"
 )
@@ -66,30 +65,12 @@ func (t *TunAdapter) SetupAdminHandlers(a *admin.AdminSocket) {
 		t.ckr.setEnabled(enabled)
 		return admin.Info{"enabled": enabled}, nil
 	})
-	a.AddHandler("addSourceSubnet", []string{"subnet"}, func(in admin.Info) (admin.Info, error) {
-		if err := t.ckr.addSourceSubnet(in["subnet"].(string)); err == nil {
-			return admin.Info{"added": []string{in["subnet"].(string)}}, nil
-		} else {
-			return admin.Info{"not_added": []string{in["subnet"].(string)}}, errors.New("Failed to add source subnet")
-		}
-	})
 	a.AddHandler("addRoute", []string{"subnet", "box_pub_key"}, func(in admin.Info) (admin.Info, error) {
 		if err := t.ckr.addRoute(in["subnet"].(string), in["box_pub_key"].(string)); err == nil {
 			return admin.Info{"added": []string{fmt.Sprintf("%s via %s", in["subnet"].(string), in["box_pub_key"].(string))}}, nil
 		} else {
 			return admin.Info{"not_added": []string{fmt.Sprintf("%s via %s", in["subnet"].(string), in["box_pub_key"].(string))}}, errors.New("Failed to add route")
 		}
-	})
-	a.AddHandler("getSourceSubnets", []string{}, func(in admin.Info) (admin.Info, error) {
-		var subnets []string
-		getSourceSubnets := func(snets []net.IPNet) {
-			for _, subnet := range snets {
-				subnets = append(subnets, subnet.String())
-			}
-		}
-		getSourceSubnets(t.ckr.ipv4sources)
-		getSourceSubnets(t.ckr.ipv6sources)
-		return admin.Info{"source_subnets": subnets}, nil
 	})
 	a.AddHandler("getRoutes", []string{}, func(in admin.Info) (admin.Info, error) {
 		routes := make(admin.Info)
@@ -101,13 +82,6 @@ func (t *TunAdapter) SetupAdminHandlers(a *admin.AdminSocket) {
 		getRoutes(t.ckr.ipv4routes)
 		getRoutes(t.ckr.ipv6routes)
 		return admin.Info{"routes": routes}, nil
-	})
-	a.AddHandler("removeSourceSubnet", []string{"subnet"}, func(in admin.Info) (admin.Info, error) {
-		if err := t.ckr.removeSourceSubnet(in["subnet"].(string)); err == nil {
-			return admin.Info{"removed": []string{in["subnet"].(string)}}, nil
-		} else {
-			return admin.Info{"not_removed": []string{in["subnet"].(string)}}, errors.New("Failed to remove source subnet")
-		}
 	})
 	a.AddHandler("removeRoute", []string{"subnet", "box_pub_key"}, func(in admin.Info) (admin.Info, error) {
 		if err := t.ckr.removeRoute(in["subnet"].(string), in["box_pub_key"].(string)); err == nil {

--- a/src/tuntap/iface.go
+++ b/src/tuntap/iface.go
@@ -187,11 +187,6 @@ func (tun *TunAdapter) readerPacketHandler(ch chan []byte) {
 			tun.log.Traceln("Unknown packet type, dropping")
 			continue
 		}
-		if tun.ckr.isEnabled() && !tun.ckr.isValidSource(srcAddr, addrlen) {
-			// The packet had a source address that doesn't belong to us or our
-			// configured crypto-key routing source subnets
-			continue
-		}
 		if !dstAddr.IsValid() && !dstSnet.IsValid() {
 			if key, err := tun.ckr.getPublicKeyForAddress(dstAddr, addrlen); err == nil {
 				// A public key was found, get the node ID for the search


### PR DESCRIPTION
This PR deprecates the `IPv4Sources` and `IPv6Sources` options in the crypto-key routing configuration and no longer performs source address checking in CKR scenarios.

These options were not well understood, didn't really do anything to increase security and increased the complexity of configuring CKR vs using Wireguard or similar.

`IPv4Destinations` and `IPv6Destinations` remain unchanged.