### PR TITLE
hopefully prevent a deadlock

### DIFF
--- a/src/yggdrasil/dialer.go
+++ b/src/yggdrasil/dialer.go
@@ -69,7 +69,6 @@ func (d *Dialer) DialByNodeIDandMask(nodeID, nodeMask *crypto.NodeID) (*Conn, er
 	defer t.Stop()
 	select {
 	case <-conn.session.init:
-		conn.session.startWorkers()
 		return conn, nil
 	case <-t.C:
 		conn.Close()


### PR DESCRIPTION
This should hopefully prevent an edge case where a deadlock could occur, if somehow a session was used without session workers having been started yet, or where a race between a dial and the remote end opening a session could theoretically launch multiple session workers for the same session.