### PR TITLE
Memory

### DIFF
--- a/build
+++ b/build
@@ -34,13 +34,15 @@ if [ $IOS ]; then
   gomobile bind -target ios -tags mobile -ldflags="$LDFLAGS $STRIP" -gcflags="$GCFLAGS" \
     github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil \
     github.com/yggdrasil-network/yggdrasil-go/src/config \
-    github.com/yggdrasil-network/yggdrasil-extras/src/mobile
+    github.com/yggdrasil-network/yggdrasil-extras/src/mobile \
+    github.com/yggdrasil-network/yggdrasil-extras/src/dummy
 elif [ $ANDROID ]; then
   echo "Building aar for Android"
   gomobile bind -target android -tags mobile -ldflags="$LDFLAGS $STRIP" -gcflags="$GCFLAGS" \
     github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil \
     github.com/yggdrasil-network/yggdrasil-go/src/config \
-    github.com/yggdrasil-network/yggdrasil-extras/src/mobile
+    github.com/yggdrasil-network/yggdrasil-extras/src/mobile \
+    github.com/yggdrasil-network/yggdrasil-extras/src/dummy
 else
   for CMD in `ls cmd/` ; do
     echo "Building: $CMD"

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/yggdrasil-network/yggdrasil-go
 
 require (
-	github.com/Arceliar/phony v0.0.0-20190831050304-94a6d3da9ba4
+	github.com/Arceliar/phony v0.0.0-20190831212216-7018ff05d824
 	github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hjson/hjson-go v0.0.0-20181010104306-a25ecf6bd222

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/yggdrasil-network/yggdrasil-go
 
 require (
-	github.com/Arceliar/phony v0.0.0-20190831212216-7018ff05d824
+	github.com/Arceliar/phony v0.0.0-20190831214819-9b642ea019ad
 	github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hjson/hjson-go v0.0.0-20181010104306-a25ecf6bd222

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Arceliar/phony v0.0.0-20190831212216-7018ff05d824 h1:JY7qh6yR87H8xgPUTYrrqa5cajb7zynKsbAdjhsVkyU=
-github.com/Arceliar/phony v0.0.0-20190831212216-7018ff05d824/go.mod h1:6Lkn+/zJilRMsKmbmG1RPoamiArC6HS73xbwRyp3UyI=
+github.com/Arceliar/phony v0.0.0-20190831214819-9b642ea019ad h1:670inqspOp+tAnSvkOBgrKGOIT4605Jt+6KGi2j2/S8=
+github.com/Arceliar/phony v0.0.0-20190831214819-9b642ea019ad/go.mod h1:6Lkn+/zJilRMsKmbmG1RPoamiArC6HS73xbwRyp3UyI=
 github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8 h1:WD8iJ37bRNwvETMfVTusVSAi0WdXTpfNVGY2aHycNKY=
 github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8/go.mod h1:gq31gQ8wEHkR+WekdWsqDuf8pXTUZA9BnnzTuPz1Y9U=
 github.com/hashicorp/go-syslog v1.0.0 h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Arceliar/phony v0.0.0-20190831050304-94a6d3da9ba4 h1:OePImnPRBqS6JiHuVVq4Rfvt2yyhqMpWCB63PrwGrJE=
-github.com/Arceliar/phony v0.0.0-20190831050304-94a6d3da9ba4/go.mod h1:6Lkn+/zJilRMsKmbmG1RPoamiArC6HS73xbwRyp3UyI=
+github.com/Arceliar/phony v0.0.0-20190831212216-7018ff05d824 h1:JY7qh6yR87H8xgPUTYrrqa5cajb7zynKsbAdjhsVkyU=
+github.com/Arceliar/phony v0.0.0-20190831212216-7018ff05d824/go.mod h1:6Lkn+/zJilRMsKmbmG1RPoamiArC6HS73xbwRyp3UyI=
 github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8 h1:WD8iJ37bRNwvETMfVTusVSAi0WdXTpfNVGY2aHycNKY=
 github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8/go.mod h1:gq31gQ8wEHkR+WekdWsqDuf8pXTUZA9BnnzTuPz1Y9U=
 github.com/hashicorp/go-syslog v1.0.0 h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=

--- a/src/util/bytes_mobile.go
+++ b/src/util/bytes_mobile.go
@@ -2,6 +2,12 @@
 
 package util
 
+import "runtime/debug"
+
+func init() {
+	debug.SetGCPercent(25)
+}
+
 // On mobile, just return a nil slice.
 func GetBytes() []byte {
 	return nil

--- a/src/util/bytes_mobile.go
+++ b/src/util/bytes_mobile.go
@@ -1,0 +1,13 @@
+//+build mobile
+
+package util
+
+// On mobile, just return a nil slice.
+func GetBytes() []byte {
+	return nil
+}
+
+// On mobile, don't do anything.
+func PutBytes(bs []byte) {
+	return
+}

--- a/src/util/bytes_other.go
+++ b/src/util/bytes_other.go
@@ -1,0 +1,18 @@
+//+build !mobile
+
+package util
+
+import "sync"
+
+// This is used to buffer recently used slices of bytes, to prevent allocations in the hot loops.
+var byteStore = sync.Pool{New: func() interface{} { return []byte(nil) }}
+
+// Gets an empty slice from the byte store.
+func GetBytes() []byte {
+	return byteStore.Get().([]byte)[:0]
+}
+
+// Puts a slice in the store.
+func PutBytes(bs []byte) {
+	byteStore.Put(bs)
+}

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -23,19 +22,6 @@ func LockThread() {
 // A wrapper around runtime.UnlockOSThread() so it doesn't need to be imported elsewhere.
 func UnlockThread() {
 	runtime.UnlockOSThread()
-}
-
-// This is used to buffer recently used slices of bytes, to prevent allocations in the hot loops.
-var byteStore = sync.Pool{New: func() interface{} { return []byte(nil) }}
-
-// Gets an empty slice from the byte store.
-func GetBytes() []byte {
-	return byteStore.Get().([]byte)[:0]
-}
-
-// Puts a slice in the store.
-func PutBytes(bs []byte) {
-	byteStore.Put(bs)
 }
 
 // Gets a slice of the appropriate length, reusing existing slice capacity when possible


### PR DESCRIPTION
Work-in-progress to reduce memory usage on `mobile` builds.

This has some security implications. Previously, we tracked old nonces received (the last 64 nonces, or all nonces for the last second, whichever was greater). We would reject packets if they were either older than the oldest known nonce, or one of the known nonces, so this prevented duplicate packets from ever emerging from a session.

Now, we track the highest nonce ever received (unless timestamped protocol traffic resets it) and the time we received that nonce. We allow a packet in if it's a new highest nonce ever, or if we received a new highest nonce every in the last 1 second. This means there's a 1 second window after legitimate traffic, during which replayed traffic could result in duplicate packets making it out of the tuntap. However, these packets have no effect on the session (in particular, session pings / searches to detect coord changes won't be blocked), and it saves us the (significant) memory associated with tracking old nonces.