### PR TITLE
Cleanup and possible bugfixes

### DIFF
--- a/src/tuntap/tun.go
+++ b/src/tuntap/tun.go
@@ -189,9 +189,11 @@ func (tun *TunAdapter) Stop() error {
 
 func (tun *TunAdapter) _stop() error {
 	tun.isOpen = false
-	// TODO: we have nothing that cleanly stops all the various goroutines opened
 	// by TUN/TAP, e.g. readers/writers, sessions
-	tun.iface.Close()
+	if tun.iface != nil {
+		// Just in case we failed to start up the iface for some reason, this can apparently happen on Windows
+		tun.iface.Close()
+	}
 	return nil
 }
 

--- a/src/tuntap/tun_windows.go
+++ b/src/tuntap/tun_windows.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	water "github.com/yggdrasil-network/water"
 )
@@ -42,6 +43,7 @@ func (tun *TunAdapter) setup(ifname string, iftapmode bool, addr string, mtu int
 		tun.log.Traceln(string(output))
 		return err
 	}
+	time.Sleep(time.Second) // FIXME artifical delay to give netsh time to take effect
 	// Bring the interface back up
 	cmd = exec.Command("netsh", "interface", "set", "interface", iface.Name(), "admin=ENABLED")
 	tun.log.Debugln("netsh command:", strings.Join(cmd.Args, " "))
@@ -51,6 +53,7 @@ func (tun *TunAdapter) setup(ifname string, iftapmode bool, addr string, mtu int
 		tun.log.Traceln(string(output))
 		return err
 	}
+	time.Sleep(time.Second) // FIXME artifical delay to give netsh time to take effect
 	// Get a new iface
 	iface, err = water.New(config)
 	if err != nil {
@@ -86,6 +89,7 @@ func (tun *TunAdapter) setupMTU(mtu int) error {
 		tun.log.Traceln(string(output))
 		return err
 	}
+	time.Sleep(time.Second) // FIXME artifical delay to give netsh time to take effect
 	return nil
 }
 
@@ -106,5 +110,6 @@ func (tun *TunAdapter) setupAddress(addr string) error {
 		tun.log.Traceln(string(output))
 		return err
 	}
+	time.Sleep(time.Second) // FIXME artifical delay to give netsh time to take effect
 	return nil
 }


### PR DESCRIPTION
Possibly helps with #471 by adding artificial delay so `netsh` commands have time to take effect before the next one is called. If it really is caused by a race between commands being issued and the tap state changes fully taking effect.

Fixes #490 and #521 (I think).