### PR TITLE
Bugfix

### DIFF
--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -204,6 +204,11 @@ func (sinfo *searchInfo) checkDHTRes(res *dhtRes) bool {
 		if !isIn {
 			panic("This should never happen")
 		}
+	} else {
+		sinfo.callback(nil, errors.New("session already exists"))
+		// Cleanup
+		delete(sinfo.searches.searches, res.Dest)
+		return true
 	}
 	// FIXME (!) replay attacks could mess with coords? Give it a handle (tstamp)?
 	sess.coords = res.Coords


### PR DESCRIPTION
Previously, races between `Dial` and either another `Dial` to the same node (e.g. one using a `200::/8` address and one using a `300::/8` address) or an `Accept`ed `Listen` could cause multiple `yggdrasil.Conn` to associate with the same session, which would do who-knows-what. Pinging a node simultaneously at a `200` and `300` address, when no session already existed, seemed to just blackhole them both in my quick tests.

This changes the behavior so that `Dial`'s search will fail if, when it finishes, it sees that a session to that node already exists. This seems to fix the `200`+`300` ping test by causing one of the `Dial`s to fail, and then redirecting any future traffic for either address to the same `Conn`.