### PR TITLE
Documentation updates

### DIFF
--- a/src/address/address.go
+++ b/src/address/address.go
@@ -1,3 +1,5 @@
+// Package address contains the types used by yggdrasil to represent IPv6 addresses or prefixes, as well as functions for working with these types.
+// Of particular importance are the functions used to derive addresses or subnets from a NodeID, or to get the NodeID and bitmask of the bits visible from an address, which is needed for DHT searches.
 package address
 
 import "github.com/yggdrasil-network/yggdrasil-go/src/crypto"

--- a/src/address/address.go
+++ b/src/address/address.go
@@ -2,21 +2,21 @@ package address
 
 import "github.com/yggdrasil-network/yggdrasil-go/src/crypto"
 
-// address represents an IPv6 address in the yggdrasil address range.
+// Address represents an IPv6 address in the yggdrasil address range.
 type Address [16]byte
 
-// subnet represents an IPv6 /64 subnet in the yggdrasil subnet range.
+// Subnet represents an IPv6 /64 subnet in the yggdrasil subnet range.
 type Subnet [8]byte
 
-// address_prefix is the prefix used for all addresses and subnets in the network.
+// GetPrefix returns the address prefix used by yggdrasil.
 // The current implementation requires this to be a muliple of 8 bits + 7 bits.
 // The 8th bit of the last byte is used to signal nodes (0) or /64 prefixes (1).
-// Nodes that configure this differently will be unable to communicate with eachother, though routing and the DHT machinery *should* still work.
+// Nodes that configure this differently will be unable to communicate with eachother using IP packets, though routing and the DHT machinery *should* still work.
 func GetPrefix() [1]byte {
 	return [...]byte{0x02}
 }
 
-// isValid returns true if an address falls within the range used by nodes in the network.
+// IsValid returns true if an address falls within the range used by nodes in the network.
 func (a *Address) IsValid() bool {
 	prefix := GetPrefix()
 	for idx := range prefix {
@@ -27,7 +27,7 @@ func (a *Address) IsValid() bool {
 	return true
 }
 
-// isValid returns true if a prefix falls within the range usable by the network.
+// IsValid returns true if a prefix falls within the range usable by the network.
 func (s *Subnet) IsValid() bool {
 	prefix := GetPrefix()
 	l := len(prefix)
@@ -39,8 +39,8 @@ func (s *Subnet) IsValid() bool {
 	return (*s)[l-1] == prefix[l-1]|0x01
 }
 
-// address_addrForNodeID takes a *NodeID as an argument and returns an *address.
-// This subnet begins with the address prefix, with the last bit set to 0 to indicate an address.
+// AddrForNodeID takes a *NodeID as an argument and returns an *Address.
+// This address begins with the contents of GetPrefix(), with the last bit set to 0 to indicate an address.
 // The following 8 bits are set to the number of leading 1 bits in the NodeID.
 // The NodeID, excluding the leading 1 bits and the first leading 0 bit, is truncated to the appropriate length and makes up the remainder of the address.
 func AddrForNodeID(nid *crypto.NodeID) *Address {
@@ -80,7 +80,7 @@ func AddrForNodeID(nid *crypto.NodeID) *Address {
 	return &addr
 }
 
-// address_subnetForNodeID takes a *NodeID as an argument and returns a *subnet.
+// SubnetForNodeID takes a *NodeID as an argument and returns an *Address.
 // This subnet begins with the address prefix, with the last bit set to 1 to indicate a prefix.
 // The following 8 bits are set to the number of leading 1 bits in the NodeID.
 // The NodeID, excluding the leading 1 bits and the first leading 0 bit, is truncated to the appropriate length and makes up the remainder of the subnet.
@@ -96,10 +96,10 @@ func SubnetForNodeID(nid *crypto.NodeID) *Subnet {
 	return &snet
 }
 
-// getNodeIDandMask returns two *NodeID.
-// The first is a NodeID with all the bits known from the address set to their correct values.
-// The second is a bitmask with 1 bit set for each bit that was known from the address.
-// This is used to look up NodeIDs in the DHT and tell if they match an address.
+// GetNodeIDandMask returns two *NodeID.
+// The first is a NodeID with all the bits known from the Address set to their correct values.
+// The second is a bitmask with 1 bit set for each bit that was known from the Address.
+// This is used to look up NodeIDs in the DHT and tell if they match an Address.
 func (a *Address) GetNodeIDandMask() (*crypto.NodeID, *crypto.NodeID) {
 	// Mask is a bitmask to mark the bits visible from the address
 	// This means truncated leading 1s, first leading 0, and visible part of addr
@@ -126,10 +126,10 @@ func (a *Address) GetNodeIDandMask() (*crypto.NodeID, *crypto.NodeID) {
 	return &nid, &mask
 }
 
-// getNodeIDandMask returns two *NodeID.
-// The first is a NodeID with all the bits known from the address set to their correct values.
-// The second is a bitmask with 1 bit set for each bit that was known from the subnet.
-// This is used to look up NodeIDs in the DHT and tell if they match a subnet.
+// GetNodeIDandMask returns two *NodeID.
+// The first is a NodeID with all the bits known from the Subnet set to their correct values.
+// The second is a bitmask with 1 bit set for each bit that was known from the Subnet.
+// This is used to look up NodeIDs in the DHT and tell if they match a Subnet.
 func (s *Subnet) GetNodeIDandMask() (*crypto.NodeID, *crypto.NodeID) {
 	// As with the address version, but visible parts of the subnet prefix instead
 	var nid crypto.NodeID

--- a/src/crypto/crypto.go
+++ b/src/crypto/crypto.go
@@ -1,3 +1,6 @@
+// Package crypto is a wrapper around packages under golang.org/x/crypto/, particulaly curve25519, ed25519, and nacl/box.
+// This is used to avoid explicitly importing and using these packages throughout yggdrasil.
+// It also includes the all-important NodeID and TreeID types, which are used to identify nodes in the DHT and in the spanning tree's root selection algorithm, respectively.
 package crypto
 
 /*

--- a/src/util/bytes_mobile.go
+++ b/src/util/bytes_mobile.go
@@ -8,12 +8,14 @@ func init() {
 	debug.SetGCPercent(25)
 }
 
-// On mobile, just return a nil slice.
+// GetBytes always returns a nil slice on mobile platforms.
 func GetBytes() []byte {
 	return nil
 }
 
-// On mobile, don't do anything.
+// PutBytes does literally nothing on mobile platforms.
+// This is done rather than keeping a free list of bytes on platforms with memory constraints.
+// It's needed to help keep memory usage low enough to fall under the limits set for e.g. iOS NEPacketTunnelProvider apps.
 func PutBytes(bs []byte) {
 	return
 }

--- a/src/util/bytes_other.go
+++ b/src/util/bytes_other.go
@@ -7,12 +7,12 @@ import "sync"
 // This is used to buffer recently used slices of bytes, to prevent allocations in the hot loops.
 var byteStore = sync.Pool{New: func() interface{} { return []byte(nil) }}
 
-// Gets an empty slice from the byte store.
+// GetBytes returns a 0-length (possibly nil) slice of bytes from a free list, so it may have a larger capacity.
 func GetBytes() []byte {
 	return byteStore.Get().([]byte)[:0]
 }
 
-// Puts a slice in the store.
+// PutBytes stores a slice in a free list, where it can potentially be reused to prevent future allocations.
 func PutBytes(bs []byte) {
 	byteStore.Put(bs)
 }

--- a/src/util/cancellation.go
+++ b/src/util/cancellation.go
@@ -7,15 +7,22 @@ import (
 	"time"
 )
 
+// Cancellation is used to signal when things should shut down, such as signaling anything associated with a Conn to exit.
+// This is and is similar to a context, but with an error to specify the reason for the cancellation.
 type Cancellation interface {
-	Finished() <-chan struct{}
-	Cancel(error) error
-	Error() error
+	Finished() <-chan struct{} // Finished returns a channel which will be closed when Cancellation.Cancel is first called.
+	Cancel(error) error // Cancel closes the channel returned by Finished and sets the error returned by error, or else returns the existing error if the Cancellation has already run.
+	Error() error // Error returns the error provided to Cancel, or nil if no error has been provided.
 }
 
+// CancellationFinalized is an error returned if a cancellation object was garbage collected and the finalizer was run.
+// If you ever see this, then you're probably doing something wrong with your code.
 var CancellationFinalized = errors.New("finalizer called")
+
+// CancellationTimeoutError is used when a CancellationWithTimeout or CancellationWithDeadline is cancelled due to said timeout.
 var CancellationTimeoutError = errors.New("timeout")
 
+// CancellationFinalizer is set as a finalizer when creating a new cancellation with NewCancellation(), and generally shouldn't be needed by the user, but is included in case other implementations of the same interface want to make use of it.
 func CancellationFinalizer(c Cancellation) {
 	c.Cancel(CancellationFinalized)
 }
@@ -27,6 +34,7 @@ type cancellation struct {
 	done   bool
 }
 
+// NewCancellation returns a pointer to a struct satisfying the Cancellation interface.
 func NewCancellation() Cancellation {
 	c := cancellation{
 		cancel: make(chan struct{}),
@@ -35,10 +43,12 @@ func NewCancellation() Cancellation {
 	return &c
 }
 
+// Finished returns a channel which will be closed when Cancellation.Cancel is first called.
 func (c *cancellation) Finished() <-chan struct{} {
 	return c.cancel
 }
 
+// Cancel closes the channel returned by Finished and sets the error returned by error, or else returns the existing error if the Cancellation has already run.
 func (c *cancellation) Cancel(err error) error {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
@@ -52,6 +62,7 @@ func (c *cancellation) Cancel(err error) error {
 	}
 }
 
+// Error returns the error provided to Cancel, or nil if no error has been provided.
 func (c *cancellation) Error() error {
 	c.mutex.RLock()
 	err := c.err
@@ -59,6 +70,7 @@ func (c *cancellation) Error() error {
 	return err
 }
 
+// CancellationChild returns a new Cancellation which can be Cancelled independently of the parent, but which will also be Cancelled if the parent is Cancelled first.
 func CancellationChild(parent Cancellation) Cancellation {
 	child := NewCancellation()
 	go func() {
@@ -71,6 +83,7 @@ func CancellationChild(parent Cancellation) Cancellation {
 	return child
 }
 
+// CancellationWithTimeout returns a ChildCancellation that will automatically be Cancelled with a CancellationTimeoutError after the timeout.
 func CancellationWithTimeout(parent Cancellation, timeout time.Duration) Cancellation {
 	child := CancellationChild(parent)
 	go func() {
@@ -85,6 +98,7 @@ func CancellationWithTimeout(parent Cancellation, timeout time.Duration) Cancell
 	return child
 }
 
+// CancellationWithTimeout returns a ChildCancellation that will automatically be Cancelled with a CancellationTimeoutError after the specified deadline.
 func CancellationWithDeadline(parent Cancellation, deadline time.Time) Cancellation {
 	return CancellationWithTimeout(parent, deadline.Sub(time.Now()))
 }

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -9,22 +9,22 @@ import (
 	"time"
 )
 
-// A wrapper around runtime.Gosched() so it doesn't need to be imported elsewhere.
+// Yield just executes runtime.Gosched(), and is included so we don't need to explicitly import runtime elsewhere.
 func Yield() {
 	runtime.Gosched()
 }
 
-// A wrapper around runtime.LockOSThread() so it doesn't need to be imported elsewhere.
+// LockThread executes runtime.LockOSThread(), and is included so we don't need to explicitly import runtime elsewhere.
 func LockThread() {
 	runtime.LockOSThread()
 }
 
-// A wrapper around runtime.UnlockOSThread() so it doesn't need to be imported elsewhere.
+// UnlockThread executes runtime.UnlockOSThread(), and is included so we don't need to explicitly import runtime elsewhere.
 func UnlockThread() {
 	runtime.UnlockOSThread()
 }
 
-// Gets a slice of the appropriate length, reusing existing slice capacity when possible
+// ResizeBytes returns a slice of the specified length. If the provided slice has sufficient capacity, it will be resized and returned rather than allocating a new slice.
 func ResizeBytes(bs []byte, length int) []byte {
 	if cap(bs) >= length {
 		return bs[:length]
@@ -33,7 +33,7 @@ func ResizeBytes(bs []byte, length int) []byte {
 	}
 }
 
-// This is a workaround to go's broken timer implementation
+// TimerStop stops a timer and makes sure the channel is drained, returns true if the timer was stopped before firing.
 func TimerStop(t *time.Timer) bool {
 	stopped := t.Stop()
 	select {
@@ -43,10 +43,8 @@ func TimerStop(t *time.Timer) bool {
 	return stopped
 }
 
-// Run a blocking function with a timeout.
-// Returns true if the function returns.
-// Returns false if the timer fires.
-// The blocked function remains blocked--the caller is responsible for somehow killing it.
+// FuncTimeout runs the provided function in a separate goroutine, and returns true if the function finishes executing before the timeout passes, or false if the timeout passes.
+// It includes no mechanism to stop the function if the timeout fires, so the user is expected to do so on their own (such as with a Cancellation or a context).
 func FuncTimeout(f func(), timeout time.Duration) bool {
 	success := make(chan struct{})
 	go func() {
@@ -63,9 +61,8 @@ func FuncTimeout(f func(), timeout time.Duration) bool {
 	}
 }
 
-// This calculates the difference between two arrays and returns items
-// that appear in A but not in B - useful somewhat when reconfiguring
-// and working out what configuration items changed
+// Difference loops over two strings and returns the elements of A which do not appear in B.
+// This is somewhat useful when needing to determine which elements of a configuration file have changed.
 func Difference(a, b []string) []string {
 	ab := []string{}
 	mb := map[string]bool{}
@@ -93,7 +90,7 @@ func DecodeCoordString(in string) (out []uint64) {
 	return out
 }
 
-// GetFlowLabel takes an IP packet as an argument and returns some information about the traffic flow.
+// GetFlowKey takes an IP packet as an argument and returns some information about the traffic flow.
 // For IPv4 packets, this is derived from the source and destination protocol and port numbers.
 // For IPv6 packets, this is derived from the FlowLabel field of the packet if this was set, otherwise it's handled like IPv4.
 // The FlowKey is then used internally by Yggdrasil for congestion control.

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -1,3 +1,5 @@
+// Package util contains miscellaneous utilities used by yggdrasil.
+// In particular, this includes a crypto worker pool, Cancellation machinery, and a sync.Pool used to reuse []byte.
 package util
 
 // These are misc. utility functions that didn't really fit anywhere else

--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -16,29 +16,37 @@ import (
 )
 
 // Peer represents a single peer object. This contains information from the
-// preferred switch port for this peer, although there may be more than one in
-// reality.
+// preferred switch port for this peer, although there may be more than one
+// active switch port connection to the peer in reality.
+//
+// This struct is informational only - you cannot manipulate peer connections
+// using instances of this struct. You should use the AddPeer or RemovePeer
+// functions instead.
 type Peer struct {
-	PublicKey  crypto.BoxPubKey
-	Endpoint   string
-	BytesSent  uint64
-	BytesRecvd uint64
-	Protocol   string
-	Port       uint64
-	Uptime     time.Duration
+	PublicKey  crypto.BoxPubKey // The public key of the remote node
+	Endpoint   string           // The connection string used to connect to the peer
+	BytesSent  uint64           // Number of bytes sent to this peer
+	BytesRecvd uint64           // Number of bytes received from this peer
+	Protocol   string           // The transport protocol that this peer is connected with, typically "tcp"
+	Port       uint64           // Switch port number for this peer connection
+	Uptime     time.Duration    // How long this peering has been active for
 }
 
 // SwitchPeer represents a switch connection to a peer. Note that there may be
 // multiple switch peers per actual peer, e.g. if there are multiple connections
 // to a given node.
+//
+// This struct is informational only - you cannot manipulate switch peer
+// connections using instances of this struct. You should use the AddPeer or
+// RemovePeer functions instead.
 type SwitchPeer struct {
-	PublicKey  crypto.BoxPubKey
-	Coords     []uint64
-	BytesSent  uint64
-	BytesRecvd uint64
-	Port       uint64
-	Protocol   string
-	Endpoint   string
+	PublicKey  crypto.BoxPubKey // The public key of the remote node
+	Coords     []uint64         // The coordinates of the remote node
+	BytesSent  uint64           // Number of bytes sent via this switch port
+	BytesRecvd uint64           // Number of bytes received via this switch port
+	Port       uint64           // Switch port number for this switch peer
+	Protocol   string           // The transport protocol that this switch port is connected with, typically "tcp"
+	Endpoint   string           // The connection string used to connect to the switch peer
 }
 
 // DHTEntry represents a single DHT entry that has been learned or cached from
@@ -64,32 +72,36 @@ type NodeInfoPayload []byte
 // congestion and a list of switch queues created in response to congestion on a
 // given link.
 type SwitchQueues struct {
-	Queues       []SwitchQueue
-	Count        uint64
-	Size         uint64
-	HighestCount uint64
-	HighestSize  uint64
-	MaximumSize  uint64
+	Queues       []SwitchQueue // An array of SwitchQueue objects containing information about individual queues
+	Count        uint64        // The current number of active switch queues
+	Size         uint64        // The current total size of active switch queues
+	HighestCount uint64        // The highest recorded number of switch queues so far
+	HighestSize  uint64        // The highest recorded total size of switch queues so far
+	MaximumSize  uint64        // The maximum allowed total size of switch queues, as specified by config
 }
 
-// SwitchQueue represents a single switch queue, which is created in response
-// to congestion on a given link.
+// SwitchQueue represents a single switch queue. Switch queues are only created
+// in response to congestion on a given link and represent how much data has
+// been temporarily cached for sending once the congestion has cleared.
 type SwitchQueue struct {
-	ID      string
-	Size    uint64
-	Packets uint64
-	Port    uint64
+	ID      string // The ID of the switch queue
+	Size    uint64 // The total size, in bytes, of the queue
+	Packets uint64 // The number of packets in the queue
+	Port    uint64 // The switch port to which the queue applies
 }
 
-// Session represents an open session with another node.
+// Session represents an open session with another node. Sessions are opened in
+// response to traffic being exchanged between two nodes using Conn objects.
+// Note that sessions will automatically be closed by Yggdrasil if no traffic is
+// exchanged for around two minutes.
 type Session struct {
-	PublicKey   crypto.BoxPubKey
-	Coords      []uint64
-	BytesSent   uint64
-	BytesRecvd  uint64
-	MTU         uint16
-	Uptime      time.Duration
-	WasMTUFixed bool
+	PublicKey   crypto.BoxPubKey // The public key of the remote node
+	Coords      []uint64         // The coordinates of the remote node
+	BytesSent   uint64           // Bytes sent to the session
+	BytesRecvd  uint64           // Bytes received from the session
+	MTU         uint16           // The maximum supported message size of the session
+	Uptime      time.Duration    // How long this session has been active for
+	WasMTUFixed bool             // This field is no longer used
 }
 
 // GetPeers returns one or more Peer objects containing information about active

--- a/src/yggdrasil/doc.go
+++ b/src/yggdrasil/doc.go
@@ -125,6 +125,9 @@ Using Connections
 Conn objects are implementations of io.ReadWriteCloser, and as such, you can
 Read, Write and Close them as necessary.
 
+Each Read or Write operation can deal with a buffer with a maximum size of 65535
+bytes - any bigger than this and the operation will return an error.
+
 For example, to write to the Conn from the supplied buffer:
 
   buf := []byte{1, 2, 3, 4, 5}
@@ -151,6 +154,23 @@ When you are happy that a connection is no longer required, you can discard it:
   if err != nil {
     // ...
   }
+
+Limitations
+
+You should be aware of the following limitations when working with the Yggdrasil
+library:
+
+Individual messages written through Yggdrasil connections can not exceed 65535
+bytes in size. Yggdrasil has no concept of fragmentation, so if you try to send
+a message that exceeds 65535 bytes in size, it will be dropped altogether and
+an error will be returned.
+
+Yggdrasil connections are unreliable by nature. Messages are delivered on a
+best-effort basis, and employs congestion control where appropriate to ensure
+that congestion does not affect message transport, but Yggdrasil will not
+retransmit any messages that have been lost. If reliable delivery is important
+then you should manually implement acknowledgement and retransmission of
+messages.
 
 */
 package yggdrasil

--- a/src/yggdrasil/doc.go
+++ b/src/yggdrasil/doc.go
@@ -1,0 +1,156 @@
+/*
+Package yggdrasil implements the core functionality of the Yggdrasil Network.
+
+Introduction
+
+Yggdrasil is a proof-of-concept mesh network which provides end-to-end encrypted
+communication between nodes in a decentralised fashion. The network is arranged
+using a globally-agreed spanning tree which provides each node with a locator
+(coordinates relative to the root) and a distributed hash table (DHT) mechanism
+for finding other nodes.
+
+Each node also implements a router, which is responsible for encryption of
+traffic, searches and connections, and a switch, which is responsible ultimately
+for forwarding traffic across the network.
+
+While many Yggdrasil nodes in existence today are IP nodes - that is, they are
+transporting IPv6 packets, like a kind of mesh VPN - it is also possible to
+integrate Yggdrasil into your own applications and use it as a generic data
+transport, similar to UDP.
+
+This library is what you need to integrate and use Yggdrasil in your own
+application.
+
+Basics
+
+In order to start an Yggdrasil node, you should start by generating node
+configuration, which amongst other things, includes encryption keypairs which
+are used to generate the node's identity, and supply a logger which Yggdrasil's
+output will be written to.
+
+This may look something like this:
+
+  import (
+    "os"
+    "github.com/gologme/log"
+    "github.com/yggdrasil-network/yggdrasil-go/src/config"
+    "github.com/yggdrasil-network/yggdrasil-go/src/yggdrasil"
+  )
+
+  type node struct {
+    core   yggdrasil.Core
+    config *config.NodeConfig
+    log    *log.Logger
+  }
+
+You then can supply node configuration and a logger:
+
+  n := node{}
+  n.log = log.New(os.Stdout, "", log.Flags())
+  n.config = config.GenerateConfig()
+
+In the above example, we ask the config package to supply new configuration each
+time, which results in fresh encryption keys and therefore a new identity. It is
+normally preferable in most cases to persist node configuration onto the
+filesystem or into some configuration store so that the node's identity does not
+change each time that the program starts. Note that Yggdrasil will automatically
+fill in any missing configuration items with sane defaults.
+
+Once you have supplied a logger and some node configuration, you can then start
+the node:
+
+  n.core.Start(n.config, n.log)
+
+Add some peers to connect to the network:
+
+  n.core.AddPeer("tcp://some-host.net:54321", "")
+  n.core.AddPeer("tcp://[2001::1:2:3]:54321", "")
+  n.core.AddPeer("tcp://1.2.3.4:54321", "")
+
+You can also ask the API for information about our node:
+
+  n.log.Println("My node ID is", n.core.NodeID())
+  n.log.Println("My public key is", n.core.EncryptionPublicKey())
+  n.log.Println("My coords are", n.core.Coords())
+
+Incoming Connections
+
+Once your node is started, you can then listen for connections from other nodes
+by asking the API for a Listener:
+
+  listener, err := n.core.ConnListen()
+  if err != nil {
+    // ...
+  }
+
+The Listener has a blocking Accept function which will wait for incoming
+connections from remote nodes. It will return a Conn when a connection is
+received. If the node never receives any incoming connections then this function
+can block forever, so be prepared for that, perhaps by listening in a separate
+goroutine.
+
+Assuming that you have defined a myConnectionHandler function to deal with
+incoming connections:
+
+  for {
+    conn, err := listener.Accept()
+    if err != nil {
+      // ...
+    }
+
+    // We've got a new connection
+    go myConnectionHandler(conn)
+  }
+
+Outgoing Connections
+
+If you know the node ID of the remote node that you want to talk to, you can
+dial an outbound connection to it. To do this, you should first ask the API for
+a Dialer:
+
+  dialer, err := n.core.ConnDialer()
+  if err != nil {
+    // ...
+  }
+
+You can then dial using the 16-byte node ID in hexadecimal format, for example:
+
+  conn, err := dialer.Dial("nodeid", "24a58cfce691ec016b0f698f7be1bee983cea263781017e99ad3ef62b4ef710a45d6c1a072c5ce46131bd574b78818c9957042cafeeed13966f349e94eb771bf")
+  if err != nil {
+    // ...
+  }
+
+Using Connections
+
+Conn objects are implementations of io.ReadWriteCloser, and as such, you can
+Read, Write and Close them as necessary.
+
+For example, to write to the Conn from the supplied buffer:
+
+  buf := []byte{1, 2, 3, 4, 5}
+  w, err := conn.Write(buf)
+  if err != nil {
+    // ...
+  } else {
+    // written w bytes
+  }
+
+Reading from the Conn into the supplied buffer:
+
+  buf := make([]byte, 65535)
+  r, err := conn.Read(buf)
+  if err != nil {
+    // ...
+  } else {
+    // read r bytes
+  }
+
+When you are happy that a connection is no longer required, you can discard it:
+
+  err := conn.Close()
+  if err != nil {
+    // ...
+  }
+
+*/
+package yggdrasil


### PR DESCRIPTION
This contains various `godoc` documentation updates for the `src/yggdrasil` package so far.

My goal is:
- [ ] All exported `struct` types should be annotated
- [ ] `doc.go` should contain a sufficient amount of detail to be useful to someone who wants to embed Yggdrasil into their application
- [ ] Each exported function should have useful information documented, including any behaviours that should be known about
- [ ] Other non-`src/yggdrasil` modules should be included in this, e.g.
  - [x] `src/address` Address/subnet
  - [x] `src/crypto` Crypto
  - [x] `src/config` Config
  - [ ] `src/tuntap` TUN/TAP
  - [ ] `src/admin` Admin socket
  - [ ] `src/multicast` Multicast
  - [x] `src/util` Misc utilities
- [ ] Update the `README.md`
- [ ] Update the whitepaper with stuff like:
   - [ ] Switch magic, e.g. switch queues, flow labels, load balancing across multiple switch peers, queue sizes