### PR TITLE
Switch

### DIFF
--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -470,7 +470,14 @@ func (sinfo *sessionInfo) _recvPacket(p *wire_trafficPacket) {
 		callback := func() {
 			util.PutBytes(p.Payload)
 			if !isOK || k != sinfo.sharedSesKey || !sinfo._nonceIsOK(&p.Nonce) {
-				// Either we failed to decrypt, or the session was updated, or we received this packet in the mean time
+				// Either we failed to decrypt, or the session was updated, or we
+				// received this packet in the mean time
+				util.PutBytes(bs)
+				return
+			}
+			if sinfo.conn == nil {
+				// There's no connection associated with this session for some reason
+				// TODO: Figure out why this happens sometimes, it shouldn't
 				util.PutBytes(bs)
 				return
 			}

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -470,14 +470,7 @@ func (sinfo *sessionInfo) _recvPacket(p *wire_trafficPacket) {
 		callback := func() {
 			util.PutBytes(p.Payload)
 			if !isOK || k != sinfo.sharedSesKey || !sinfo._nonceIsOK(&p.Nonce) {
-				// Either we failed to decrypt, or the session was updated, or we
-				// received this packet in the mean time
-				util.PutBytes(bs)
-				return
-			}
-			if sinfo.conn == nil {
-				// There's no connection associated with this session for some reason
-				// TODO: Figure out why this happens sometimes, it shouldn't
+				// Either we failed to decrypt, or the session was updated, or we received this packet in the mean time
 				util.PutBytes(bs)
 				return
 			}

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -677,13 +677,10 @@ func (t *switchTable) _handleIn(packet []byte, idle map[switchPort]struct{}) boo
 	ports := t.core.peers.getPorts()
 	for _, cinfo := range closer {
 		to := ports[cinfo.elem.port]
-		_, isIdle := idle[cinfo.elem.port]
 		var update bool
 		switch {
 		case to == nil:
 			// no port was found, ignore it
-		case !isIdle:
-			// the port is busy, ignore it
 		case best == nil:
 			// this is the first idle port we've found, so select it until we find a
 			// better candidate port to use instead
@@ -713,6 +710,9 @@ func (t *switchTable) _handleIn(packet []byte, idle map[switchPort]struct{}) boo
 	}
 	if best != nil {
 		// Send to the best idle next hop
+		if _, isIdle := idle[best.elem.port]; !isIdle {
+			return false
+		}
 		delete(idle, best.elem.port)
 		ports[best.elem.port].sendPacketsFrom(t, [][]byte{packet})
 		return true


### PR DESCRIPTION
Something to try to stabilize switch behavior a bit.

When there are multiple idle links the same distance from the destination, send to the one which forwarded the most recent root update the fastest. That should tend towards selecting paths that give a low latency to the root, and also (hopefully) give relatively stable behavior, since root updates only happen so frequently.

If this does not work, we could also try only selecting the *best* link according to some metric, and buffer traffic if that link happens to be busy. That may be necessary if packets are coming in faster than we send them (particularly if TCP head-of-line blocking causes a bunch of packets to arrive all at once), since writes are probably inherently slower than reads.