### PR TITLE
Switch

### DIFF
--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -677,10 +677,13 @@ func (t *switchTable) _handleIn(packet []byte, idle map[switchPort]struct{}) boo
 	ports := t.core.peers.getPorts()
 	for _, cinfo := range closer {
 		to := ports[cinfo.elem.port]
+		_, isIdle := idle[cinfo.elem.port]
 		var update bool
 		switch {
 		case to == nil:
 			// no port was found, ignore it
+		case !isIdle:
+			// the port is busy, ignore it
 		case best == nil:
 			// this is the first idle port we've found, so select it until we find a
 			// better candidate port to use instead
@@ -710,9 +713,6 @@ func (t *switchTable) _handleIn(packet []byte, idle map[switchPort]struct{}) boo
 	}
 	if best != nil {
 		// Send to the best idle next hop
-		if _, isIdle := idle[best.elem.port]; !isIdle {
-			return false
-		}
 		delete(idle, best.elem.port)
 		ports[best.elem.port].sendPacketsFrom(t, [][]byte{packet})
 		return true


### PR DESCRIPTION
Reverts https://github.com/yggdrasil-network/yggdrasil-go/pull/542/commits/80ba24d51255c3751e2b25aceee52b20d59ff746 since this causes things to block *hard* if the shortest path (in terms of hop count) is unusably bad. Better to flap routes and make TCP unusably bad for 1 stream than to block *all* traffic.

I will open an issue describing the problem in detail and the requirements for a fix.

