### PR TITLE
Switch hack

### DIFF
--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -721,15 +721,6 @@ func (t *switchTable) _handleIn(packet []byte, idle map[switchPort]struct{}, sen
 			ports[best.elem.port].sendPacketsFrom(t, [][]byte{packet})
 			return true
 		}
-		//delete(idle, best.elem.port)
-		// Tell ourselves to send to this node later
-		// If another (e.g. even better) hop becomes idle in the mean time, it'll take the packet instead
-		// FIXME this is just a hack, but seems to help with stability...
-		//go t.Act(nil, func() {
-		//	t._idleIn(best.elem.port)
-		//})
-		//ports[best.elem.port].sendPacketsFrom(t, [][]byte{packet})
-		//return true
 	}
 	// Didn't find anyone idle to send it to
 	return false
@@ -799,6 +790,7 @@ func (b *switch_buffers) _cleanup(t *switchTable) {
 // Loops over packets and sends the newest one that's OK for this peer to send
 // Returns true if the peer is no longer idle, false if it should be added to the idle list
 func (t *switchTable) _handleIdle(port switchPort) bool {
+	// TODO? only send packets for which this is the best next hop that isn't currently blocked sending
 	to := t.core.peers.getPorts()[port]
 	if to == nil {
 		return true

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -233,8 +233,9 @@ func (t *tcp) call(saddr string, options interface{}, sintf string) {
 		}
 		defer func() {
 			// Block new calls for a little while, to mitigate livelock scenarios
-			time.Sleep(default_timeout)
-			time.Sleep(time.Duration(rand.Intn(1000)) * time.Millisecond)
+			rand.Seed(time.Now().UnixNano())
+			delay := default_timeout + time.Duration(rand.Intn(10000))*time.Millisecond
+			time.Sleep(delay)
 			t.mutex.Lock()
 			delete(t.calls, callname)
 			t.mutex.Unlock()


### PR DESCRIPTION
So the trick here is, when we receive a packet and have an idle link, don't immediately send to that link. Instead, remove the link from the idle list (as normal), but buffer the packet and launch a new goroutine that will (at some point in the future, at the scheduler's whim) send a message to the switch notifying it of the idle peer. What I hope it does is give the best link a chance to forward that packet and notify the switch that it's idle before the 2nd best link's fake idle notification gets back to the switch. I'm not convinced that it actually does that, but whatever is really happening, it *seems* to help things somewhat in my tests.

Running some tests in network namespaces with artificial latency, this patch seems to help. If a node has 2 links with identical latency, it seems to result in no retransmissions (after the first second or so) in iperf3. If a node has two links with wildly different latency, then it flaps a lot, but it still seems to be more stable than without (e.g. it holds steady at the average bandwidth instead of oscillating wildly).

Also added some minor change to how TCP delays after redialing, since this was taking too long to make namespaces settle into a working state when I started them up at the same time and added delay to the veth devices.