### PR TITLE
Packet length checks and logging

### DIFF
--- a/src/tuntap/iface.go
+++ b/src/tuntap/iface.go
@@ -148,6 +148,11 @@ func (tun *TunAdapter) _handlePacket(recvd []byte, err error) {
 	// Offset the buffer from now on so that we can ignore ethernet frames if
 	// they are present
 	bs := recvd[offset:]
+	// Check if the packet is long enough to detect if it's an ICMP packet or not
+	if len(bs) < 7 {
+		tun.log.Traceln("TUN/TAP iface read undersized unknown packet, length:", len(bs))
+		return
+	}
 	// If we detect an ICMP packet then hand it to the ICMPv6 module
 	if bs[6] == 58 {
 		// Found an ICMPv6 packet - we need to make sure to give ICMPv6 the full
@@ -175,6 +180,7 @@ func (tun *TunAdapter) _handlePacket(recvd []byte, err error) {
 	if bs[0]&0xf0 == 0x60 {
 		// Check if we have a fully-sized IPv6 header
 		if len(bs) < 40 {
+			tun.log.Traceln("TUN/TAP iface read undersized ipv6 packet, length:", len(bs))
 			return
 		}
 		// Check the packet size
@@ -188,6 +194,7 @@ func (tun *TunAdapter) _handlePacket(recvd []byte, err error) {
 	} else if bs[0]&0xf0 == 0x40 {
 		// Check if we have a fully-sized IPv4 header
 		if len(bs) < 20 {
+			tun.log.Traceln("TUN/TAP iface read undersized ipv6 packet, length:", len(bs))
 			return
 		}
 		// Check the packet size

--- a/src/tuntap/iface.go
+++ b/src/tuntap/iface.go
@@ -194,7 +194,7 @@ func (tun *TunAdapter) _handlePacket(recvd []byte, err error) {
 	} else if bs[0]&0xf0 == 0x40 {
 		// Check if we have a fully-sized IPv4 header
 		if len(bs) < 20 {
-			tun.log.Traceln("TUN/TAP iface read undersized ipv6 packet, length:", len(bs))
+			tun.log.Traceln("TUN/TAP iface read undersized ipv4 packet, length:", len(bs))
 			return
 		}
 		// Check the packet size

--- a/src/util/cancellation.go
+++ b/src/util/cancellation.go
@@ -11,8 +11,8 @@ import (
 // This is and is similar to a context, but with an error to specify the reason for the cancellation.
 type Cancellation interface {
 	Finished() <-chan struct{} // Finished returns a channel which will be closed when Cancellation.Cancel is first called.
-	Cancel(error) error // Cancel closes the channel returned by Finished and sets the error returned by error, or else returns the existing error if the Cancellation has already run.
-	Error() error // Error returns the error provided to Cancel, or nil if no error has been provided.
+	Cancel(error) error        // Cancel closes the channel returned by Finished and sets the error returned by error, or else returns the existing error if the Cancellation has already run.
+	Error() error              // Error returns the error provided to Cancel, or nil if no error has been provided.
 }
 
 // CancellationFinalized is an error returned if a cancellation object was garbage collected and the finalizer was run.


### PR DESCRIPTION
Fixes #553 I think, though it's still a mystery to me why undersized packets would be read in the first place. Adds some trace level logging in the places where we drop packets for being too short, in case we need to monitor this.