### PR TITLE
#60 Add simple tests and benchmark

### DIFF
--- a/src/yggdrasil/core_test.go
+++ b/src/yggdrasil/core_test.go
@@ -1,8 +1,11 @@
 package yggdrasil
 
 import (
+	"bytes"
+	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gologme/log"
 
@@ -27,7 +30,7 @@ func GetLoggerWithPrefix(prefix string) *log.Logger {
 	return l
 }
 
-func TestCore_Start(t *testing.T) {
+func CreateAndConnectTwo(t *testing.T) (*Core, *Core) {
 	nodeA := Core{}
 	_, err := nodeA.Start(GenerateConfig(), GetLoggerWithPrefix("A: "))
 	if err != nil {
@@ -44,4 +47,84 @@ func TestCore_Start(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if l := len(nodeA.GetPeers()); l != 1 {
+		t.Fatal("unexpected number of peers", l)
+	}
+	if l := len(nodeB.GetPeers()); l != 1 {
+		t.Fatal("unexpected number of peers", l)
+	}
+
+	return &nodeA, &nodeB
+}
+
+func TestCore_Start_Connect(t *testing.T) {
+	CreateAndConnectTwo(t)
+}
+
+func TestCore_Start_Transfer(t *testing.T) {
+	nodeA, nodeB := CreateAndConnectTwo(t)
+
+	// Listen
+	listener, err := nodeA.ConnListen()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	done := make(chan struct{})
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 64)
+		n, err := conn.Read(buf)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if n != 64 {
+			t.Error("missing data")
+			return
+		}
+		_, err = conn.Write(buf)
+		if err != nil {
+			t.Error(err)
+		}
+		done <- struct{}{}
+	}()
+
+	time.Sleep(3 * time.Second) // FIXME
+	// Dial
+	dialer, err := nodeB.ConnDialer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(nodeA.GetSwitchPeers())
+	t.Log(nodeB.GetSwitchPeers())
+	t.Log(nodeA.GetSessions())
+	t.Log(nodeB.GetSessions())
+	conn, err := dialer.Dial("nodeid", nodeA.NodeID().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	msg := make([]byte, 64)
+	rand.Read(msg)
+	conn.Write(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 64)
+	_, err = conn.Read(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Compare(msg, buf) != 0 {
+		t.Fatal("expected echo")
+	}
+	<-done
 }

--- a/src/yggdrasil/core_test.go
+++ b/src/yggdrasil/core_test.go
@@ -22,23 +22,26 @@ func GenerateConfig() *config.NodeConfig {
 	return cfg
 }
 
-func GetLoggerWithPrefix(prefix string) *log.Logger {
+func GetLoggerWithPrefix(prefix string, verbose bool) *log.Logger {
 	l := log.New(os.Stderr, prefix, log.Flags())
+	if !verbose {
+		return l
+	}
 	l.EnableLevel("info")
 	l.EnableLevel("warn")
 	l.EnableLevel("error")
 	return l
 }
 
-func CreateAndConnectTwo(t testing.TB) (*Core, *Core) {
+func CreateAndConnectTwo(t testing.TB, verbose bool) (*Core, *Core) {
 	nodeA := Core{}
-	_, err := nodeA.Start(GenerateConfig(), GetLoggerWithPrefix("A: "))
+	_, err := nodeA.Start(GenerateConfig(), GetLoggerWithPrefix("A: ", verbose))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	nodeB := Core{}
-	_, err = nodeB.Start(GenerateConfig(), GetLoggerWithPrefix("B: "))
+	_, err = nodeB.Start(GenerateConfig(), GetLoggerWithPrefix("B: ", verbose))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +74,7 @@ func WaitConnected(nodeA, nodeB *Core) bool {
 }
 
 func TestCore_Start_Connect(t *testing.T) {
-	CreateAndConnectTwo(t)
+	CreateAndConnectTwo(t, true)
 }
 
 func CreateEchoListener(t testing.TB, nodeA *Core, bufLen int, repeats int) chan struct{} {
@@ -114,7 +117,7 @@ func CreateEchoListener(t testing.TB, nodeA *Core, bufLen int, repeats int) chan
 }
 
 func TestCore_Start_Transfer(t *testing.T) {
-	nodeA, nodeB := CreateAndConnectTwo(t)
+	nodeA, nodeB := CreateAndConnectTwo(t, true)
 
 	msgLen := 1500
 	done := CreateEchoListener(t, nodeA, msgLen, 1)
@@ -151,7 +154,7 @@ func TestCore_Start_Transfer(t *testing.T) {
 }
 
 func BenchmarkCore_Start_Transfer(b *testing.B) {
-	nodeA, nodeB := CreateAndConnectTwo(b)
+	nodeA, nodeB := CreateAndConnectTwo(b, false)
 
 	msgLen := 1500 // typical MTU
 	done := CreateEchoListener(b, nodeA, msgLen, b.N)

--- a/src/yggdrasil/core_test.go
+++ b/src/yggdrasil/core_test.go
@@ -1,0 +1,47 @@
+package yggdrasil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gologme/log"
+
+	"github.com/yggdrasil-network/yggdrasil-go/src/config"
+)
+
+// GenerateConfig is modification
+func GenerateConfig() *config.NodeConfig {
+	cfg := config.GenerateConfig()
+	cfg.AdminListen = "none"
+	cfg.Listen = []string{"tcp://127.0.0.1:0"}
+	cfg.IfName = "none"
+
+	return cfg
+}
+
+func GetLoggerWithPrefix(prefix string) *log.Logger {
+	l := log.New(os.Stderr, prefix, log.Flags())
+	l.EnableLevel("info")
+	l.EnableLevel("warn")
+	l.EnableLevel("error")
+	return l
+}
+
+func TestCore_Start(t *testing.T) {
+	nodeA := Core{}
+	_, err := nodeA.Start(GenerateConfig(), GetLoggerWithPrefix("A: "))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nodeB := Core{}
+	_, err = nodeB.Start(GenerateConfig(), GetLoggerWithPrefix("B: "))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = nodeB.AddPeer("tcp://"+nodeA.link.tcp.getAddr().String(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This pull request adds:
 * test for peering connection between two nodes (on localhost),
 * test for message transfer between two nodes in both directions,
 * benchmark for transfer between nodes.

Tests should be considered sanity checks as they will not direct the developer to the particular point of failure.
Benchmark makes it easy to pinpoint places where performance can be improved when run with `cpu`/`memprofiler` or similar tools.