### PR TITLE
Systemd: tun module and capabilities

### DIFF
--- a/contrib/systemd/yggdrasil.service
+++ b/contrib/systemd/yggdrasil.service
@@ -8,6 +8,8 @@ Group=yggdrasil
 ProtectHome=true
 ProtectSystem=true
 SyslogIdentifier=yggdrasil
+CapabilityBoundSet=CAP_NET_ADMIN
+ExecStartPre=+/sbin/modprobe tun
 ExecStartPre=/bin/sh -ec "if ! test -s /etc/yggdrasil.conf; \
                 then umask 077; \
                 yggdrasil -genconf > /etc/yggdrasil.conf; \


### PR DESCRIPTION
- Enable (and limit to) capabilities that require to setup tun/tap interface.
- Ensure that tun module is active.