### PR TITLE
CKR deadlock fix

### DIFF
--- a/src/tuntap/conn.go
+++ b/src/tuntap/conn.go
@@ -31,7 +31,7 @@ func (s *tunConn) close() {
 }
 
 func (s *tunConn) _close_from_tun() {
-	s.conn.Close()
+	go s.conn.Close() // Just in case it blocks on actor operations
 	delete(s.tun.addrToConn, s.addr)
 	delete(s.tun.subnetToConn, s.snet)
 	func() {

--- a/src/yggdrasil/conn.go
+++ b/src/yggdrasil/conn.go
@@ -260,7 +260,7 @@ func (c *Conn) _write(msg FlowKeyMessage) error {
 	c.session.Act(c, func() {
 		// Send the packet
 		c.session._send(msg)
-		// Session keep-alive, while we wait for the crypto workers from sefnd
+		// Session keep-alive, while we wait for the crypto workers from send
 		switch {
 		case time.Since(c.session.time) > 6*time.Second:
 			if c.session.time.Before(c.session.pingTime) && time.Since(c.session.pingTime) > 6*time.Second {


### PR DESCRIPTION
Fixes #565.

When using CKR, the actor was calling `yggdrasil.Conn.RemoteAddr()`, but this function uses `phony.Block` under the hood, so it could deadlock under load. Some `yggdrasil.Conn` code was rewritten to make sure that the internal state needed for the `RemoteAddr()` call is finalized by the time the `Conn` is reachable by any outside code, so the `RemoteAddr()` implementation can safely read this info without needing to send a message to the actor or block, making it safe for other actors to use.

Theoretically, the same deadlock could happen when we call `yggdrasil.Conn.Close()`, so that now happens in a separate goroutine (since we don't need the return value or care when it finally closes, just as long as it does).