### PR TITLE
Reduce latency under load

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,3 +17,5 @@ require (
 	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
 	golang.org/x/text v0.3.2
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/yggdrasil-network/yggdrasil-go
 
 require (
-	github.com/Arceliar/phony v0.0.0-20190907031509-af5bdbeecab6
+	github.com/Arceliar/phony v0.0.0-20191004004458-c7ba8368bafa
 	github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hjson/hjson-go v3.0.1-0.20190209023717-9147687966d9+incompatible
@@ -17,5 +17,3 @@ require (
 	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a
 	golang.org/x/text v0.3.2
 )
-
-go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Arceliar/phony v0.0.0-20190907031509-af5bdbeecab6 h1:zMj5Q1V0yF4WNfV/FpXG6iXfPJ965Xc5asR2vHXanXc=
-github.com/Arceliar/phony v0.0.0-20190907031509-af5bdbeecab6/go.mod h1:6Lkn+/zJilRMsKmbmG1RPoamiArC6HS73xbwRyp3UyI=
+github.com/Arceliar/phony v0.0.0-20191004004458-c7ba8368bafa h1:bFoWgQ17NKP4FBB2Tnt1QZ8fZqrxLYORIlHUa5ioDjc=
+github.com/Arceliar/phony v0.0.0-20191004004458-c7ba8368bafa/go.mod h1:6Lkn+/zJilRMsKmbmG1RPoamiArC6HS73xbwRyp3UyI=
 github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8 h1:WD8iJ37bRNwvETMfVTusVSAi0WdXTpfNVGY2aHycNKY=
 github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8/go.mod h1:gq31gQ8wEHkR+WekdWsqDuf8pXTUZA9BnnzTuPz1Y9U=
 github.com/hashicorp/go-syslog v1.0.0 h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -104,7 +104,7 @@ type peer struct {
 	firstSeen  time.Time       // To track uptime for getPeers
 	linkOut    func([]byte)    // used for protocol traffic (bypasses the switch)
 	dinfo      *dhtInfo        // used to keep the DHT working
-	out        func([][]byte)  // Set up by whatever created the peers struct, used to send packets to other nodes
+	out        func([]byte)    // Set up by whatever created the peers struct, used to send packets to other nodes
 	done       (chan struct{}) // closed to exit the linkLoop
 	close      func()          // Called when a peer is removed, to close the underlying connection, or via admin api
 	// The below aren't actually useful internally, they're just gathered for getPeers statistics
@@ -244,22 +244,16 @@ func (p *peer) _handleTraffic(packet []byte) {
 	p.core.switchTable.packetInFrom(p, packet)
 }
 
-func (p *peer) sendPacketsFrom(from phony.Actor, packets [][]byte) {
+func (p *peer) sendPacketFrom(from phony.Actor, packet []byte) {
 	p.Act(from, func() {
-		p._sendPackets(packets)
+		p._sendPackets(packet)
 	})
 }
 
 // This just calls p.out(packet) for now.
-func (p *peer) _sendPackets(packets [][]byte) {
-	// Is there ever a case where something more complicated is needed?
-	// What if p.out blocks?
-	var size int
-	for _, packet := range packets {
-		size += len(packet)
-	}
-	p.bytesSent += uint64(size)
-	p.out(packets)
+func (p *peer) _sendPackets(packet []byte) {
+	p.bytesSent += uint64(len(packet))
+	p.out(packet)
 }
 
 // This wraps the packet in the inner (ephemeral) and outer (permanent) crypto layers.

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -62,7 +62,7 @@ func (r *router) init(core *Core) {
 		},
 	}
 	p := r.core.peers.newPeer(&r.core.boxPub, &r.core.sigPub, &crypto.BoxSharedKey{}, &self, nil)
-	p.out = func(packets [][]byte) { r.handlePackets(p, packets) }
+	p.out = func(packet []byte) { r.handlePacket(p, packet) }
 	r.out = func(bs []byte) { p.handlePacketFrom(r, bs) }
 	r.nodeinfo.init(r.core)
 	r.core.config.Mutex.RLock()
@@ -97,11 +97,9 @@ func (r *router) start() error {
 }
 
 // In practice, the switch will call this with 1 packet
-func (r *router) handlePackets(from phony.Actor, packets [][]byte) {
+func (r *router) handlePacket(from phony.Actor, packet []byte) {
 	r.Act(from, func() {
-		for _, packet := range packets {
-			r._handlePacket(packet)
-		}
+		r._handlePacket(packet)
 	})
 }
 

--- a/src/yggdrasil/stream.go
+++ b/src/yggdrasil/stream.go
@@ -38,12 +38,9 @@ func (s *stream) init(rwc io.ReadWriteCloser) {
 func (s *stream) writeMsg(bs []byte) (int, error) {
 	s.outputBuffer.Write(streamMsg[:])
 	s.outputBuffer.Write(wire_encode_uint64(uint64(len(bs))))
-	n, err := s.outputBuffer.Write(bs)
-	err2 := s.outputBuffer.Flush()
-	if err == nil {
-		err = err2
-	}
-	return n, err
+	s.outputBuffer.Write(bs)
+	s.outputBuffer.Flush() // TODO? delay flushing until we're idle
+	return len(bs), nil    // TODO? return an error? its not like we check for it...
 }
 
 // readMsg reads a message from the stream, accounting for stream padding, and is *not* thread safe.

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -60,6 +60,7 @@ func (t *tcp) setExtraOptions(c net.Conn) {
 	switch sock := c.(type) {
 	case *net.TCPConn:
 		sock.SetNoDelay(true)
+		sock.SetWriteBuffer(streamMsgSize)
 	// TODO something for socks5
 	default:
 	}


### PR DESCRIPTION
EDIT: needs more work, the bufferbloat is better but throughput suffers with high latency links.

In my tests, this changeset drastically reduces latency when under load. The parts that matter are the 1 line change in tcp.go and the change to writeMsg(s) in stream.go, the rest is just updated to match the slight change in API needed by the writeMsg change.

Between network namespaces with 10ms latency and 10 Mbps bandwidth limits attached to the link (so 20 ms round trip), when running iperf in the background to keep the link saturated, the latency before this patch would consistently climb to around the 2000 ms range and hover there. After this patch, the latency varies between around 40 and 120 ms in the best case, depending on MTU, and around 80 to 180 MTU in the worst case (less stable for small packets -- large packets seem to slowly climb in latency and then drop back down again).

Unfortunately, this does reduce speed someone for small packets, since it no longer bunches up many small packets to write them together in 1 syscall. There's room to improve this in the future, by delaying when the buffer flushes until the link is idle, but I'm not completely certain how to make that play nice with the timers to detect blocks on syscalls, so that's something to investigate in the future. Since sending many small packets is slower either way, I think cutting the latency by a factor of ~50 is worth more than the bandwidth we lose from this (it drops from ~600-700 to ~400-500 on my machine).

I also updated to the latest version of my `phony` library for the actor model stuff, though I expect that not to have noticeable affects on performance for this application.