### PR TITLE
Enable bbr for tcp sockets on linux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/yggdrasil-network/yggdrasil-go
 
 require (
-	github.com/Arceliar/phony v0.0.0-20190907031509-af5bdbeecab6
+	github.com/Arceliar/phony v0.0.0-20191004004458-c7ba8368bafa
 	github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hjson/hjson-go v3.0.1-0.20190209023717-9147687966d9+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Arceliar/phony v0.0.0-20190907031509-af5bdbeecab6 h1:zMj5Q1V0yF4WNfV/FpXG6iXfPJ965Xc5asR2vHXanXc=
-github.com/Arceliar/phony v0.0.0-20190907031509-af5bdbeecab6/go.mod h1:6Lkn+/zJilRMsKmbmG1RPoamiArC6HS73xbwRyp3UyI=
+github.com/Arceliar/phony v0.0.0-20191004004458-c7ba8368bafa h1:bFoWgQ17NKP4FBB2Tnt1QZ8fZqrxLYORIlHUa5ioDjc=
+github.com/Arceliar/phony v0.0.0-20191004004458-c7ba8368bafa/go.mod h1:6Lkn+/zJilRMsKmbmG1RPoamiArC6HS73xbwRyp3UyI=
 github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8 h1:WD8iJ37bRNwvETMfVTusVSAi0WdXTpfNVGY2aHycNKY=
 github.com/gologme/log v0.0.0-20181207131047-4e5d8ccb38e8/go.mod h1:gq31gQ8wEHkR+WekdWsqDuf8pXTUZA9BnnzTuPz1Y9U=
 github.com/hashicorp/go-syslog v1.0.0 h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=

--- a/src/yggdrasil/tcp_linux.go
+++ b/src/yggdrasil/tcp_linux.go
@@ -19,10 +19,14 @@ func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
 		bbr = unix.SetsockoptString(int(fd), unix.IPPROTO_TCP, unix.TCP_CONGESTION, "bbr")
 	})
 
-	switch {
-	case bbr != nil:
-		return bbr
-	default:
-		return control
+	// Log any errors
+	if bbr != nil {
+		t.link.core.log.Debugln("Failed to set tcp_congestion_control to bbr for socket, SetsockoptString error:", bbr)
 	}
+	if control != nil {
+		t.link.core.log.Debugln("Failed to set tcp_congestion_control to bbr for socket, Control error:", control)
+	}
+
+	// Return nil because errors here are not considered fatal for the connection, it just means congestion control is suboptimal
+	return nil
 }

--- a/src/yggdrasil/tcp_linux.go
+++ b/src/yggdrasil/tcp_linux.go
@@ -15,7 +15,6 @@ func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
 	var bbr error
 
 	control = c.Control(func(fd uintptr) {
-		// sys/socket.h: #define	SO_RECV_ANYIF	0x1104
 		bbr = unix.SetsockoptString(int(fd), unix.IPPROTO_TCP, unix.TCP_CONGESTION, "bbr")
 	})
 

--- a/src/yggdrasil/tcp_linux.go
+++ b/src/yggdrasil/tcp_linux.go
@@ -1,0 +1,28 @@
+// +build linux
+
+package yggdrasil
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// WARNING: This context is used both by net.Dialer and net.Listen in tcp.go
+
+func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
+	var control error
+	var bbr error
+
+	control = c.Control(func(fd uintptr) {
+		// sys/socket.h: #define	SO_RECV_ANYIF	0x1104
+		bbr = unix.SetsockoptString(int(fd), unix.IPPROTO_TCP, unix.TCP_CONGESTION, "bbr")
+	})
+
+	switch {
+	case bbr != nil:
+		return bbr
+	default:
+		return control
+	}
+}

--- a/src/yggdrasil/tcp_other.go
+++ b/src/yggdrasil/tcp_other.go
@@ -1,4 +1,4 @@
-// +build !darwin
+// +build !darwin,!linux
 
 package yggdrasil
 


### PR DESCRIPTION
Using the bbr congestion control mechanism on linux can massively reduce latency when under load. Ideally, this should be set system-wide with `sysctl -w net.ipv4.tcp_congestion_control=bbr`, but that's seems invasive. This patch uses a sockopt to set bbr congestion control on links to ygg peers.

You still get better performance if the endpoints of a connection have bbr enabled, since then they also react to the full end-to-end bufferbloat (including ygg's internal buffers), but enabling it at the link level seems to give *most* of the benefits (latency is ~25-33% as large as without enabling bbr).

I'm debating whether or not it makes sense to also *optionally* set it system-wide, but set that option to enabled by default, so linux users (with a recent enough kernel) have things "just work". I hesitate because that's kind of messy, since it would affect *all* applications running on the system, and it would remain in effect even after ygg exits.