### PR TITLE
fix nil pointer dereference in yggdrasil.Conn.search

### DIFF
--- a/src/yggdrasil/conn.go
+++ b/src/yggdrasil/conn.go
@@ -115,12 +115,12 @@ func (c *Conn) search() error {
 				default:
 					if sinfo != nil {
 						// Finish initializing the session
-						sinfo.setConn(nil, c)
-					}
-					c.session = sinfo
-					c.nodeID = crypto.GetNodeID(&c.session.theirPermPub)
-					for i := range c.nodeMask {
-						c.nodeMask[i] = 0xFF
+						c.session = sinfo
+						c.session.setConn(nil, c)
+						c.nodeID = crypto.GetNodeID(&c.session.theirPermPub)
+						for i := range c.nodeMask {
+							c.nodeMask[i] = 0xFF
+						}
 					}
 					err = e
 					close(done)


### PR DESCRIPTION
Fixes #568 
The `yggdrasil.Conn.search`  function was checking for a non-nil pointer before one of the places the returned session was being used, but not in another, so failed searches could cause a crash. This should now work correctly (I hope, but I'm apparently terrible at writing this one function).