### PR TITLE
Search bugfix

### DIFF
--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -205,6 +205,8 @@ func (sinfo *searchInfo) checkDHTRes(res *dhtRes) bool {
 			panic("This should never happen")
 		}
 	} else {
+		sess.coords = res.Coords         // In case coords have updated
+		sess.ping(sinfo.searches.router) // In case the remote side needs updating
 		sinfo.callback(nil, errors.New("session already exists"))
 		// Cleanup
 		delete(sinfo.searches.searches, res.Dest)

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -189,34 +189,34 @@ func (sinfo *searchInfo) checkDHTRes(res *dhtRes) bool {
 	if themMasked != destMasked {
 		return false
 	}
+	finishSearch := func(sess *sessionInfo, err error) {
+		if sess != nil {
+			// FIXME (!) replay attacks could mess with coords? Give it a handle (tstamp)?
+			sess.coords = res.Coords
+			sess.ping(sinfo.searches.router)
+		}
+		if err != nil {
+			sinfo.callback(nil, err)
+		} else {
+			sinfo.callback(sess, nil)
+		}
+		// Cleanup
+		delete(sinfo.searches.searches, res.Dest)
+	}
 	// They match, so create a session and send a sessionRequest
+	var err error
 	sess, isIn := sinfo.searches.router.sessions.getByTheirPerm(&res.Key)
 	if !isIn {
+		// Don't already have a session
 		sess = sinfo.searches.router.sessions.createSession(&res.Key)
 		if sess == nil {
-			// nil if the DHT search finished but the session wasn't allowed
-			sinfo.callback(nil, errors.New("session not allowed"))
-			// Cleanup
-			delete(sinfo.searches.searches, res.Dest)
-			return true
-		}
-		_, isIn := sinfo.searches.router.sessions.getByTheirPerm(&res.Key)
-		if !isIn {
+			err = errors.New("session not allowed")
+		} else if _, isIn := sinfo.searches.router.sessions.getByTheirPerm(&res.Key); !isIn {
 			panic("This should never happen")
 		}
 	} else {
-		sess.coords = res.Coords         // In case coords have updated
-		sess.ping(sinfo.searches.router) // In case the remote side needs updating
-		sinfo.callback(nil, errors.New("session already exists"))
-		// Cleanup
-		delete(sinfo.searches.searches, res.Dest)
-		return true
+		err = errors.New("session already exists")
 	}
-	// FIXME (!) replay attacks could mess with coords? Give it a handle (tstamp)?
-	sess.coords = res.Coords
-	sess.ping(sinfo.searches.router)
-	sinfo.callback(sess, nil)
-	// Cleanup
-	delete(sinfo.searches.searches, res.Dest)
+	finishSearch(sess, err)
 	return true
 }


### PR DESCRIPTION
This should fix an issue where a search for an existing session doesn't update the session's coords when the search completes. This can cause the session to enter a broken state if the remote end's coords change.