### PR TITLE
Have listen and dial return a net.Conn

### DIFF
--- a/src/address/address.go
+++ b/src/address/address.go
@@ -2,7 +2,11 @@
 // Of particular importance are the functions used to derive addresses or subnets from a NodeID, or to get the NodeID and bitmask of the bits visible from an address, which is needed for DHT searches.
 package address
 
-import "github.com/yggdrasil-network/yggdrasil-go/src/crypto"
+import (
+	"fmt"
+
+	"github.com/yggdrasil-network/yggdrasil-go/src/crypto"
+)
 
 // Address represents an IPv6 address in the yggdrasil address range.
 type Address [16]byte
@@ -128,6 +132,13 @@ func (a *Address) GetNodeIDandMask() (*crypto.NodeID, *crypto.NodeID) {
 	return &nid, &mask
 }
 
+// GetNodeIDLengthString returns a string representation of the known bits of the NodeID, along with the number of known bits, for use with yggdrasil.Dialer's Dial and DialContext functions.
+func (a *Address) GetNodeIDLengthString() string {
+	nid, mask := a.GetNodeIDandMask()
+	l := mask.PrefixLength()
+	return fmt.Sprintf("%s/%d", nid.String(), l)
+}
+
 // GetNodeIDandMask returns two *NodeID.
 // The first is a NodeID with all the bits known from the Subnet set to their correct values.
 // The second is a bitmask with 1 bit set for each bit that was known from the Subnet.
@@ -155,4 +166,11 @@ func (s *Subnet) GetNodeIDandMask() (*crypto.NodeID, *crypto.NodeID) {
 		mask[idx/8] |= 0x80 >> byte(idx%8)
 	}
 	return &nid, &mask
+}
+
+// GetNodeIDLengthString returns a string representation of the known bits of the NodeID, along with the number of known bits, for use with yggdrasil.Dialer's Dial and DialContext functions.
+func (s *Subnet) GetNodeIDLengthString() string {
+	nid, mask := s.GetNodeIDandMask()
+	l := mask.PrefixLength()
+	return fmt.Sprintf("%s/%d", nid.String(), l)
 }

--- a/src/tuntap/conn.go
+++ b/src/tuntap/conn.go
@@ -93,7 +93,7 @@ func (s *tunConn) _read(bs []byte) (err error) {
 			skip = true
 		} else if key, err := s.tun.ckr.getPublicKeyForAddress(srcAddr, addrlen); err == nil {
 			srcNodeID := crypto.GetNodeID(&key)
-			if s.conn.RemoteAddr() == *srcNodeID {
+			if *s.conn.RemoteAddr().(*crypto.NodeID) == *srcNodeID {
 				// This is the one allowed CKR case, where source and destination addresses are both good
 			} else {
 				// The CKR key associated with this address doesn't match the sender's NodeID
@@ -170,7 +170,7 @@ func (s *tunConn) _write(bs []byte) (err error) {
 			skip = true
 		} else if key, err := s.tun.ckr.getPublicKeyForAddress(dstAddr, addrlen); err == nil {
 			dstNodeID := crypto.GetNodeID(&key)
-			if s.conn.RemoteAddr() == *dstNodeID {
+			if *s.conn.RemoteAddr().(*crypto.NodeID) == *dstNodeID {
 				// This is the one allowed CKR case, where source and destination addresses are both good
 			} else {
 				// The CKR key associated with this address doesn't match the sender's NodeID

--- a/src/tuntap/tun.go
+++ b/src/tuntap/tun.go
@@ -52,7 +52,7 @@ type TunAdapter struct {
 	//mutex        sync.RWMutex // Protects the below
 	addrToConn   map[address.Address]*tunConn
 	subnetToConn map[address.Subnet]*tunConn
-	dials        map[crypto.NodeID][][]byte // Buffer of packets to send after dialing finishes
+	dials        map[string][][]byte // Buffer of packets to send after dialing finishes
 	isOpen       bool
 }
 
@@ -117,7 +117,7 @@ func (tun *TunAdapter) Init(config *config.NodeState, log *log.Logger, listener 
 	tun.dialer = dialer
 	tun.addrToConn = make(map[address.Address]*tunConn)
 	tun.subnetToConn = make(map[address.Subnet]*tunConn)
-	tun.dials = make(map[crypto.NodeID][][]byte)
+	tun.dials = make(map[string][][]byte)
 	tun.writer.tun = tun
 	tun.reader.tun = tun
 }

--- a/src/tuntap/tun.go
+++ b/src/tuntap/tun.go
@@ -219,7 +219,7 @@ func (tun *TunAdapter) handler() error {
 			return err
 		}
 		phony.Block(tun, func() {
-			if _, err := tun._wrap(conn); err != nil {
+			if _, err := tun._wrap(conn.(*yggdrasil.Conn)); err != nil {
 				// Something went wrong when storing the connection, typically that
 				// something already exists for this address or subnet
 				tun.log.Debugln("TUN/TAP handler wrap:", err)
@@ -237,9 +237,9 @@ func (tun *TunAdapter) _wrap(conn *yggdrasil.Conn) (c *tunConn, err error) {
 	}
 	c = &s
 	// Get the remote address and subnet of the other side
-	remoteNodeID := conn.RemoteAddr()
-	s.addr = *address.AddrForNodeID(&remoteNodeID)
-	s.snet = *address.SubnetForNodeID(&remoteNodeID)
+	remoteNodeID := conn.RemoteAddr().(*crypto.NodeID)
+	s.addr = *address.AddrForNodeID(remoteNodeID)
+	s.snet = *address.SubnetForNodeID(remoteNodeID)
 	// Work out if this is already a destination we already know about
 	atc, aok := tun.addrToConn[s.addr]
 	stc, sok := tun.subnetToConn[s.snet]

--- a/src/yggdrasil/conn.go
+++ b/src/yggdrasil/conn.go
@@ -3,6 +3,7 @@ package yggdrasil
 import (
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/yggdrasil-network/yggdrasil-go/src/crypto"
@@ -348,14 +349,14 @@ func (c *Conn) Close() (err error) {
 
 // LocalAddr returns the complete node ID of the local side of the connection.
 // This is always going to return your own node's node ID.
-func (c *Conn) LocalAddr() crypto.NodeID {
-	return *crypto.GetNodeID(&c.core.boxPub)
+func (c *Conn) LocalAddr() net.Addr {
+	return crypto.GetNodeID(&c.core.boxPub)
 }
 
 // RemoteAddr returns the complete node ID of the remote side of the connection.
-func (c *Conn) RemoteAddr() crypto.NodeID {
+func (c *Conn) RemoteAddr() net.Addr {
 	// RemoteAddr is set during the dial or accept, and isn't changed, so it's safe to access directly
-	return *c.nodeID
+	return c.nodeID
 }
 
 // SetDeadline is equivalent to calling both SetReadDeadline and

--- a/src/yggdrasil/dialer.go
+++ b/src/yggdrasil/dialer.go
@@ -72,19 +72,16 @@ func (d *Dialer) DialByNodeIDandMask(ctx context.Context, nodeID, nodeMask *cryp
 		return nil, err
 	}
 	conn.session.setConn(nil, conn)
-	var c context.Context
 	var cancel context.CancelFunc
-	const timeout = 6 * time.Second
-	if ctx != nil {
-		c, cancel = context.WithTimeout(ctx, timeout)
-	} else {
-		c, cancel = context.WithTimeout(context.Background(), timeout)
+	if ctx == nil {
+		ctx = context.Background()
 	}
+	ctx, cancel = context.WithTimeout(ctx, 6*time.Second)
 	defer cancel()
 	select {
 	case <-conn.session.init:
 		return conn, nil
-	case <-c.Done():
+	case <-ctx.Done():
 		conn.Close()
 		return nil, errors.New("session handshake timeout")
 	}

--- a/src/yggdrasil/dialer.go
+++ b/src/yggdrasil/dialer.go
@@ -19,15 +19,12 @@ type Dialer struct {
 
 // Dial opens a session to the given node. The first paramter should be "nodeid"
 // and the second parameter should contain a hexadecimal representation of the
-// target node ID. Internally, it uses DialContext with a 6-second timeout.
+// target node ID. It uses DialContext internally.
 func (d *Dialer) Dial(network, address string) (net.Conn, error) {
-	const timeout = 6 * time.Second
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	return d.DialContext(ctx, network, address)
+	return d.DialContext(nil, network, address)
 }
 
-// DialContext is used internally by Dial, and should only be used with a context that includes a timeout.
+// DialContext is used internally by Dial, and should only be used with a context that includes a timeout. It uses DialByNodeIDandMask internally.
 func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
 	var nodeID crypto.NodeID
 	var nodeMask crypto.NodeID
@@ -66,7 +63,7 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 }
 
 // DialByNodeIDandMask opens a session to the given node based on raw
-// NodeID parameters.
+// NodeID parameters. If ctx is nil or has no timeout, then a default timeout of 6 seconds will apply, beginning *after* the search finishes.
 func (d *Dialer) DialByNodeIDandMask(ctx context.Context, nodeID, nodeMask *crypto.NodeID) (net.Conn, error) {
 	conn := newConn(d.core, nodeID, nodeMask, nil)
 	if err := conn.search(); err != nil {
@@ -75,10 +72,19 @@ func (d *Dialer) DialByNodeIDandMask(ctx context.Context, nodeID, nodeMask *cryp
 		return nil, err
 	}
 	conn.session.setConn(nil, conn)
+	var c context.Context
+	var cancel context.CancelFunc
+	const timeout = 6 * time.Second
+	if ctx != nil {
+		c, cancel = context.WithTimeout(ctx, timeout)
+	} else {
+		c, cancel = context.WithTimeout(context.Background(), timeout)
+	}
+	defer cancel()
 	select {
 	case <-conn.session.init:
 		return conn, nil
-	case <-ctx.Done():
+	case <-c.Done():
 		conn.Close()
 		return nil, errors.New("session handshake timeout")
 	}

--- a/src/yggdrasil/listener.go
+++ b/src/yggdrasil/listener.go
@@ -13,7 +13,7 @@ type Listener struct {
 }
 
 // Accept blocks until a new incoming session is received
-func (l *Listener) Accept() (*Conn, error) {
+func (l *Listener) Accept() (net.Conn, error) {
 	select {
 	case c, ok := <-l.conn:
 		if !ok {


### PR DESCRIPTION
This PR adjust the `Listener` to return a `(net.Conn, err)` so as to match that part of the `net.Listener` interface. In doing so, the interface of `yggdrasil.Conn` was changed slightly to return `net.Addr` from `LocalAddr` and `RemoteAddr`, and the tun/tap code was updated to type assert things as needed to work with this interface.

Marked as unfinished / work-in-progress since I'm sure there's probably more low-hanging fruit we could add to this (e.g. match the `Dialer` interface too).