### PR TITLE
systemd: Allow ExecStartPre failures

### DIFF
--- a/contrib/systemd/yggdrasil.service
+++ b/contrib/systemd/yggdrasil.service
@@ -9,7 +9,7 @@ ProtectHome=true
 ProtectSystem=true
 SyslogIdentifier=yggdrasil
 CapabilityBoundSet=CAP_NET_ADMIN
-ExecStartPre=+/sbin/modprobe tun
+ExecStartPre=+-/sbin/modprobe tun
 ExecStartPre=/bin/sh -ec "if ! test -s /etc/yggdrasil.conf; \
                 then umask 077; \
                 yggdrasil -genconf > /etc/yggdrasil.conf; \


### PR DESCRIPTION
As per #573, this amends `ExecStartPre` to allow failures. This stops a failed `modprobe tun` from preventing Yggdrasil startup in, e.g. OpenVZ containers. 