### PR TITLE
Initial connection upgrade/TLS steganography 

### DIFF
--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -280,7 +280,14 @@ func (c *Core) ConnDialer() (*Dialer, error) {
 // "Listen" configuration item, e.g.
 // 		tcp://a.b.c.d:e
 func (c *Core) ListenTCP(uri string) (*TcpListener, error) {
-	return c.link.tcp.listen(uri)
+	return c.link.tcp.listen(uri, nil)
+}
+
+// ListenTLS starts a new TLS listener. The input URI should match that of the
+// "Listen" configuration item, e.g.
+// 		tls://a.b.c.d:e
+func (c *Core) ListenTLS(uri string) (*TcpListener, error) {
+	return c.link.tcp.listen(uri, c.link.tcp.tls.forListener)
 }
 
 // NodeID gets the node ID. This is derived from your router encryption keys.

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -93,9 +93,11 @@ func (l *link) call(uri string, sintf string) error {
 	pathtokens := strings.Split(strings.Trim(u.Path, "/"), "/")
 	switch u.Scheme {
 	case "tcp":
-		l.tcp.call(u.Host, nil, sintf)
+		l.tcp.call(u.Host, nil, sintf, nil)
 	case "socks":
-		l.tcp.call(pathtokens[0], u.Host, sintf)
+		l.tcp.call(pathtokens[0], u.Host, sintf, nil)
+	case "tls":
+		l.tcp.call(u.Host, nil, sintf, l.tcp.tls.forDialer)
 	default:
 		return errors.New("unknown call scheme: " + u.Scheme)
 	}
@@ -109,7 +111,10 @@ func (l *link) listen(uri string) error {
 	}
 	switch u.Scheme {
 	case "tcp":
-		_, err := l.tcp.listen(u.Host)
+		_, err := l.tcp.listen(u.Host, nil)
+		return err
+	case "tls":
+		_, err := l.tcp.listen(u.Host, l.tcp.tls.forListener)
 		return err
 	default:
 		return errors.New("unknown listen scheme: " + u.Scheme)

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -355,6 +355,7 @@ func (t *tcp) call(saddr string, options interface{}, sintf string, upgrade *Tcp
 func (t *tcp) handler(sock net.Conn, incoming bool, options interface{}, upgrade *TcpUpgrade) {
 	defer t.waitgroup.Done() // Happens after sock.close
 	defer sock.Close()
+	t.setExtraOptions(sock)
 	var upgraded bool
 	if upgrade != nil {
 		var err error
@@ -365,7 +366,6 @@ func (t *tcp) handler(sock net.Conn, incoming bool, options interface{}, upgrade
 			upgraded = true
 		}
 	}
-	t.setExtraOptions(sock)
 	stream := stream{}
 	stream.init(sock)
 	var name, proto, local, remote string

--- a/src/yggdrasil/tls.go
+++ b/src/yggdrasil/tls.go
@@ -38,6 +38,7 @@ func (t *tcptls) init(tcp *tcp) {
 
 	certBuf := &bytes.Buffer{}
 
+	// TODO: because NotAfter is finite, we should add some mechanism to regenerate the certificate and restart the listeners periodically for nodes with very high uptimes. Perhaps regenerate certs and restart listeners every few months or so.
 	pubtemp := x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
@@ -65,7 +66,7 @@ func (t *tcptls) init(tcp *tcp) {
 	t.config = &tls.Config{
 		RootCAs: cpool,
 		Certificates: []tls.Certificate{
-			tls.Certificate{
+			{
 				Certificate: [][]byte{derbytes},
 				PrivateKey:  edpriv,
 			},

--- a/src/yggdrasil/tls.go
+++ b/src/yggdrasil/tls.go
@@ -1,0 +1,92 @@
+package yggdrasil
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/pem"
+	"log"
+	"math/big"
+	"net"
+	"time"
+)
+
+type tcptls struct {
+	tcp         *tcp
+	config      *tls.Config
+	forDialer   *TcpUpgrade
+	forListener *TcpUpgrade
+}
+
+func (t *tcptls) init(tcp *tcp) {
+	t.tcp = tcp
+	t.forDialer = &TcpUpgrade{
+		upgrade: t.upgradeDialer,
+		name:    "tls",
+	}
+	t.forListener = &TcpUpgrade{
+		upgrade: t.upgradeListener,
+		name:    "tls",
+	}
+
+	edpriv := make(ed25519.PrivateKey, ed25519.PrivateKeySize)
+	copy(edpriv[:], tcp.link.core.sigPriv[:])
+
+	certBuf := &bytes.Buffer{}
+
+	pubtemp := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: hex.EncodeToString(tcp.link.core.sigPub[:]),
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour * 24 * 365),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	derbytes, err := x509.CreateCertificate(rand.Reader, &pubtemp, &pubtemp, edpriv.Public(), edpriv)
+	if err != nil {
+		log.Fatalf("Failed to create certificate: %s", err)
+	}
+
+	if err := pem.Encode(certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: derbytes}); err != nil {
+		panic("failed to encode certificate into PEM")
+	}
+
+	cpool := x509.NewCertPool()
+	cpool.AppendCertsFromPEM(derbytes)
+
+	t.config = &tls.Config{
+		RootCAs: cpool,
+		Certificates: []tls.Certificate{
+			tls.Certificate{
+				Certificate: [][]byte{derbytes},
+				PrivateKey:  edpriv,
+			},
+		},
+		InsecureSkipVerify: true,
+		MinVersion:         tls.VersionTLS13,
+	}
+}
+
+func (t *tcptls) upgradeListener(c net.Conn) (net.Conn, error) {
+	conn := tls.Server(c, t.config)
+	if err := conn.Handshake(); err != nil {
+		return c, err
+	}
+	return conn, nil
+}
+
+func (t *tcptls) upgradeDialer(c net.Conn) (net.Conn, error) {
+	conn := tls.Client(c, t.config)
+	if err := conn.Handshake(); err != nil {
+		return c, err
+	}
+	return conn, nil
+}


### PR DESCRIPTION
This is an experiment to implement peerings over TLS connections. 

This PR does nothing to Yggdrasil's own encryption, so a peering over TLS actually is encrypted twice. This might have performance penalties.

One thing to be aware of is that there's *absolutely no peer validation whatsoever* at the TLS layer—no certificate validation, no hostname verification, nothing. It's good for steganography (e.g. hiding the fact that it's an Yggdrasil connection) but not much else at this stage.

It works by implementing `TcpUpgrade`, which is a descriptor containing a new protocol name and a function for *replacing* the existing `net.Conn` with a new one that implements other security layers—in this case, `tls.go` replaces the `net.Conn` by wrapping it in a `tls.Conn`.

If no `TcpUpgrade` is specified, a regular peering is made exactly as they are today.

You can test this by specifying `tls://` instead of `tcp://` for both peers and listeners.

----

Benchmarks are as follows:

Link MTU 9000, Yggdrasil MTU 65535, with TLS:
```
[ ID] Interval           Transfer     Bandwidth
[  4]   0.00-10.00  sec  2.00 GBytes  1.71 Gbits/sec                  sender
[  4]   0.00-10.00  sec  1.99 GBytes  1.71 Gbits/sec                  receiver
```

Link MTU 9000, Yggdrasil MTU 65535, without TLS: 
```
[ ID] Interval           Transfer     Bandwidth
[  4]   0.00-10.00  sec  2.50 GBytes  2.15 Gbits/sec                  sender
[  4]   0.00-10.00  sec  2.50 GBytes  2.15 Gbits/sec                  receiver
```

Link MTU 9000, Yggdrasil MTU 1280, with TLS:
```
[ ID] Interval           Transfer     Bandwidth
[  4]   0.00-10.00  sec   202 MBytes   169 Mbits/sec                  sender
[  4]   0.00-10.00  sec   200 MBytes   168 Mbits/sec                  receiver
```

Link MTU 9000, Yggdrasil MTU 1280, without TLS:
```
[ ID] Interval           Transfer     Bandwidth
[  4]   0.00-10.00  sec   319 MBytes   267 Mbits/sec                  sender
[  4]   0.00-10.00  sec   318 MBytes   266 Mbits/sec                  receiver
```