### PR TITLE
BindToDevice

### DIFF
--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -299,7 +299,7 @@ func (t *tcp) call(saddr string, options interface{}, sintf string, upgrade *Tcp
 				Timeout: time.Second * 5,
 			}
 			if sintf != "" {
-				dialer.Control = t.getContextWithBindToDevice(sintf)
+				dialer.Control = t.getControl(sintf)
 				ief, err := net.InterfaceByName(sintf)
 				if err != nil {
 					return

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -299,6 +299,7 @@ func (t *tcp) call(saddr string, options interface{}, sintf string, upgrade *Tcp
 				Timeout: time.Second * 5,
 			}
 			if sintf != "" {
+				dialer.Control = t.getContextWithBindToDevice(sintf)
 				ief, err := net.InterfaceByName(sintf)
 				if err != nil {
 					return

--- a/src/yggdrasil/tcp_darwin.go
+++ b/src/yggdrasil/tcp_darwin.go
@@ -26,3 +26,7 @@ func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
 		return control
 	}
 }
+
+func (t *tcp) getControl(sintf string) func(string, string, syscall.RawConn) error {
+	return t.tcpContext
+}

--- a/src/yggdrasil/tcp_linux.go
+++ b/src/yggdrasil/tcp_linux.go
@@ -30,7 +30,7 @@ func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
 	return nil
 }
 
-func (t *tcp) getContextWithBindToDevice(sintf string) func(string, string, syscall.RawConn) error {
+func (t *tcp) getControl(sintf string) func(string, string, syscall.RawConn) error {
 	return func(network, address string, c syscall.RawConn) error {
 		var err error
 		btd := func(fd uintptr) {

--- a/src/yggdrasil/tcp_other.go
+++ b/src/yggdrasil/tcp_other.go
@@ -11,3 +11,7 @@ import (
 func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
 	return nil
 }
+
+func (t *tcp) getControl(sintf string) func(string, string, syscall.RawConn) error {
+	return t.tcpContext
+}


### PR DESCRIPTION
This PR sets `SO_BINDTODEVICE` on linux for peers configured through the `InterfacePeers` option. This *appears* to ensure that packets to/from these peers are not swallowed by the routing table, if e.g. a CKR route is set which overlaps the peer's address range. In particular, I think this should make using CKR as a default route work without needing to manually configure routes to each peer (or carefully construct a routing table that doesn't cover the peers' address ranges).

That's great, but it's linux-specific as far as I know. Apparently macOS already gives the intended behavior, but we may want to look for similar workaround for the BSDs and Windows.

EDIT: one thing to note, `InterfacePeers` applies only to outgoing peers connections. Incoming connections will still obey the usual routing table rules, which could theoretically be problematic if you receive an incoming connection from a CKR routed address range (or any other vpn, for that matter). I suppose we could add some kind of `InterfaceListen` option too, if we wanted to bind incoming connections to a specific interface, and/or do so automatically for link-local peers (though those should already be effectively bound to one interface, just by the nature of link-local addressing).