### PR TITLE
Fix data race

### DIFF
--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -192,7 +192,7 @@ func (sinfo *searchInfo) checkDHTRes(res *dhtRes) bool {
 	finishSearch := func(sess *sessionInfo, err error) {
 		if sess != nil {
 			// FIXME (!) replay attacks could mess with coords? Give it a handle (tstamp)?
-			sess.coords = res.Coords
+			sess.Act(sinfo.searches.router, func() { sess.coords = res.Coords })
 			sess.ping(sinfo.searches.router)
 		}
 		if err != nil {


### PR DESCRIPTION
Fixes a bug found by the race detector.

When a search for an existing session finishes, the router was updating the coords of the session, which could race with the session trying to use those coords for things like sending traffic or session pings.

This fix causes the router to send a message to the session, telling it to update its own coords, instead of trying to directly update the coords on its own.