### PR TITLE
fix deadlock when AddPeer fails

### DIFF
--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -424,6 +424,7 @@ func (c *Core) AddPeer(addr string, sintf string) error {
 		return err
 	}
 	c.config.Mutex.Lock()
+	defer c.config.Mutex.Unlock()
 	if sintf == "" {
 		for _, peer := range c.config.Current.Peers {
 			if peer == addr {
@@ -445,7 +446,6 @@ func (c *Core) AddPeer(addr string, sintf string) error {
 			c.config.Current.InterfacePeers[sintf] = append(c.config.Current.InterfacePeers[sintf], addr)
 		}
 	}
-	c.config.Mutex.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
Fixes #596 (a deadlock from a mutex that wasn't unlocked when `AddPeer` fails). Note that removing a peer from the API doesn't remove it from the internal `Config`, so attempting to add the peer again fails, but at least it doesn't deadlock.

