### PR TITLE
Systemd: move config generation to a separate unit

### DIFF
--- a/contrib/systemd/yggdrasil-default-config.service
+++ b/contrib/systemd/yggdrasil-default-config.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=yggdrasil default config generator
+ConditionPathExists=|!/etc/yggdrasil.conf
+ConditionFileNotEmpty=|!/etc/yggdrasil.conf
+Wants=local-fs.target
+After=local-fs.target
+
+[Service]
+Type=oneshot
+Group=yggdrasil
+StandardOutput=file:/etc/yggdrasil.conf
+ExecStart=/usr/bin/yggdrasil -genconf
+ExecStartPost=/usr/bin/chmod 0640 /etc/yggdrasil.conf

--- a/contrib/systemd/yggdrasil.service
+++ b/contrib/systemd/yggdrasil.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=yggdrasil
 Wants=network.target
+Wants=yggdrasil-default-config.service
 After=network.target
+After=yggdrasil-default-config.service
 
 [Service]
 Group=yggdrasil
@@ -10,11 +12,6 @@ ProtectSystem=true
 SyslogIdentifier=yggdrasil
 CapabilityBoundSet=CAP_NET_ADMIN
 ExecStartPre=+-/sbin/modprobe tun
-ExecStartPre=/bin/sh -ec "if ! test -s /etc/yggdrasil.conf; \
-                then umask 077; \
-                yggdrasil -genconf > /etc/yggdrasil.conf; \
-                echo 'WARNING: A new /etc/yggdrasil.conf file has been generated.'; \
-            fi"
 ExecStart=/usr/bin/yggdrasil -useconffile /etc/yggdrasil.conf
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always


### PR DESCRIPTION
- Modular unit composition: different tasks in separate units
- Use systemd tool set to run checks
- Avoid using inline shell in unit