### PR TITLE
Improve MTU handling

### DIFF
--- a/src/tuntap/tun_bsd.go
+++ b/src/tuntap/tun_bsd.go
@@ -99,7 +99,7 @@ func (tun *TunAdapter) setup(ifname string, iftapmode bool, addr string, mtu int
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = getSupportedMTU(mtu)
+	tun.mtu = getSupportedMTU(mtu, iftapmode)
 	return tun.setupAddress(addr)
 }
 

--- a/src/tuntap/tun_darwin.go
+++ b/src/tuntap/tun_darwin.go
@@ -18,7 +18,8 @@ import (
 // Configures the "utun" adapter with the correct IPv6 address and MTU.
 func (tun *TunAdapter) setup(ifname string, iftapmode bool, addr string, mtu int) error {
 	if iftapmode {
-		tun.log.Warnln("TAP mode is not supported on this platform, defaulting to TUN")
+		tun.log.Warnln("Warning: TAP mode is not supported on this platform, defaulting to TUN")
+		iftapmode = false
 	}
 	config := water.Config{DeviceType: water.TUN}
 	iface, err := water.New(config)
@@ -26,7 +27,7 @@ func (tun *TunAdapter) setup(ifname string, iftapmode bool, addr string, mtu int
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = getSupportedMTU(mtu)
+	tun.mtu = getSupportedMTU(mtu, iftapmode)
 	return tun.setupAddress(addr)
 }
 

--- a/src/tuntap/tun_linux.go
+++ b/src/tuntap/tun_linux.go
@@ -26,7 +26,7 @@ func (tun *TunAdapter) setup(ifname string, iftapmode bool, addr string, mtu int
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = getSupportedMTU(mtu)
+	tun.mtu = getSupportedMTU(mtu, iftapmode)
 	// The following check is specific to Linux, as the TAP driver only supports
 	// an MTU of 65535-14 to make room for the ethernet headers. This makes sure
 	// that the MTU gets rounded down to 65521 instead of causing a panic.

--- a/src/tuntap/tun_other.go
+++ b/src/tuntap/tun_other.go
@@ -21,13 +21,13 @@ func (tun *TunAdapter) setup(ifname string, iftapmode bool, addr string, mtu int
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = getSupportedMTU(mtu)
+	tun.mtu = getSupportedMTU(mtu, iftapmode)
 	return tun.setupAddress(addr)
 }
 
 // We don't know how to set the IPv6 address on an unknown platform, therefore
 // write about it to stdout and don't try to do anything further.
 func (tun *TunAdapter) setupAddress(addr string) error {
-	tun.log.Warnln("Platform not supported, you must set the address of", tun.iface.Name(), "to", addr)
+	tun.log.Warnln("Warning: Platform not supported, you must set the address of", tun.iface.Name(), "to", addr)
 	return nil
 }

--- a/src/tuntap/tun_windows.go
+++ b/src/tuntap/tun_windows.go
@@ -17,7 +17,8 @@ import (
 // delegate the hard work to "netsh".
 func (tun *TunAdapter) setup(ifname string, iftapmode bool, addr string, mtu int) error {
 	if !iftapmode {
-		tun.log.Warnln("TUN mode is not supported on this platform, defaulting to TAP")
+		tun.log.Warnln("Warning: TUN mode is not supported on this platform, defaulting to TAP")
+		iftapmode = true
 	}
 	config := water.Config{DeviceType: water.TAP}
 	config.PlatformSpecificParams.ComponentID = "tap0901"
@@ -60,7 +61,7 @@ func (tun *TunAdapter) setup(ifname string, iftapmode bool, addr string, mtu int
 		panic(err)
 	}
 	tun.iface = iface
-	tun.mtu = getSupportedMTU(mtu)
+	tun.mtu = getSupportedMTU(mtu, iftapmode)
 	err = tun.setupMTU(tun.mtu)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR does three things:

1. The handling of MTUs when outside of the acceptable range for the platform is improved
1. Ethernet header bytes are now accounted for in the maximum MTU calculations
1. A warning is now written to `stdout` when the MTU has been changed from the configured value for some reason

This closes #603. 