### PR TITLE
Add API functions for manipulating maximum session MTU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.3.12] - 2019-11-22
 ### Added
-- New command line parameters `-address` and `-subnet` for getting the address/subnet from the config file, for use with `-useconffile` or `-useconf` 
+- New API functions `SetMaximumSessionMTU` and `GetMaximumSessionMTU`
+- New command line parameters `-address` and `-subnet` for getting the address/subnet from the config file, for use with `-useconffile` or `-useconf`
 - A warning is now produced in the Yggdrasil output at startup when the MTU in the config is invalid or has been adjusted for some reason
 
 ### Changed

--- a/src/tuntap/tun.go
+++ b/src/tuntap/tun.go
@@ -35,6 +35,7 @@ const tun_ETHER_HEADER_LENGTH = 14
 // you should pass this object to the yggdrasil.SetRouterAdapter() function
 // before calling yggdrasil.Start().
 type TunAdapter struct {
+	core        *yggdrasil.Core
 	writer      tunWriter
 	reader      tunReader
 	config      *config.NodeState
@@ -131,6 +132,7 @@ func (tun *TunAdapter) Init(core *yggdrasil.Core, config *config.NodeState, log 
 	if !ok {
 		return fmt.Errorf("invalid options supplied to TunAdapter module")
 	}
+	tun.core = core
 	tun.config = config
 	tun.log = log
 	tun.listener = tunoptions.Listener
@@ -181,6 +183,7 @@ func (tun *TunAdapter) _start() error {
 	if tun.MTU() != current.IfMTU {
 		tun.log.Warnf("Warning: Interface MTU %d automatically adjusted to %d (supported range is 1280-%d)", current.IfMTU, tun.MTU(), MaximumMTU(tun.IsTAP()))
 	}
+	tun.core.SetMaximumSessionMTU(uint16(tun.MTU()))
 	tun.isOpen = true
 	go tun.handler()
 	tun.reader.Act(nil, tun.reader._read) // Start the reader

--- a/src/tuntap/tun.go
+++ b/src/tuntap/tun.go
@@ -233,6 +233,12 @@ func (tun *TunAdapter) UpdateConfig(config *config.NodeConfig) {
 	// Replace the active configuration with the supplied one
 	tun.config.Replace(*config)
 
+	// If the MTU has changed in the TUN/TAP module then this is where we would
+	// tell the router so that updated session pings can be sent. However, we
+	// don't currently update the MTU of the adapter once it has been created so
+	// this doesn't actually happen in the real world yet.
+	//   tun.core.SetMaximumSessionMTU(...)
+
 	// Notify children about the configuration change
 	tun.Act(nil, tun.ckr.configure)
 }

--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -365,18 +365,19 @@ func (c *Core) SetNodeInfo(nodeinfo interface{}, nodeinfoprivacy bool) {
 
 // GetMaximumSessionMTU returns the maximum allowed session MTU size.
 func (c *Core) GetMaximumSessionMTU(mtu uint16) uint16 {
-	return c.router.sessions.myMaximumMTU
+	mtu := 0
+	phony.Block(c.router, func() {
+		mtu = c.router.sessions.myMaximumMTU
+	})
+	return mtu
 }
 
-// SetMaximumSessionMTU sets the maximum allowed session MTU size. The return
-// value contains the actual set value, since Yggdrasil will not accept MTUs
-// below 1280 bytes. The default value is 65535 bytes.
-func (c *Core) SetMaximumSessionMTU(mtu uint16) uint16 {
-	if mtu < 1280 {
-		mtu = 1280
-	}
-	c.router.sessions.myMaximumMTU = mtu
-	return mtu
+// SetMaximumSessionMTU sets the maximum allowed session MTU size. The default
+// value is 65535 bytes.
+func (c *Core) SetMaximumSessionMTU(mtu uint16) {
+	phony.Block(c.router, func() {
+		c.router.sessions.myMaximumMTU = mtu
+	})
 }
 
 // GetNodeInfo requests nodeinfo from a remote node, as specified by the public

--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -364,19 +364,23 @@ func (c *Core) SetNodeInfo(nodeinfo interface{}, nodeinfoprivacy bool) {
 }
 
 // GetMaximumSessionMTU returns the maximum allowed session MTU size.
-func (c *Core) GetMaximumSessionMTU(mtu uint16) uint16 {
-	mtu := 0
-	phony.Block(c.router, func() {
+func (c *Core) GetMaximumSessionMTU() uint16 {
+	var mtu uint16
+	phony.Block(&c.router, func() {
 		mtu = c.router.sessions.myMaximumMTU
 	})
 	return mtu
 }
 
 // SetMaximumSessionMTU sets the maximum allowed session MTU size. The default
-// value is 65535 bytes.
+// value is 65535 bytes. Session pings will be sent to update all open sessions
+// if the MTU has changed.
 func (c *Core) SetMaximumSessionMTU(mtu uint16) {
-	phony.Block(c.router, func() {
-		c.router.sessions.myMaximumMTU = mtu
+	phony.Block(&c.router, func() {
+		if c.router.sessions.myMaximumMTU != mtu {
+			c.router.sessions.myMaximumMTU = mtu
+			c.router.sessions.reconfigure()
+		}
 	})
 }
 

--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -363,6 +363,22 @@ func (c *Core) SetNodeInfo(nodeinfo interface{}, nodeinfoprivacy bool) {
 	c.router.nodeinfo.setNodeInfo(nodeinfo, nodeinfoprivacy)
 }
 
+// GetMaximumSessionMTU returns the maximum allowed session MTU size.
+func (c *Core) GetMaximumSessionMTU(mtu uint16) uint16 {
+	return c.router.sessions.myMaximumMTU
+}
+
+// SetMaximumSessionMTU sets the maximum allowed session MTU size. The return
+// value contains the actual set value, since Yggdrasil will not accept MTUs
+// below 1280 bytes. The default value is 65535 bytes.
+func (c *Core) SetMaximumSessionMTU(mtu uint16) uint16 {
+	if mtu < 1280 {
+		mtu = 1280
+	}
+	c.router.sessions.myMaximumMTU = mtu
+	return mtu
+}
+
 // GetNodeInfo requests nodeinfo from a remote node, as specified by the public
 // key and coordinates specified. The third parameter specifies whether a cached
 // result is acceptable - this results in less traffic being generated than is

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -189,8 +189,6 @@ func (ss *sessions) createSession(theirPermKey *crypto.BoxPubKey) *sessionInfo {
 	sinfo.mySesPriv = *priv
 	sinfo.myNonce = *crypto.NewBoxNonce()
 	sinfo.theirMTU = 1280
-	// TODO: sinfo.myMTU becomes unnecessary if we always have a reference to the
-	// sessions struct so let's check if that is the case
 	sinfo.myMTU = ss.myMaximumMTU
 	now := time.Now()
 	sinfo.timeOpened = now

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -136,7 +136,10 @@ func (ss *sessions) init(r *router) {
 func (ss *sessions) reconfigure() {
 	ss.router.Act(nil, func() {
 		for _, session := range ss.sinfos {
-			session.myMTU = ss.myMaximumMTU
+			sinfo, mtu := session, ss.myMaximumMTU
+			sinfo.Act(ss.router, func() {
+				sinfo.myMTU = mtu
+			})
 			session.ping(ss.router)
 		}
 	})

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -55,10 +55,6 @@ type sessionInfo struct {
 	callbacks     []chan func()       // Finished work from crypto workers
 }
 
-func (sinfo *sessionInfo) reconfigure() {
-	// This is where reconfiguration would go, if we had anything to do
-}
-
 // Represents a session ping/pong packet, andincludes information like public keys, a session handle, coords, a timestamp to prevent replays, and the tun/tap MTU.
 type sessionPing struct {
 	SendPermPub crypto.BoxPubKey // Sender's permanent key
@@ -138,9 +134,12 @@ func (ss *sessions) init(r *router) {
 }
 
 func (ss *sessions) reconfigure() {
-	for _, session := range ss.sinfos {
-		session.reconfigure()
-	}
+	ss.router.Act(nil, func() {
+		for _, session := range ss.sinfos {
+			session.myMTU = ss.myMaximumMTU
+			session.ping(ss.router)
+		}
+	})
 }
 
 // Determines whether the session with a given publickey is allowed based on


### PR DESCRIPTION
The problem today is that the `tuntap` module would wrap the MTU down to a sane size but the session code in `Core` wouldn't. This would mean that setting a value larger than 65535 would cause a `uint16` overflow and then traffic wouldn't send over the session.

This adds new API functions for setting the maximum MTU, and then updates `tuntap` to call those as necessary, so that the session code is notified about the *real* TUN/TAP MTU.

For the sake of solving this problem for v0.3.12, I don't plan to make any other big changes, but it probably makes sense to fail hard or ensure that the `NodeConfig` expects a `uint16` rather than an `int` to make these kinds of mistakes more obvious. 

This also removes one of our awful shared-config-struct references, which I will shortly be on a mission to nuke all of them from `src/yggdrasil`. 