### PR TITLE
Bugfix

### DIFF
--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -369,6 +369,7 @@ func (intf *linkInterface) notifyRead(size int) {
 		intf.stalled = false
 		if !intf.unstalled {
 			intf._notifySwitch()
+			intf.unstalled = true
 		}
 		if size > 0 && intf.stallTimer == nil {
 			intf.stallTimer = time.AfterFunc(keepAliveTime, intf.notifyDoKeepAlive)

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -808,12 +808,12 @@ func (t *switchTable) _handleIdle(port switchPort) bool {
 			packet := buf.packets[0]
 			coords := switch_getPacketCoords(packet.bytes)
 			priority := float64(now.Sub(packet.time)) / float64(buf.size)
-			if priority > bestPriority && t.portIsCloser(coords, port) {
+			if priority >= bestPriority && t.portIsCloser(coords, port) {
 				best = streamID
 				bestPriority = priority
 			}
 		}
-		if bestPriority != 0 {
+		if best != "" {
 			buf := t.queues.bufs[best]
 			var packet switch_packetInfo
 			// TODO decide if this should be LIFO or FIFO


### PR DESCRIPTION
This attempts to prevent incorrect idle notification in the switch, which should (hopefully) help with some packet reordering issues.

It needs testing to make sure that other things don't break as a result, specifically that the flow of packets along a link doesn't become permanently blocked if a link is temporarily out and becomes "stalled" in the link code.

