### PR TITLE
Update yggdrasil.service

### DIFF
--- a/contrib/systemd/yggdrasil.service
+++ b/contrib/systemd/yggdrasil.service
@@ -8,7 +8,7 @@ Group=yggdrasil
 ProtectHome=true
 ProtectSystem=true
 SyslogIdentifier=yggdrasil
-CapabilityBoundingSet=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW
 ExecStartPre=+-/sbin/modprobe tun
 ExecStartPre=/bin/sh -ec "if ! test -s /etc/yggdrasil.conf; \
                 then umask 077; \


### PR DESCRIPTION
For `InterfacePeers` to work properly, it looks like the process needs `NET_CAP_RAW` capabilities.