### PR TITLE
Fix return value in Multicast.Stop()

### DIFF
--- a/src/multicast/multicast.go
+++ b/src/multicast/multicast.go
@@ -112,7 +112,7 @@ func (m *Multicast) Stop() error {
 		err = m._stop()
 	})
 	m.log.Debugln("Stopped multicast module")
-	return nil
+	return err
 }
 
 func (m *Multicast) _stop() error {


### PR DESCRIPTION
This function always returns nil
Fixed fail execution:
```
go test ./src...
```
vet: src/multicast/multicast.go:110:6: err declared but not used