### PR TITLE
MSI bugfixes

### DIFF
--- a/contrib/msi/build-msi.sh
+++ b/contrib/msi/build-msi.sh
@@ -185,6 +185,9 @@ cat > wix.xml << EOF
     </Feature>
 
     <Feature Id="WintunFeature" Title="Wintun" Level="1">
+      <Condition Level="0">
+        NOT UPGRADINGPRODUCTCODE
+      </Condition>
       <MergeRef Id="Wintun" />
     </Feature>
 

--- a/contrib/msi/build-msi.sh
+++ b/contrib/msi/build-msi.sh
@@ -100,7 +100,7 @@ cat > wix.xml << EOF
       Id="*"
       Keywords="Installer"
       Description="Yggdrasil Network Installer"
-      Comments="This is the Yggdrasil Network router for Windows."
+      Comments="Yggdrasil Network standalone router for Windows."
       Manufacturer="github.com/yggdrasil-network"
       InstallerVersion="200"
       InstallScope="perMachine"
@@ -115,7 +115,8 @@ cat > wix.xml << EOF
     <Media
       Id="1"
       Cabinet="Media.cab"
-      EmbedCab="yes" />
+      EmbedCab="yes"
+      CompressionLevel="high" />
 
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="${PKGINSTFOLDER}" Name="PFiles">

--- a/contrib/msi/build-msi.sh
+++ b/contrib/msi/build-msi.sh
@@ -83,12 +83,18 @@ else
   exit 1
 fi
 
+if [ $PKGNAME != "master" ]; then
+  PKGDISPLAYNAME="Yggdrasil Network (${PKGNAME} branch)"
+elif
+  PKGDISPLAYNAME="Yggdrasil Network"
+fi
+
 # Generate the wix.xml file
 cat > wix.xml << EOF
 <?xml version="1.0" encoding="windows-1252"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
   <Product
-    Name="Yggdrasil (${PKGNAME} branch)"
+    Name="${PKGDISPLAYNAME}"
     Id="*"
     UpgradeCode="${PKGGUID}"
     Language="1033"

--- a/contrib/msi/build-msi.sh
+++ b/contrib/msi/build-msi.sh
@@ -186,7 +186,7 @@ cat > wix.xml << EOF
 
     <Feature Id="WintunFeature" Title="Wintun" Level="1">
       <Condition Level="0">
-        NOT UPGRADINGPRODUCTCODE
+        UPGRADINGPRODUCTCODE
       </Condition>
       <MergeRef Id="Wintun" />
     </Feature>

--- a/contrib/msi/build-msi.sh
+++ b/contrib/msi/build-msi.sh
@@ -85,7 +85,7 @@ fi
 
 if [ $PKGNAME != "master" ]; then
   PKGDISPLAYNAME="Yggdrasil Network (${PKGNAME} branch)"
-elif
+else
   PKGDISPLAYNAME="Yggdrasil Network"
 fi
 

--- a/contrib/msi/build-msi.sh
+++ b/contrib/msi/build-msi.sh
@@ -177,11 +177,14 @@ cat > wix.xml << EOF
         SourceFile="${PKGMSMNAME}" />
     </Directory>
 
-    <Feature Id="Complete" Level="1">
-      <MergeRef Id="Wintun" />
+    <Feature Id="YggdrasilFeature" Title="Yggdrasil" Level="1">
       <ComponentRef Id="MainExecutable" />
       <ComponentRef Id="CtrlExecutable" />
       <ComponentRef Id="ConfigScript" />
+    </Feature>
+
+    <Feature Id="WintunFeature" Title="Wintun" Level="1">
+      <MergeRef Id="Wintun" />
     </Feature>
 
     <CustomAction


### PR DESCRIPTION
This should hopefully fix some problems in the MSI with the Wintun driver being incorrectly uninstalled during upgrades and not being reinstalled properly. 

This also sets the compression level higher for smaller downloads and sets the product name to a more friendly name.