### PR TITLE
Misc tuning

### DIFF
--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -398,6 +398,7 @@ func (c *Core) GetNodeInfo(key crypto.BoxPubKey, coords []uint64, nocache bool) 
 		}
 	})
 	c.router.nodeinfo.sendNodeInfo(key, wire_coordsUint64stoBytes(coords), false)
+	phony.Block(&c.router.nodeinfo, func() {}) // Wait for sendNodeInfo before starting timer
 	timer := time.AfterFunc(6*time.Second, func() { close(response) })
 	defer timer.Stop()
 	for res := range response {

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -387,6 +387,8 @@ func (t *dht) getImportant() []*dhtInfo {
 			if dist < minDist {
 				minDist = dist
 				important = append(important, info)
+			} else if len(important) < 2 {
+				important = append(important, info)
 			}
 		}
 		var temp []*dhtInfo
@@ -396,6 +398,8 @@ func (t *dht) getImportant() []*dhtInfo {
 			dist := uint64(loc.dist(info.coords))
 			if dist < minDist {
 				minDist = dist
+				temp = append(temp, info)
+			} else if len(temp) < 2 {
 				temp = append(temp, info)
 			}
 		}

--- a/src/yggdrasil/nodeinfo.go
+++ b/src/yggdrasil/nodeinfo.go
@@ -41,7 +41,7 @@ type nodeinfoReqRes struct {
 // Initialises the nodeinfo cache/callback maps, and starts a goroutine to keep
 // the cache/callback maps clean of stale entries
 func (m *nodeinfo) init(core *Core) {
-	m.Act(m, func() {
+	m.Act(nil, func() {
 		m._init(core)
 	})
 }
@@ -66,13 +66,13 @@ func (m *nodeinfo) _cleanup() {
 		}
 	}
 	time.AfterFunc(time.Second*30, func() {
-		m.Act(m, m._cleanup)
+		m.Act(nil, m._cleanup)
 	})
 }
 
 // Add a callback for a nodeinfo lookup
 func (m *nodeinfo) addCallback(sender crypto.BoxPubKey, call func(nodeinfo *NodeInfoPayload)) {
-	m.Act(m, func() {
+	m.Act(nil, func() {
 		m._addCallback(sender, call)
 	})
 }
@@ -164,8 +164,8 @@ func (m *nodeinfo) _getCachedNodeInfo(key crypto.BoxPubKey) (NodeInfoPayload, er
 }
 
 // Handles a nodeinfo request/response - called from the router
-func (m *nodeinfo) handleNodeInfo(nodeinfo *nodeinfoReqRes) {
-	m.Act(m, func() {
+func (m *nodeinfo) handleNodeInfo(from phony.Actor, nodeinfo *nodeinfoReqRes) {
+	m.Act(from, func() {
 		m._handleNodeInfo(nodeinfo)
 	})
 }
@@ -181,7 +181,7 @@ func (m *nodeinfo) _handleNodeInfo(nodeinfo *nodeinfoReqRes) {
 
 // Send nodeinfo request or response - called from the router
 func (m *nodeinfo) sendNodeInfo(key crypto.BoxPubKey, coords []byte, isResponse bool) {
-	m.Act(m, func() {
+	m.Act(nil, func() {
 		m._sendNodeInfo(key, coords, isResponse)
 	})
 }

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -250,5 +250,5 @@ func (r *router) _handleNodeInfo(bs []byte, fromKey *crypto.BoxPubKey) {
 		return
 	}
 	req.SendPermPub = *fromKey
-	r.nodeinfo.handleNodeInfo(&req)
+	r.nodeinfo.handleNodeInfo(r, &req)
 }

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -24,10 +24,8 @@ import (
 // This defines the maximum number of dhtInfo that we keep track of for nodes to query in an ongoing search.
 const search_MAX_SEARCH_SIZE = 16
 
-// This defines the time after which we send a new search packet.
-// Search packets are sent automatically immediately after a response is received.
-// So this allows for timeouts and for long searches to become increasingly parallel.
-const search_RETRY_TIME = time.Second
+// This defines the time after which we time out a search (so it can restart).
+const search_RETRY_TIME = 3 * time.Second
 
 // Information about an ongoing search.
 // Includes the target NodeID, the bitmask to match it to an IP, and the list of nodes to visit / already visited.


### PR DESCRIPTION
Just a few relatively small optimizations that seemed like low hanging fruit.

1. `yggdrasilctl` now just calls `os.Exit` on some function, which returns an error code. That allows the internal function to safely use `defer` for cleanup etc, since this happens before the `os.Exit` call causes everything to shut down immediately.
2. In the DHT, always store the 2 closest nodes in each direction around the ring. That way, if your immediate neighbor disappears, you always already know the replacement. This *should* make things a little more robust under node joins/leaves, and *may* speed up bootstrapping a little.
3. The search code has been simplified significantly. Now, instead of storing a list of all visited nodes, we store the single closest node to the destination that we've gotten a response from. When a response comes in, we immediately send a request to *all* nodes in the response (in parallel) that are closer to the destination than the closest visited node. This makes each search take up constant space, and searches should finish more quickly (especially when a node fails to respond or when searching for an unreachable destination).

Not very well tested yet.