### PR TITLE
Actorise NodeInfo

### DIFF
--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -78,6 +78,7 @@ func (r *router) init(core *Core) {
 func (r *router) reconfigure() {
 	// Reconfigure the router
 	current := r.core.config.GetCurrent()
+	r.core.log.Println("Reloading NodeInfo...")
 	if err := r.nodeinfo.setNodeInfo(current.NodeInfo, current.NodeInfoPrivacy); err != nil {
 		r.core.log.Errorln("Error reloading NodeInfo:", err)
 	} else {


### PR DESCRIPTION
This converts the NodeInfo code to operate around its own actor, rather than the router actor. It also removes all mutexes within `nodeinfo.go` as a result.

The hope is that multiple on-going searches should not block as they do today, which is a big part of why the API server has stopped collecting NodeInfo properly.