### PR TITLE
Fixed initrc

### DIFF
--- a/contrib/freebsd/yggdrasil
+++ b/contrib/freebsd/yggdrasil
@@ -47,6 +47,7 @@ yggdrasil_start()
 	else 
 		logger -s -t yggdrasil "Destroying ${tap_name} adapter"
 		/sbin/ifconfig ${tap_name} destroy || logger -s -t yggdrasil "Failed to destroy ${tap_name} adapter"
+	fi
 
 	test ! -d /var/run/yggdrasil && mkdir -p /var/run/yggdrasil
 

--- a/contrib/freebsd/yggdrasil
+++ b/contrib/freebsd/yggdrasil
@@ -36,7 +36,7 @@ yggdrasil_start()
 		/usr/local/bin/yggdrasil -genconf > /usr/local/etc/yggdrasil.conf
 	)
 
-	tap_path="$(cat /usr/local/etc/yggdrasil.conf | egrep -o '/dev/tap[0-9]{1,2}$')"
+	tap_path="$(cat /usr/local/etc/yggdrasil.conf | egrep -o '/dev/tap[0-9]{1,2}')"
 	tap_name="$(echo -n ${tap_path} | tr -d '/dev/')"
 
 	/sbin/ifconfig ${tap_name} >/dev/null 2>&1

--- a/contrib/freebsd/yggdrasil
+++ b/contrib/freebsd/yggdrasil
@@ -31,25 +31,30 @@ yggdrasil_start()
 		return 1
 	)
 
-	test ! -f /etc/yggdrasil.conf && (
-		logger -s -t yggdrasil "Generating new configuration file into /etc/yggdrasil.conf"
-		/usr/local/bin/yggdrasil -genconf > /etc/yggdrasil.conf
+	test ! -f /usr/local/etc/yggdrasil.conf && (
+		logger -s -t yggdrasil "Generating new configuration file into /usr/local/etc/yggdrasil.conf"
+		/usr/local/bin/yggdrasil -genconf > /usr/local/etc/yggdrasil.conf
 	)
 
-	tap_path="$(cat /etc/yggdrasil.conf | egrep -o '/dev/tap[0-9]{1,2}$')"
+	tap_path="$(cat /usr/local/etc/yggdrasil.conf | egrep -o '/dev/tap[0-9]{1,2}$')"
 	tap_name="$(echo -n ${tap_path} | tr -d '/dev/')"
 
-	/sbin/ifconfig ${tap_name} >/dev/null 2>&1 || (
+	/sbin/ifconfig ${tap_name} >/dev/null 2>&1
+
+	if [ $? != 0 ]; then
 		logger -s -t yggdrasil "Creating ${tap_name} adapter"
 		/sbin/ifconfig ${tap_name} create || logger -s -t yggdrasil "Failed to create ${tap_name} adapter"
-	)
+	else 
+		logger -s -t yggdrasil "Destroying ${tap_name} adapter"
+		/sbin/ifconfig ${tap_name} destroy || logger -s -t yggdrasil "Failed to destroy ${tap_name} adapter"
 
 	test ! -d /var/run/yggdrasil && mkdir -p /var/run/yggdrasil
 
 	logger -s -t yggdrasil "Starting yggdrasil"
-	${command} ${command_args} /usr/local/bin/yggdrasil -useconffile /etc/yggdrasil.conf \
+	${command} ${command_args} /usr/local/bin/yggdrasil -useconffile /usr/local/etc/yggdrasil.conf \
 		1>/var/log/yggdrasil.stdout.log \
 		2>/var/log/yggdrasil.stderr.log &
+	route -6 add 200::/7 -iface ${tap_name} > /dev/null 1>/dev/null 2>/dev/null &
 }
 
 yggdrasil_stop()
@@ -57,7 +62,7 @@ yggdrasil_stop()
 	logger -s -t yggdrasil "Stopping yggdrasil"
 	test -f /var/run/yggdrasil/${name}.pid && kill -TERM $(cat /var/run/yggdrasil/${name}.pid)
 
-	tap_path="$(cat /etc/yggdrasil.conf | grep /dev/tap | egrep -o '/dev/.*$')"
+	tap_path="$(cat /usr/local/etc/yggdrasil.conf | grep /dev/tap | egrep -o '/dev/.*$')"
         tap_name="$(echo -n ${tap_path} | tr -d '/dev/')"
 
 	/sbin/ifconfig ${tap_name} >/dev/null 2>&1 && (


### PR DESCRIPTION
* Made routing work properly (sometimes yggdrasil does but due to some bug it doesn't add route quick enough) 
* Removed tap0 if it existed during start (and recreated it)
* Use the `/usr/local/etc/` instead of `/etc/` to comply with the FreeBSD hier. In FreeBSD, `/etc/` is reserved for the base system; `/usr/local/etc/` is meant for the third-party applications.