### PR TITLE
Sort search response results before sending requests

### DIFF
--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -16,6 +16,7 @@ package yggdrasil
 
 import (
 	"errors"
+	"sort"
 	"time"
 
 	"github.com/yggdrasil-network/yggdrasil-go/src/crypto"
@@ -100,6 +101,11 @@ func (sinfo *searchInfo) addToSearch(res *dhtRes) {
 			// Response is closer to the destination
 			sinfo.toVisit = append(sinfo.toVisit, info)
 		}
+		// Sort
+		sort.SliceStable(sinfo.toVisit, func(i, j int) bool {
+			// Should return true if i is closer to the destination than j
+			return dht_ordered(&res.Dest, sinfo.toVisit[i].getNodeID(), sinfo.toVisit[j].getNodeID())
+		})
 	}
 }
 


### PR DESCRIPTION
This is an old behavior that was dropped during some search tuning, but still seems to improve things (and seems more correct anyway).