### PR TITLE
Search

### DIFF
--- a/src/yggdrasil/conn.go
+++ b/src/yggdrasil/conn.go
@@ -130,8 +130,8 @@ func (c *Conn) search() error {
 					close(done)
 				}
 			}
-			sinfo, infos := c.core.router.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
-			sinfo.continueSearch(infos)
+			sinfo := c.core.router.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
+			sinfo.startSearch()
 		} else {
 			err = errors.New("search already exists")
 			close(done)
@@ -152,11 +152,10 @@ func (c *Conn) doSearch() {
 		if !isIn {
 			// Nothing was found, so create a new search
 			searchCompleted := func(sinfo *sessionInfo, e error) {}
-			var infos []*dhtInfo
-			sinfo, infos = c.core.router.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
+			sinfo = c.core.router.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
 			c.core.log.Debugf("%s DHT search started: %p", c.String(), sinfo)
 			// Start the search
-			sinfo.continueSearch(infos)
+			sinfo.startSearch()
 		}
 	}
 	c.core.router.Act(c.session, routerWork)

--- a/src/yggdrasil/conn.go
+++ b/src/yggdrasil/conn.go
@@ -130,8 +130,8 @@ func (c *Conn) search() error {
 					close(done)
 				}
 			}
-			sinfo := c.core.router.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
-			sinfo.continueSearch()
+			sinfo, infos := c.core.router.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
+			sinfo.continueSearch(infos)
 		} else {
 			err = errors.New("search already exists")
 			close(done)
@@ -152,10 +152,11 @@ func (c *Conn) doSearch() {
 		if !isIn {
 			// Nothing was found, so create a new search
 			searchCompleted := func(sinfo *sessionInfo, e error) {}
-			sinfo = c.core.router.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
+			var infos []*dhtInfo
+			sinfo, infos = c.core.router.searches.newIterSearch(c.nodeID, c.nodeMask, searchCompleted)
 			c.core.log.Debugf("%s DHT search started: %p", c.String(), sinfo)
 			// Start the search
-			sinfo.continueSearch()
+			sinfo.continueSearch(infos)
 		}
 	}
 	c.core.router.Act(c.session, routerWork)

--- a/src/yggdrasil/search.go
+++ b/src/yggdrasil/search.go
@@ -170,6 +170,7 @@ func (sinfo *searchInfo) startSearch() {
 			time.AfterFunc(search_RETRY_TIME-elapsed, cleanupFunc)
 		})
 	}
+	time.AfterFunc(search_RETRY_TIME, cleanupFunc)
 }
 
 // Calls create search, and initializes the iterative search parts of the struct before returning it.

--- a/src/yggdrasil/session.go
+++ b/src/yggdrasil/session.go
@@ -43,7 +43,6 @@ type sessionInfo struct {
 	time          time.Time           // Time we last received a packet
 	mtuTime       time.Time           // time myMTU was last changed
 	pingTime      time.Time           // time the first ping was sent since the last received packet
-	pingSend      time.Time           // time the last ping was sent
 	coords        []byte              // coords of destination
 	reset         bool                // reset if coords change
 	tstamp        int64               // ATOMIC - tstamp from their last session ping, replay attack mitigation
@@ -197,7 +196,6 @@ func (ss *sessions) createSession(theirPermKey *crypto.BoxPubKey) *sessionInfo {
 	sinfo.time = now
 	sinfo.mtuTime = now
 	sinfo.pingTime = now
-	sinfo.pingSend = now
 	sinfo.init = make(chan struct{})
 	sinfo.cancel = util.NewCancellation()
 	higher := false


### PR DESCRIPTION
More search optimizations and debug level logging.

Each search response now starts up a separate thread to continue the search. These threads end as soon as they no longer contain any nodes to attempt that are closer than the closest node (in keyspace) to respond so far. This is meant to help prevent various DoS attacks where a malicious node would block the search by returning a large number of results with bad coords, to try to block the search from progressing (which now only blocks the malicious node's thread of the search).