### PR TITLE
check if an error was returned by Core._init and return it if so

### DIFF
--- a/contrib/ansible/genkeys.go
+++ b/contrib/ansible/genkeys.go
@@ -12,9 +12,9 @@ import (
 	"net"
 	"os"
 
+	"github.com/cheggaaa/pb/v3"
 	"github.com/yggdrasil-network/yggdrasil-go/src/address"
 	"github.com/yggdrasil-network/yggdrasil-go/src/crypto"
-	"github.com/cheggaaa/pb/v3"
 )
 
 var numHosts = flag.Int("hosts", 1, "number of host vars to generate")
@@ -30,7 +30,7 @@ type keySet struct {
 func main() {
 	flag.Parse()
 
-	bar := pb.StartNew(*keyTries * 2 + *numHosts)
+	bar := pb.StartNew(*keyTries*2 + *numHosts)
 
 	if *numHosts > *keyTries {
 		println("Can't generate less keys than hosts.")

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -160,7 +160,10 @@ func (c *Core) _start(nc *config.NodeConfig, log *log.Logger) (*config.NodeState
 	}
 
 	c.log.Infoln("Starting up...")
-	c._init()
+	if err := c._init(); err != nil {
+		c.log.Errorln("Failed to initialize core")
+		return nil, err
+	}
 
 	if err := c.link.init(c); err != nil {
 		c.log.Errorln("Failed to start link interfaces")


### PR DESCRIPTION
Fixes #671 sort-of. It should now catch the error when initializing the core and report something a little more useful, instead of crashing with a segfault when trying to start the switch. It should print an error along the lines of:
```
2020/03/31 18:16:48 Build name: yggdrasil-bugfix
2020/03/31 18:16:48 Build version: 0.3.13-0014
2020/03/31 18:16:48 Starting up...
2020/03/31 18:16:48 Failed to initialize core
2020/03/31 18:16:48 An error occurred during startup
panic: encoding/hex: invalid byte: U+006E 'n'
```
There's probably still room to improve that, but it's better than a segfault at least...