### PR TITLE
Fixed some linter issues

### DIFF
--- a/cmd/genkeys/main.go
+++ b/cmd/genkeys/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	for {
 		newKey := <-newKeys
-		if isBetter(currentBest[:], newKey.id[:]) || len(currentBest) == 0 {
+		if isBetter(currentBest, newKey.id[:]) || len(currentBest) == 0 {
 			currentBest = newKey.id
 			for _, channel := range threadChannels {
 				select {
@@ -61,13 +61,13 @@ func main() {
 			fmt.Println("--------------------------------------------------------------------------------")
 			switch {
 			case *doSig:
-				fmt.Println("sigPriv:", hex.EncodeToString(newKey.priv[:]))
-				fmt.Println("sigPub:", hex.EncodeToString(newKey.pub[:]))
-				fmt.Println("TreeID:", hex.EncodeToString(newKey.id[:]))
+				fmt.Println("sigPriv:", hex.EncodeToString(newKey.priv))
+				fmt.Println("sigPub:", hex.EncodeToString(newKey.pub))
+				fmt.Println("TreeID:", hex.EncodeToString(newKey.id))
 			default:
-				fmt.Println("boxPriv:", hex.EncodeToString(newKey.priv[:]))
-				fmt.Println("boxPub:", hex.EncodeToString(newKey.pub[:]))
-				fmt.Println("NodeID:", hex.EncodeToString(newKey.id[:]))
+				fmt.Println("boxPriv:", hex.EncodeToString(newKey.priv))
+				fmt.Println("boxPub:", hex.EncodeToString(newKey.pub))
+				fmt.Println("NodeID:", hex.EncodeToString(newKey.id))
 				fmt.Println("IP:", newKey.ip)
 			}
 		}
@@ -76,12 +76,10 @@ func main() {
 
 func isBetter(oldID, newID []byte) bool {
 	for idx := range oldID {
-		if newID[idx] > oldID[idx] {
-			return true
+		if newID[idx] == oldID[idx] {
+			continue
 		}
-		if newID[idx] < oldID[idx] {
-			return false
-		}
+		return newID[idx] > oldID[idx]
 	}
 	return false
 }

--- a/cmd/genkeys/main.go
+++ b/cmd/genkeys/main.go
@@ -76,10 +76,9 @@ func main() {
 
 func isBetter(oldID, newID []byte) bool {
 	for idx := range oldID {
-		if newID[idx] == oldID[idx] {
-			continue
+		if newID[idx] != oldID[idx] {
+			return newID[idx] > oldID[idx]
 		}
-		return newID[idx] > oldID[idx]
 	}
 	return false
 }

--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -60,8 +60,8 @@ func readConfig(useconf *bool, useconffile *string, normaliseconf *bool) *config
 	// throwing everywhere when it's converting things into UTF-16 for the hell
 	// of it - remove it and decode back down into UTF-8. This is necessary
 	// because hjson doesn't know what to do with UTF-16 and will panic
-	if bytes.Compare(conf[0:2], []byte{0xFF, 0xFE}) == 0 ||
-		bytes.Compare(conf[0:2], []byte{0xFE, 0xFF}) == 0 {
+	if bytes.Equal(conf[0:2], []byte{0xFF, 0xFE}) ||
+		bytes.Equal(conf[0:2], []byte{0xFE, 0xFF}) {
 		utf := unicode.UTF16(unicode.BigEndian, unicode.UseBOM)
 		decoder := utf.NewDecoder()
 		conf, err = decoder.Bytes(conf)
@@ -222,7 +222,7 @@ func main() {
 	getNodeID := func() *crypto.NodeID {
 		if pubkey, err := hex.DecodeString(cfg.EncryptionPublicKey); err == nil {
 			var box crypto.BoxPubKey
-			copy(box[:], pubkey[:])
+			copy(box[:], pubkey)
 			return crypto.GetNodeID(&box)
 		}
 		return nil

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -78,8 +78,8 @@ func run() int {
 
 	if *server == endpoint {
 		if config, err := ioutil.ReadFile(defaults.GetDefaults().DefaultConfigFile); err == nil {
-			if bytes.Compare(config[0:2], []byte{0xFF, 0xFE}) == 0 ||
-				bytes.Compare(config[0:2], []byte{0xFE, 0xFF}) == 0 {
+			if bytes.Equal(config[0:2], []byte{0xFF, 0xFE}) ||
+				bytes.Equal(config[0:2], []byte{0xFE, 0xFF}) {
 				utf := unicode.UTF16(unicode.BigEndian, unicode.UseBOM)
 				decoder := utf.NewDecoder()
 				config, err = decoder.Bytes(config)

--- a/src/admin/admin.go
+++ b/src/admin/admin.go
@@ -181,13 +181,12 @@ func (a *AdminSocket) SetupAdminHandlers(na *AdminSocket) {
 					in["uri"].(string),
 				},
 			}, nil
-		} else {
-			return Info{
-				"not_added": []string{
-					in["uri"].(string),
-				},
-			}, errors.New("Failed to add peer")
 		}
+		return Info{
+			"not_added": []string{
+				in["uri"].(string),
+			},
+		}, errors.New("Failed to add peer")
 	})
 	a.AddHandler("removePeer", []string{"port"}, func(in Info) (Info, error) {
 		port, err := strconv.ParseInt(fmt.Sprint(in["port"]), 10, 64)
@@ -200,13 +199,12 @@ func (a *AdminSocket) SetupAdminHandlers(na *AdminSocket) {
 					fmt.Sprint(port),
 				},
 			}, nil
-		} else {
-			return Info{
-				"not_removed": []string{
-					fmt.Sprint(port),
-				},
-			}, errors.New("Failed to remove peer")
 		}
+		return Info{
+			"not_removed": []string{
+				fmt.Sprint(port),
+			},
+		}, errors.New("Failed to remove peer")
 	})
 	a.AddHandler("getAllowedEncryptionPublicKeys", []string{}, func(in Info) (Info, error) {
 		return Info{"allowed_box_pubs": a.core.GetAllowedEncryptionPublicKeys()}, nil
@@ -218,13 +216,12 @@ func (a *AdminSocket) SetupAdminHandlers(na *AdminSocket) {
 					in["box_pub_key"].(string),
 				},
 			}, nil
-		} else {
-			return Info{
-				"not_added": []string{
-					in["box_pub_key"].(string),
-				},
-			}, errors.New("Failed to add allowed key")
 		}
+		return Info{
+			"not_added": []string{
+				in["box_pub_key"].(string),
+			},
+		}, errors.New("Failed to add allowed key")
 	})
 	a.AddHandler("removeAllowedEncryptionPublicKey", []string{"box_pub_key"}, func(in Info) (Info, error) {
 		if a.core.RemoveAllowedEncryptionPublicKey(in["box_pub_key"].(string)) == nil {
@@ -250,10 +247,10 @@ func (a *AdminSocket) SetupAdminHandlers(na *AdminSocket) {
 		coords := util.DecodeCoordString(in["coords"].(string))
 		var boxPubKey crypto.BoxPubKey
 		if b, err := hex.DecodeString(in["box_pub_key"].(string)); err == nil {
-			copy(boxPubKey[:], b[:])
+			copy(boxPubKey[:], b)
 			if n, err := hex.DecodeString(in["target"].(string)); err == nil {
 				var targetNodeID crypto.NodeID
-				copy(targetNodeID[:], n[:])
+				copy(targetNodeID[:], n)
 				result, reserr = a.core.DHTPing(boxPubKey, coords, &targetNodeID)
 			} else {
 				result, reserr = a.core.DHTPing(boxPubKey, coords, nil)
@@ -294,7 +291,7 @@ func (a *AdminSocket) SetupAdminHandlers(na *AdminSocket) {
 			return Info{}, errors.New("Expecting both box_pub_key and coords")
 		} else {
 			if b, err := hex.DecodeString(in["box_pub_key"].(string)); err == nil {
-				copy(boxPubKey[:], b[:])
+				copy(boxPubKey[:], b)
 			} else {
 				return Info{}, err
 			}

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -30,9 +30,8 @@ func UnlockThread() {
 func ResizeBytes(bs []byte, length int) []byte {
 	if cap(bs) >= length {
 		return bs[:length]
-	} else {
-		return make([]byte, length)
 	}
+	return make([]byte, length)
 }
 
 // TimerStop stops a timer and makes sure the channel is drained, returns true if the timer was stopped before firing.


### PR DESCRIPTION
I just fixed some issues from [golangci-lint](https://github.com/golangci/golangci-lint). There are many more issues but I decided to try at first with the most simple. Anyway, it is connected with issue #314.
Is it a good idea to use such a linter in CI? It can check a new code automatically before code review. Also, it is super fast and it checked all the project within a minute.

These are some issues which [golangci-lint](https://github.com/golangci/golangci-lint) found: 

`cmd/genkeys/main.go`
```go
cmd/genkeys/main.go:54:15: unslice: could simplify currentBest[:] to currentBest (gocritic)
        if isBetter(currentBest[:], newKey.id[:]) || len(currentBest) == 0 {
                    ^
cmd/genkeys/main.go:64:48: unslice: could simplify newKey.priv[:] to newKey.priv (gocritic)
                fmt.Println("sigPriv:", hex.EncodeToString(newKey.priv[:]))
                                                           ^
cmd/genkeys/main.go:65:47: unslice: could simplify newKey.pub[:] to newKey.pub (gocritic)
                fmt.Println("sigPub:", hex.EncodeToString(newKey.pub[:]))
                                                          ^
cmd/genkeys/main.go:66:47: unslice: could simplify newKey.id[:] to newKey.id (gocritic)
                fmt.Println("TreeID:", hex.EncodeToString(newKey.id[:]))
                                                          ^
cmd/genkeys/main.go:68:48: unslice: could simplify newKey.priv[:] to newKey.priv (gocritic)
                fmt.Println("boxPriv:", hex.EncodeToString(newKey.priv[:]))
                                                           ^
cmd/genkeys/main.go:69:47: unslice: could simplify newKey.pub[:] to newKey.pub (gocritic)
                fmt.Println("boxPub:", hex.EncodeToString(newKey.pub[:]))
                                                          ^
cmd/genkeys/main.go:70:47: unslice: could simplify newKey.id[:] to newKey.id (gocritic)
                fmt.Println("NodeID:", hex.EncodeToString(newKey.id[:]))
                                                          ^
```

`cmd/yggdrasil/main.go`
```go
cmd/yggdrasil/main.go:225:17: unslice: could simplify pubkey[:] to pubkey (gocritic)
            copy(box[:], pubkey[:])
                         ^
cmd/yggdrasil/main.go:63:5: S1004: should use bytes.Equal(conf[0:2], []byte{0xFF, 0xFE}) instead (gosimple)
    if bytes.Compare(conf[0:2], []byte{0xFF, 0xFE}) == 0 ||
       ^
cmd/yggdrasil/main.go:64:3: S1004: should use bytes.Equal(conf[0:2], []byte{0xFE, 0xFF}) instead (gosimple)
        bytes.Compare(conf[0:2], []byte{0xFE, 0xFF}) == 0 {
        ^
```

`cmd/yggdrasilctl/main.go`
```go
cmd/yggdrasilctl/main.go:81:7: S1004: should use bytes.Equal(config[0:2], []byte{0xFF, 0xFE}) instead (gosimple)
            if bytes.Compare(config[0:2], []byte{0xFF, 0xFE}) == 0 ||
               ^
cmd/yggdrasilctl/main.go:82:5: S1004: should use bytes.Equal(config[0:2], []byte{0xFE, 0xFF}) instead (gosimple)
                bytes.Compare(config[0:2], []byte{0xFE, 0xFF}) == 0 {
                ^
```

`src/admin/admin.go`
```go
src/admin/admin.go:184:10: `if` block ends with a `return` statement, so drop this `else` and outdent its block (golint)
        } else {
               ^
src/admin/admin.go:203:10: `if` block ends with a `return` statement, so drop this `else` and outdent its block (golint)
        } else {
               ^
src/admin/admin.go:221:10: `if` block ends with a `return` statement, so drop this `else` and outdent its block (golint)
        } else {
               ^
src/admin/admin.go:253:23: unslice: could simplify b[:] to b (gocritic)
            copy(boxPubKey[:], b[:])
                               ^
src/admin/admin.go:256:27: unslice: could simplify n[:] to n (gocritic)
                copy(targetNodeID[:], n[:])
                                      ^
src/admin/admin.go:297:24: unslice: could simplify b[:] to b (gocritic)
                copy(boxPubKey[:], b[:])
                                   ^
```

`src/util/util.go`
```go
src/util/util.go:33:9: `if` block ends with a `return` statement, so drop this `else` and outdent its block (golint)
    } else {
           ^
```