### PR TITLE
Public key pinning support

### DIFF
--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -103,7 +103,7 @@ func (l *link) call(uri string, sintf string) error {
 	if pubkeys, ok := u.Query()["curve25519"]; ok && len(pubkeys) > 0 {
 		tcpOpts.pinnedCurve25519Keys = make(map[crypto.BoxPubKey]struct{})
 		for _, pubkey := range pubkeys {
-			if boxPub, err := hex.DecodeString(pubkey); err != nil {
+			if boxPub, err := hex.DecodeString(pubkey); err == nil {
 				var boxPubKey crypto.BoxPubKey
 				copy(boxPubKey[:], boxPub)
 				tcpOpts.pinnedCurve25519Keys[boxPubKey] = struct{}{}
@@ -113,7 +113,7 @@ func (l *link) call(uri string, sintf string) error {
 	if pubkeys, ok := u.Query()["ed25519"]; ok && len(pubkeys) > 0 {
 		tcpOpts.pinnedEd25519Keys = make(map[crypto.SigPubKey]struct{})
 		for _, pubkey := range pubkeys {
-			if sigPub, err := hex.DecodeString(pubkey); err != nil {
+			if sigPub, err := hex.DecodeString(pubkey); err == nil {
 				var sigPubKey crypto.SigPubKey
 				copy(sigPubKey[:], sigPub)
 				tcpOpts.pinnedEd25519Keys[sigPubKey] = struct{}{}

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yggdrasil-network/yggdrasil-go/src/address"
 	"github.com/yggdrasil-network/yggdrasil-go/src/crypto"
 	"github.com/yggdrasil-network/yggdrasil-go/src/util"
+	"golang.org/x/net/proxy"
 
 	"github.com/Arceliar/phony"
 )
@@ -127,6 +128,11 @@ func (l *link) call(uri string, sintf string) error {
 		l.tcp.call(u.Host, tcpOpts, sintf)
 	case "socks":
 		tcpOpts.socksProxyAddr = u.Host
+		if u.User != nil {
+			tcpOpts.socksProxyAuth = &proxy.Auth{}
+			tcpOpts.socksProxyAuth.User = u.User.Username()
+			tcpOpts.socksProxyAuth.Password, _ = u.User.Password()
+		}
 		l.tcp.call(pathtokens[0], tcpOpts, sintf)
 	case "tls":
 		tcpOpts.upgrade = l.tcp.tls.forDialer

--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -1,7 +1,6 @@
 package yggdrasil
 
 import (
-	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -71,8 +70,8 @@ type linkInterface struct {
 }
 
 type linkOptions struct {
-	pinnedCurve25519Keys []crypto.BoxPubKey
-	pinnedEd25519Keys    []crypto.SigPubKey
+	pinnedCurve25519Keys map[crypto.BoxPubKey]struct{}
+	pinnedEd25519Keys    map[crypto.SigPubKey]struct{}
 }
 
 func (l *link) init(c *Core) error {
@@ -102,24 +101,22 @@ func (l *link) call(uri string, sintf string) error {
 	pathtokens := strings.Split(strings.Trim(u.Path, "/"), "/")
 	tcpOpts := tcpOptions{}
 	if pubkeys, ok := u.Query()["curve25519"]; ok && len(pubkeys) > 0 {
+		tcpOpts.pinnedCurve25519Keys = make(map[crypto.BoxPubKey]struct{})
 		for _, pubkey := range pubkeys {
 			if boxPub, err := hex.DecodeString(pubkey); err != nil {
 				var boxPubKey crypto.BoxPubKey
 				copy(boxPubKey[:], boxPub)
-				tcpOpts.pinnedCurve25519Keys = append(
-					tcpOpts.pinnedCurve25519Keys, boxPubKey,
-				)
+				tcpOpts.pinnedCurve25519Keys[boxPubKey] = struct{}{}
 			}
 		}
 	}
 	if pubkeys, ok := u.Query()["ed25519"]; ok && len(pubkeys) > 0 {
+		tcpOpts.pinnedEd25519Keys = make(map[crypto.SigPubKey]struct{})
 		for _, pubkey := range pubkeys {
 			if sigPub, err := hex.DecodeString(pubkey); err != nil {
 				var sigPubKey crypto.SigPubKey
 				copy(sigPubKey[:], sigPub)
-				tcpOpts.pinnedEd25519Keys = append(
-					tcpOpts.pinnedEd25519Keys, sigPubKey,
-				)
+				tcpOpts.pinnedEd25519Keys[sigPubKey] = struct{}{}
 			}
 		}
 	}
@@ -222,22 +219,14 @@ func (intf *linkInterface) handler() error {
 	}
 	// Check if the remote side matches the keys we expected. This is a bit of a weak
 	// check - in future versions we really should check a signature or something like that.
-	if pinned := intf.options.pinnedCurve25519Keys; len(pinned) > 0 {
-		allowed := false
-		for _, key := range pinned {
-			allowed = allowed || (bytes.Compare(key[:], meta.box[:]) == 0)
-		}
-		if !allowed {
+	if pinned := intf.options.pinnedCurve25519Keys; pinned != nil {
+		if _, allowed := pinned[meta.box]; !allowed {
 			intf.link.core.log.Errorf("Failed to connect to node: %q sent curve25519 key that does not match pinned keys", intf.name)
 			return fmt.Errorf("failed to connect: host sent curve25519 key that does not match pinned keys")
 		}
 	}
-	if pinned := intf.options.pinnedEd25519Keys; len(pinned) > 0 {
-		allowed := false
-		for _, key := range pinned {
-			allowed = allowed || (bytes.Compare(key[:], meta.sig[:]) == 0)
-		}
-		if !allowed {
+	if pinned := intf.options.pinnedEd25519Keys; pinned != nil {
+		if _, allowed := pinned[meta.sig]; !allowed {
 			intf.link.core.log.Errorf("Failed to connect to node: %q sent ed25519 key that does not match pinned keys", intf.name)
 			return fmt.Errorf("failed to connect: host sent ed25519 key that does not match pinned keys")
 		}

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -61,6 +61,7 @@ type tcpOptions struct {
 	linkOptions
 	upgrade        *TcpUpgrade
 	socksProxyAddr string
+	socksPeerAddr  string
 }
 
 func (l *TcpListener) Stop() {
@@ -290,6 +291,7 @@ func (t *tcp) call(saddr string, options tcpOptions, sintf string) {
 				return
 			}
 			t.waitgroup.Add(1)
+			options.socksPeerAddr = saddr
 			t.handler(conn, false, options)
 		} else {
 			dst, err := net.ResolveTCPAddr("tcp", saddr)
@@ -379,10 +381,10 @@ func (t *tcp) handler(sock net.Conn, incoming bool, options tcpOptions) {
 	stream.init(sock)
 	var name, proto, local, remote string
 	if options.socksProxyAddr != "" {
-		name = "socks://" + sock.RemoteAddr().String() + "/" + options.socksProxyAddr
+		name = "socks://" + sock.RemoteAddr().String() + "/" + options.socksPeerAddr
 		proto = "socks"
 		local, _, _ = net.SplitHostPort(sock.LocalAddr().String())
-		remote, _, _ = net.SplitHostPort(options.socksProxyAddr)
+		remote, _, _ = net.SplitHostPort(options.socksPeerAddr)
 	} else {
 		if upgraded {
 			proto = options.upgrade.name

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -292,7 +292,7 @@ func (t *tcp) call(saddr string, options tcpOptions, sintf string) {
 				return
 			}
 			t.waitgroup.Add(1)
-			options.socksPeerAddr = saddr
+			options.socksPeerAddr = conn.RemoteAddr().String()
 			t.handler(conn, false, options)
 		} else {
 			dst, err := net.ResolveTCPAddr("tcp", saddr)

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -61,6 +61,7 @@ type tcpOptions struct {
 	linkOptions
 	upgrade        *TcpUpgrade
 	socksProxyAddr string
+	socksProxyAuth *proxy.Auth
 	socksPeerAddr  string
 }
 
@@ -282,7 +283,7 @@ func (t *tcp) call(saddr string, options tcpOptions, sintf string) {
 				return
 			}
 			var dialer proxy.Dialer
-			dialer, err = proxy.SOCKS5("tcp", dialerdst.String(), nil, proxy.Direct)
+			dialer, err = proxy.SOCKS5("tcp", dialerdst.String(), options.socksProxyAuth, proxy.Direct)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
This is an experimental PR that allows pinning public keys in peering strings, e.g.
- pinning by signing public key: `tcp://host:port?ed25519=key`
- pinning by encryption public key: `tcp://host:port?curve25519=key`
- pinning by both: `tcp://host:port?ed25519=key&curve25519=key`
- pinning by multiple, in case of DNS round-robin or similar: `tcp://host:port?curve25519=key&curve25519=key&ed25519=key&ed25519=key`

The peering connection will fail if the remote side does not send us a matching public key, which helps to increase the guarantee that you are indeed peering with the node that you think you are peering with.

The extended peering URLs should be backward-compatible as older versions of Yggdrasil should just ignore the query strings.

It also juggles around things into `tcpOptions` and `linkOptions` for SOCKS peerings too, and adds support for SOCKS proxy auth.