### PR TITLE
maybe fix multicast deadlock on darwin

### DIFF
--- a/src/multicast/multicast_darwin.go
+++ b/src/multicast/multicast_darwin.go
@@ -33,14 +33,14 @@ var awdlGoroutineStarted bool
 
 func (m *Multicast) _multicastStarted() {
 	C.StopAWDLBrowsing()
-	for intf := range m.Interfaces() {
+	for intf := range m._interfaces {
 		if intf == "awdl0" {
 			C.StartAWDLBrowsing()
 			break
 		}
 	}
 	m.platformhandler = time.AfterFunc(time.Minute, func() {
-		m.Act(m, m._multicastStarted)
+		m.Act(nil, m._multicastStarted)
 	})
 }
 


### PR DESCRIPTION
The issue was that `Multicast` was calling `Multicast.Interfaces()` instead of directly accessing `Multicast._interfaces`, and the former sends a message to itself and blocks until the message is handled, so it was deadlocking with itself.