### PR TITLE
Misc updates for the future branch

### DIFF
--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -376,6 +376,7 @@ func (intf *linkInterface) notifyRead(size int) {
 		if size > 0 && intf.stallTimer == nil {
 			intf.stallTimer = time.AfterFunc(keepAliveTime, intf.notifyDoKeepAlive)
 		}
+		intf.link.core.switchTable.unblockPeer(intf, intf.peer.port)
 	})
 }
 


### PR DESCRIPTION
EDIT: the other things I wanted to do here have been moved to #693, so I think the half of the changes that are here are OK on their own.

Updates to `future` to hopefully cover some edge cases where performance may have degraded compared to `develop`.

In particular: this should (hopefully) be faster about blocking and unblocking peers at the switch level, in cases where the TCP connection to a peer stops working. This still needs testing, so I'm not sure if it's done yet or not.

There's still work to do here, in particular I want to do something about switch queue sizes (currently they're hard coded, we should either read them from the config or find a reasonable way to make them zero configuration without hard coding a max size -- I think they mainly need to deal with bursts of traffic caused by e.g. TCP head-of-line blocking).

This PR also adjust the logic for how peers are inserted into the DHT, and how the DHT resets when a node's coords change. This should *hopefully* lead to faster DHT convergence after a node's coords reset (based on the sim results). It may slightly increase idle DHT traffic, by sending a DHT ping to peers immediately after receiving a switch/tree-level update from them. I expect this traffic to be small compared to the size of the (signed) update that triggers it.

The goal here is to get `future` into a state where it's possible to merge it into `develop` before we add any hard backwards compatibility breaks, just in case we need to add them to `v0.3.X` as part of a bugfix or something (I'm currently running `future` on my public node, the single switch worker in the stable builds was unable to handle the load caused by the current network, due to the way we queue everything together and then need to re-check distances whenever a link becomes idle).