### PR TITLE
Update queue behavior

### DIFF
--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -123,10 +123,10 @@ func (c *Core) GetPeers() []Peer {
 		var info Peer
 		phony.Block(p, func() {
 			info = Peer{
-				Endpoint:   p.intf.name,
+				Endpoint:   p.intf.name(),
 				BytesSent:  p.bytesSent,
 				BytesRecvd: p.bytesRecvd,
-				Protocol:   p.intf.info.linkType,
+				Protocol:   p.intf.interfaceType(),
 				Port:       uint64(port),
 				Uptime:     time.Since(p.firstSeen),
 			}
@@ -163,8 +163,8 @@ func (c *Core) GetSwitchPeers() []SwitchPeer {
 				BytesSent:  peer.bytesSent,
 				BytesRecvd: peer.bytesRecvd,
 				Port:       uint64(elem.port),
-				Protocol:   peer.intf.info.linkType,
-				Endpoint:   peer.intf.info.remote,
+				Protocol:   peer.intf.interfaceType(),
+				Endpoint:   peer.intf.remote(),
 			}
 			copy(info.PublicKey[:], peer.box[:])
 		})

--- a/src/yggdrasil/api.go
+++ b/src/yggdrasil/api.go
@@ -257,14 +257,14 @@ func (c *Core) ConnDialer() (*Dialer, error) {
 // "Listen" configuration item, e.g.
 // 		tcp://a.b.c.d:e
 func (c *Core) ListenTCP(uri string) (*TcpListener, error) {
-	return c.link.tcp.listen(uri, nil)
+	return c.links.tcp.listen(uri, nil)
 }
 
 // ListenTLS starts a new TLS listener. The input URI should match that of the
 // "Listen" configuration item, e.g.
 // 		tls://a.b.c.d:e
 func (c *Core) ListenTLS(uri string) (*TcpListener, error) {
-	return c.link.tcp.listen(uri, c.link.tcp.tls.forListener)
+	return c.links.tcp.listen(uri, c.links.tcp.tls.forListener)
 }
 
 // NodeID gets the node ID. This is derived from your router encryption keys.
@@ -463,7 +463,7 @@ func (c *Core) RemovePeer(addr string, sintf string) error {
 // This does not add the peer to the peer list, so if the connection drops, the
 // peer will not be called again automatically.
 func (c *Core) CallPeer(addr string, sintf string) error {
-	return c.link.call(addr, sintf)
+	return c.links.call(addr, sintf)
 }
 
 // DisconnectPeer disconnects a peer once. This should be specified as a port

--- a/src/yggdrasil/core.go
+++ b/src/yggdrasil/core.go
@@ -29,7 +29,7 @@ type Core struct {
 	switchTable  switchTable
 	peers        peers
 	router       router
-	link         link
+	links        links
 	log          *log.Logger
 	addPeerTimer *time.Timer
 }
@@ -165,7 +165,7 @@ func (c *Core) _start(nc *config.NodeConfig, log *log.Logger) (*config.NodeState
 		return nil, err
 	}
 
-	if err := c.link.init(c); err != nil {
+	if err := c.links.init(c); err != nil {
 		c.log.Errorln("Failed to start link interfaces")
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func (c *Core) _stop() {
 	if c.addPeerTimer != nil {
 		c.addPeerTimer.Stop()
 	}
-	c.link.stop()
+	c.links.stop()
 	/* FIXME this deadlocks, need a waitgroup or something to coordinate shutdown
 	for _, peer := range c.GetPeers() {
 		c.DisconnectPeer(peer.Port)

--- a/src/yggdrasil/packetqueue.go
+++ b/src/yggdrasil/packetqueue.go
@@ -55,11 +55,6 @@ func (q *packetQueue) drop() bool {
 	}
 	// Drop the oldest packet from the worst stream
 	packet := worstStream.infos[0].packet
-	if false && q.size-uint64(len(packet)) < streamMsgSize {
-		// TODO something better
-		// We don't want to drop *all* packets, so lets save 1 batch worth...
-		return false
-	}
 	worstStream.infos = worstStream.infos[1:]
 	worstStream.size -= uint64(len(packet))
 	q.size -= uint64(len(packet))

--- a/src/yggdrasil/packetqueue.go
+++ b/src/yggdrasil/packetqueue.go
@@ -55,7 +55,7 @@ func (q *packetQueue) drop() bool {
 	}
 	// Drop the oldest packet from the worst stream
 	packet := worstStream.infos[0].packet
-	if q.size-uint64(len(packet)) < streamMsgSize {
+	if false && q.size-uint64(len(packet)) < streamMsgSize {
 		// TODO something better
 		// We don't want to drop *all* packets, so lets save 1 batch worth...
 		return false

--- a/src/yggdrasil/packetqueue.go
+++ b/src/yggdrasil/packetqueue.go
@@ -4,9 +4,6 @@ import (
 	"time"
 )
 
-// TODO take max size from config
-const MAX_PACKET_QUEUE_SIZE = 4 * 1048576 // 4 MB
-
 type pqStreamID string
 
 type pqPacketInfo struct {
@@ -25,46 +22,50 @@ type packetQueue struct {
 	size    uint64
 }
 
-func (q *packetQueue) cleanup() {
-	for q.size > MAX_PACKET_QUEUE_SIZE {
-		// TODO? drop from a random stream
-		//  odds proportional to size? bandwidth?
-		//  always using the worst is exploitable -> flood 1 packet per random stream
-		// find the stream that's using the most bandwidth
-		now := time.Now()
-		var worst pqStreamID
-		for id := range q.streams {
+// drop will remove a packet from the queue, returning it to the pool
+//  returns true if a packet was removed, false otherwise
+func (q *packetQueue) drop() bool {
+	if q.size == 0 {
+		return false
+	}
+	// TODO? drop from a random stream
+	//  odds proportional to size? bandwidth?
+	//  always using the worst is exploitable -> flood 1 packet per random stream
+	// find the stream that's using the most bandwidth
+	now := time.Now()
+	var worst pqStreamID
+	for id := range q.streams {
+		worst = id
+		break // get a random ID to start
+	}
+	worstStream := q.streams[worst]
+	worstSize := float64(worstStream.size)
+	worstAge := now.Sub(worstStream.infos[0].time).Seconds()
+	for id, stream := range q.streams {
+		thisSize := float64(stream.size)
+		thisAge := now.Sub(stream.infos[0].time).Seconds()
+		// cross multiply to avoid division by zero issues
+		if worstSize*thisAge < thisSize*worstAge {
+			// worstSize/worstAge < thisSize/thisAge -> this uses more bandwidth
 			worst = id
-			break // get a random ID to start
-		}
-		worstStream := q.streams[worst]
-		worstSize := float64(worstStream.size)
-		worstAge := now.Sub(worstStream.infos[0].time).Seconds()
-		for id, stream := range q.streams {
-			thisSize := float64(stream.size)
-			thisAge := now.Sub(stream.infos[0].time).Seconds()
-			// cross multiply to avoid division by zero issues
-			if worstSize*thisAge < thisSize*worstAge {
-				// worstSize/worstAge < thisSize/thisAge -> this uses more bandwidth
-				worst = id
-				worstStream = stream
-				worstSize = thisSize
-				worstAge = thisAge
-			}
-		}
-		// Drop the oldest packet from the worst stream
-		packet := worstStream.infos[0].packet
-		worstStream.infos = worstStream.infos[1:]
-		worstStream.size -= uint64(len(packet))
-		q.size -= uint64(len(packet))
-		pool_putBytes(packet)
-		// save the modified stream to queues
-		if len(worstStream.infos) > 0 {
-			q.streams[worst] = worstStream
-		} else {
-			delete(q.streams, worst)
+			worstStream = stream
+			worstSize = thisSize
+			worstAge = thisAge
 		}
 	}
+	// Drop the oldest packet from the worst stream
+	packet := worstStream.infos[0].packet
+	worstStream.infos = worstStream.infos[1:]
+	worstStream.size -= uint64(len(packet))
+	q.size -= uint64(len(packet))
+	pool_putBytes(packet)
+	// save the modified stream to queues
+	if len(worstStream.infos) > 0 {
+		q.streams[worst] = worstStream
+	} else {
+		delete(q.streams, worst)
+	}
+	return true
 }
 
 func (q *packetQueue) push(packet []byte) {
@@ -80,7 +81,6 @@ func (q *packetQueue) push(packet []byte) {
 	// save update to queues
 	q.streams[id] = stream
 	q.size += uint64(len(packet))
-	q.cleanup()
 }
 
 func (q *packetQueue) pop() ([]byte, bool) {

--- a/src/yggdrasil/packetqueue.go
+++ b/src/yggdrasil/packetqueue.go
@@ -55,6 +55,11 @@ func (q *packetQueue) drop() bool {
 	}
 	// Drop the oldest packet from the worst stream
 	packet := worstStream.infos[0].packet
+	if q.size-uint64(len(packet)) < streamMsgSize {
+		// TODO something better
+		// We don't want to drop *all* packets, so lets save 1 batch worth...
+		return false
+	}
 	worstStream.infos = worstStream.infos[1:]
 	worstStream.size -= uint64(len(packet))
 	q.size -= uint64(len(packet))

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -77,23 +77,11 @@ func (ps *peers) getAllowedEncryptionPublicKeys() []string {
 	return ps.core.config.Current.AllowedEncryptionPublicKeys
 }
 
-type peerInterface interface {
-	out([][]byte)
-	linkOut([]byte)
-	notifyQueued(uint64)
-	close()
-	// These next ones are only used by the API
-	name() string
-	local() string
-	remote() string
-	interfaceType() string
-}
-
 // Information known about a peer, including their box/sig keys, precomputed shared keys (static and ephemeral) and a handler for their outgoing traffic
 type peer struct {
 	phony.Inbox
 	core       *Core
-	intf       peerInterface
+	intf       linkInterface
 	port       switchPort
 	box        crypto.BoxPubKey
 	sig        crypto.SigPubKey
@@ -134,7 +122,7 @@ func (ps *peers) _updatePeers() {
 }
 
 // Creates a new peer with the specified box, sig, and linkShared keys, using the lowest unoccupied port number.
-func (ps *peers) _newPeer(box *crypto.BoxPubKey, sig *crypto.SigPubKey, linkShared *crypto.BoxSharedKey, intf peerInterface) *peer {
+func (ps *peers) _newPeer(box *crypto.BoxPubKey, sig *crypto.SigPubKey, linkShared *crypto.BoxSharedKey, intf linkInterface) *peer {
 	now := time.Now()
 	p := peer{box: *box,
 		core:       ps.core,

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -317,7 +317,7 @@ func (p *peer) dropFromQueue(from phony.Actor, seq uint64) {
 	p.Act(from, func() {
 		if seq == p.seq {
 			p.drop = true
-			p.max = p.queue.size
+			p.max = p.queue.size + streamMsgSize
 		}
 	})
 }

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -310,7 +310,7 @@ func (p *peer) dropFromQueue(from phony.Actor, seq uint64) {
 	p.Act(from, func() {
 		switch {
 		case seq != p.seq:
-			//case p.queue.size < streamMsgSize:
+		case p.queue.size < streamMsgSize:
 		case p.queue.drop():
 			p.core.log.Debugln("DEBUG dropped:", p.port, p.queue.size)
 			p.intf.notifyQueued(p.seq)

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -281,6 +281,8 @@ func (p *peer) _sendPackets(packets [][]byte) {
 	if p.idle {
 		p.idle = false
 		p._handleIdle()
+	} else {
+		p.intf.notifyQueued(p.seq)
 	}
 }
 
@@ -296,6 +298,7 @@ func (p *peer) _handleIdle() {
 		}
 	}
 	if len(packets) > 0 {
+		p.seq++
 		p.bytesSent += uint64(size)
 		p.intf.out(packets)
 	} else {

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -306,9 +306,7 @@ func (p *peer) _handleIdle() {
 		p.seq++
 		p.bytesSent += uint64(size)
 		p.intf.out(packets)
-		if p.drop {
-			p.max = p.queue.size
-		}
+		p.max = p.queue.size
 	} else {
 		p.idle = true
 		p.drop = false
@@ -319,6 +317,7 @@ func (p *peer) dropFromQueue(from phony.Actor, seq uint64) {
 	p.Act(from, func() {
 		if seq == p.seq {
 			p.drop = true
+			p.max = p.queue.size
 		}
 	})
 }

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -289,7 +289,7 @@ func (p *peer) _sendPackets(packets [][]byte) {
 func (p *peer) _handleIdle() {
 	var packets [][]byte
 	var size uint64
-	for size < 65535 {
+	for size < streamMsgSize {
 		if packet, success := p.queue.pop(); success {
 			packets = append(packets, packet)
 			size += uint64(len(packet))

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -264,22 +264,20 @@ func (p *peer) _handleTraffic(packet []byte) {
 	coords := peer_getPacketCoords(packet)
 	next := p.table.lookup(coords)
 	if nPeer, isIn := p.ports[next]; isIn {
-		nPeer.sendPacketsFrom(p, [][]byte{packet})
+		nPeer.sendPacketFrom(p, packet)
 	}
 	//p.core.switchTable.packetInFrom(p, packet)
 }
 
-func (p *peer) sendPacketsFrom(from phony.Actor, packets [][]byte) {
+func (p *peer) sendPacketFrom(from phony.Actor, packet []byte) {
 	p.Act(from, func() {
-		p._sendPackets(packets)
+		p._sendPacket(packet)
 	})
 }
 
-func (p *peer) _sendPackets(packets [][]byte) {
+func (p *peer) _sendPacket(packet []byte) {
 	size := p.queue.size
-	for _, packet := range packets {
-		p.queue.push(packet)
-	}
+	p.queue.push(packet)
 	switch {
 	case p.idle:
 		p.idle = false

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -311,12 +311,9 @@ func (p *peer) dropFromQueue(from phony.Actor, seq uint64) {
 		switch {
 		case seq != p.seq:
 		case p.queue.drop():
+			p.core.log.Debugln("DEBUG dropped:", p.port, p.queue.size)
 			p.intf.notifyQueued(p.seq)
 		}
-		if seq != p.seq {
-			return
-		}
-
 	})
 }
 

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -310,6 +310,7 @@ func (p *peer) dropFromQueue(from phony.Actor, seq uint64) {
 	p.Act(from, func() {
 		switch {
 		case seq != p.seq:
+			//case p.queue.size < streamMsgSize:
 		case p.queue.drop():
 			p.core.log.Debugln("DEBUG dropped:", p.port, p.queue.size)
 			p.intf.notifyQueued(p.seq)

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -258,7 +258,7 @@ func (r *router) _handleNodeInfo(bs []byte, fromKey *crypto.BoxPubKey) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// routerInterface is a helper that implements peerInterface
+// routerInterface is a helper that implements linkInterface
 type routerInterface struct {
 	router *router
 }

--- a/src/yggdrasil/simlink.go
+++ b/src/yggdrasil/simlink.go
@@ -58,7 +58,7 @@ func (c *Core) NewSimlink() *Simlink {
 	s := &Simlink{rch: make(chan []byte, 1)}
 	n := "Simlink"
 	var err error
-	s.link, err = c.link.create(s, n, n, n, n, false, true)
+	s.link, err = c.links.create(s, n, n, n, n, false, true)
 	if err != nil {
 		panic(err)
 	}

--- a/src/yggdrasil/simlink.go
+++ b/src/yggdrasil/simlink.go
@@ -9,7 +9,7 @@ type Simlink struct {
 	phony.Inbox
 	rch     chan []byte
 	dest    *Simlink
-	link    *linkInterface
+	link    *link
 	started bool
 }
 

--- a/src/yggdrasil/stream.go
+++ b/src/yggdrasil/stream.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Test that this matches the interface we expect
-var _ = linkInterfaceMsgIO(&stream{})
+var _ = linkMsgIO(&stream{})
 
 type stream struct {
 	rwc          io.ReadWriteCloser

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -188,7 +188,7 @@ func (t *switchTable) init(core *Core) {
 
 func (t *switchTable) reconfigure() {
 	// This is where reconfiguration would go, if we had anything useful to do.
-	t.core.link.reconfigure()
+	t.core.links.reconfigure()
 	t.core.peers.reconfigure()
 }
 

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -33,7 +33,7 @@ const tcp_ping_interval = (default_timeout * 2 / 3)
 
 // The TCP listener and information about active TCP connections, to avoid duplication.
 type tcp struct {
-	link      *link
+	links     *links
 	waitgroup sync.WaitGroup
 	mutex     sync.Mutex // Protecting the below
 	listeners map[string]*TcpListener
@@ -86,8 +86,8 @@ func (t *tcp) getAddr() *net.TCPAddr {
 }
 
 // Initializes the struct.
-func (t *tcp) init(l *link) error {
-	t.link = l
+func (t *tcp) init(l *links) error {
+	t.links = l
 	t.tls.init(t)
 	t.mutex.Lock()
 	t.calls = make(map[string]struct{})
@@ -95,9 +95,9 @@ func (t *tcp) init(l *link) error {
 	t.listeners = make(map[string]*TcpListener)
 	t.mutex.Unlock()
 
-	t.link.core.config.Mutex.RLock()
-	defer t.link.core.config.Mutex.RUnlock()
-	for _, listenaddr := range t.link.core.config.Current.Listen {
+	t.links.core.config.Mutex.RLock()
+	defer t.links.core.config.Mutex.RUnlock()
+	for _, listenaddr := range t.links.core.config.Current.Listen {
 		switch listenaddr[:6] {
 		case "tcp://":
 			if _, err := t.listen(listenaddr[6:], nil); err != nil {
@@ -108,7 +108,7 @@ func (t *tcp) init(l *link) error {
 				return err
 			}
 		default:
-			t.link.core.log.Errorln("Failed to add listener: listener", listenaddr, "is not correctly formatted, ignoring")
+			t.links.core.log.Errorln("Failed to add listener: listener", listenaddr, "is not correctly formatted, ignoring")
 		}
 	}
 
@@ -126,35 +126,35 @@ func (t *tcp) stop() error {
 }
 
 func (t *tcp) reconfigure() {
-	t.link.core.config.Mutex.RLock()
-	added := util.Difference(t.link.core.config.Current.Listen, t.link.core.config.Previous.Listen)
-	deleted := util.Difference(t.link.core.config.Previous.Listen, t.link.core.config.Current.Listen)
-	t.link.core.config.Mutex.RUnlock()
+	t.links.core.config.Mutex.RLock()
+	added := util.Difference(t.links.core.config.Current.Listen, t.links.core.config.Previous.Listen)
+	deleted := util.Difference(t.links.core.config.Previous.Listen, t.links.core.config.Current.Listen)
+	t.links.core.config.Mutex.RUnlock()
 	if len(added) > 0 || len(deleted) > 0 {
 		for _, a := range added {
 			switch a[:6] {
 			case "tcp://":
 				if _, err := t.listen(a[6:], nil); err != nil {
-					t.link.core.log.Errorln("Error adding TCP", a[6:], "listener:", err)
+					t.links.core.log.Errorln("Error adding TCP", a[6:], "listener:", err)
 				}
 			case "tls://":
 				if _, err := t.listen(a[6:], t.tls.forListener); err != nil {
-					t.link.core.log.Errorln("Error adding TLS", a[6:], "listener:", err)
+					t.links.core.log.Errorln("Error adding TLS", a[6:], "listener:", err)
 				}
 			default:
-				t.link.core.log.Errorln("Failed to add listener: listener", a, "is not correctly formatted, ignoring")
+				t.links.core.log.Errorln("Failed to add listener: listener", a, "is not correctly formatted, ignoring")
 			}
 		}
 		for _, d := range deleted {
 			if d[:6] != "tcp://" && d[:6] != "tls://" {
-				t.link.core.log.Errorln("Failed to delete listener: listener", d, "is not correctly formatted, ignoring")
+				t.links.core.log.Errorln("Failed to delete listener: listener", d, "is not correctly formatted, ignoring")
 				continue
 			}
 			t.mutex.Lock()
 			if listener, ok := t.listeners[d[6:]]; ok {
 				t.mutex.Unlock()
 				listener.Stop()
-				t.link.core.log.Infoln("Stopped TCP listener:", d[6:])
+				t.links.core.log.Infoln("Stopped TCP listener:", d[6:])
 			} else {
 				t.mutex.Unlock()
 			}
@@ -202,13 +202,13 @@ func (t *tcp) listener(l *TcpListener, listenaddr string) {
 	}
 	// And here we go!
 	defer func() {
-		t.link.core.log.Infoln("Stopping TCP listener on:", l.Listener.Addr().String())
+		t.links.core.log.Infoln("Stopping TCP listener on:", l.Listener.Addr().String())
 		l.Listener.Close()
 		t.mutex.Lock()
 		delete(t.listeners, listenaddr)
 		t.mutex.Unlock()
 	}()
-	t.link.core.log.Infoln("Listening for TCP on:", l.Listener.Addr().String())
+	t.links.core.log.Infoln("Listening for TCP on:", l.Listener.Addr().String())
 	go func() {
 		<-l.stop
 		l.Listener.Close()
@@ -217,7 +217,7 @@ func (t *tcp) listener(l *TcpListener, listenaddr string) {
 	for {
 		sock, err := l.Listener.Accept()
 		if err != nil {
-			t.link.core.log.Errorln("Failed to accept connection:", err)
+			t.links.core.log.Errorln("Failed to accept connection:", err)
 			return
 		}
 		t.waitgroup.Add(1)
@@ -344,7 +344,7 @@ func (t *tcp) call(saddr string, options interface{}, sintf string, upgrade *Tcp
 			}
 			conn, err = dialer.Dial("tcp", dst.String())
 			if err != nil {
-				t.link.core.log.Debugf("Failed to dial %s: %s", callproto, err)
+				t.links.core.log.Debugf("Failed to dial %s: %s", callproto, err)
 				return
 			}
 			t.waitgroup.Add(1)
@@ -361,7 +361,7 @@ func (t *tcp) handler(sock net.Conn, incoming bool, options interface{}, upgrade
 	if upgrade != nil {
 		var err error
 		if sock, err = upgrade.upgrade(sock); err != nil {
-			t.link.core.log.Errorln("TCP handler upgrade failed:", err)
+			t.links.core.log.Errorln("TCP handler upgrade failed:", err)
 			return
 		} else {
 			upgraded = true
@@ -387,12 +387,12 @@ func (t *tcp) handler(sock net.Conn, incoming bool, options interface{}, upgrade
 		remote, _, _ = net.SplitHostPort(sock.RemoteAddr().String())
 	}
 	force := net.ParseIP(strings.Split(remote, "%")[0]).IsLinkLocalUnicast()
-	link, err := t.link.core.link.create(&stream, name, proto, local, remote, incoming, force)
+	link, err := t.links.create(&stream, name, proto, local, remote, incoming, force)
 	if err != nil {
-		t.link.core.log.Println(err)
+		t.links.core.log.Println(err)
 		panic(err)
 	}
-	t.link.core.log.Debugln("DEBUG: starting handler for", name)
+	t.links.core.log.Debugln("DEBUG: starting handler for", name)
 	err = link.handler()
-	t.link.core.log.Debugln("DEBUG: stopped handler for", name, err)
+	t.links.core.log.Debugln("DEBUG: stopped handler for", name, err)
 }

--- a/src/yggdrasil/tcp_linux.go
+++ b/src/yggdrasil/tcp_linux.go
@@ -20,10 +20,10 @@ func (t *tcp) tcpContext(network, address string, c syscall.RawConn) error {
 
 	// Log any errors
 	if bbr != nil {
-		t.link.core.log.Debugln("Failed to set tcp_congestion_control to bbr for socket, SetsockoptString error:", bbr)
+		t.links.core.log.Debugln("Failed to set tcp_congestion_control to bbr for socket, SetsockoptString error:", bbr)
 	}
 	if control != nil {
-		t.link.core.log.Debugln("Failed to set tcp_congestion_control to bbr for socket, Control error:", control)
+		t.links.core.log.Debugln("Failed to set tcp_congestion_control to bbr for socket, Control error:", control)
 	}
 
 	// Return nil because errors here are not considered fatal for the connection, it just means congestion control is suboptimal
@@ -38,7 +38,7 @@ func (t *tcp) getControl(sintf string) func(string, string, syscall.RawConn) err
 		}
 		c.Control(btd)
 		if err != nil {
-			t.link.core.log.Debugln("Failed to set SO_BINDTODEVICE:", sintf)
+			t.links.core.log.Debugln("Failed to set SO_BINDTODEVICE:", sintf)
 		}
 		return t.tcpContext(network, address, c)
 	}

--- a/src/yggdrasil/tls.go
+++ b/src/yggdrasil/tls.go
@@ -34,7 +34,7 @@ func (t *tcptls) init(tcp *tcp) {
 	}
 
 	edpriv := make(ed25519.PrivateKey, ed25519.PrivateKeySize)
-	copy(edpriv[:], tcp.link.core.sigPriv[:])
+	copy(edpriv[:], tcp.links.core.sigPriv[:])
 
 	certBuf := &bytes.Buffer{}
 
@@ -42,7 +42,7 @@ func (t *tcptls) init(tcp *tcp) {
 	pubtemp := x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
-			CommonName: hex.EncodeToString(tcp.link.core.sigPub[:]),
+			CommonName: hex.EncodeToString(tcp.links.core.sigPub[:]),
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(time.Hour * 24 * 365),


### PR DESCRIPTION
This is built on #692 and contains the other half of that PR.

The goal here is to remove the fixed maximum queue size and replace it with something that drops packets if (and only if) we appear to really be blocked.

The basic idea is:
1. There's no max size for each of the per-peer queues.
2. Instead, when the peer struct queues a packet, it sends a message to the link struct to see if it thinks we may be blocked.
3. The link struct responds if it thinks we are.
4. When the peer struct gets an affirmative response, it enters a "drop mode" where the queue size must be non-increasing. Every time the link send some packets, it reduces the max allowed queue size. When the link eventually becomes idle with an empty queue, it resets to normal mode. This ensures that a queue can grow as large as it needs to in order to deal with a traffic burst, but then it always decreases back to 0 before growing again (and prioritizes traffic to favor low-bandwidth flows until it has emptied, so high-bandwidth flows see packet loss and can learn that it's time to throttle down).

That's glossing over some details (e.g. sequence numbers to avoid reacting to old/outdated information).

This is work-in-progress, it still tends to drop more than I'd like, but it's not terribly far off. Goodput drops from 3 Gbps to about 2.75 Gbps when testing between network namespaces on my machine and using a large MTU. It drops from 700 Mbps to about 500 Mbps when a small MTU is used. It seems to stay consistently at or near line rate when there's a bandwidth limit involved and it's lower than those thresholds.