### PR TITLE
More buffer fine-tuning

### DIFF
--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -304,7 +304,7 @@ func (p *peer) _handleIdle() {
 func (p *peer) dropFromQueue(from phony.Actor, seq uint64) {
 	p.Act(from, func() {
 		p.Act(nil, func() {
-			if seq == p.seq {
+			if seq == p.seq && !p.idle {
 				p.drop = true
 				p.max = p.queue.size + streamMsgSize
 			}

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -290,8 +290,8 @@ func (p *peer) _handleIdle() {
 			break
 		}
 	}
+	p.seq++
 	if len(packets) > 0 {
-		p.seq++
 		p.bytesSent += uint64(size)
 		p.intf.out(packets)
 		p.max = p.queue.size
@@ -304,7 +304,7 @@ func (p *peer) _handleIdle() {
 func (p *peer) dropFromQueue(from phony.Actor, seq uint64) {
 	p.Act(from, func() {
 		p.Act(nil, func() {
-			if seq == p.seq && !p.idle {
+			if seq == p.seq {
 				p.drop = true
 				p.max = p.queue.size + streamMsgSize
 			}

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -303,10 +303,12 @@ func (p *peer) _handleIdle() {
 
 func (p *peer) dropFromQueue(from phony.Actor, seq uint64) {
 	p.Act(from, func() {
-		if seq == p.seq {
-			p.drop = true
-			p.max = p.queue.size + streamMsgSize
-		}
+		p.Act(nil, func() {
+			if seq == p.seq {
+				p.drop = true
+				p.max = p.queue.size + streamMsgSize
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
This should make dropping from the buffers less aggressive. The peer sends a message to itself to enter drop mode, instead of immediately beginning to drop packets. If an idle message sits on the queue between the original drop notification and the message that the peer sends to itself, then this will prevent the node from beginning to drop packets.