### PR TITLE
Precompute more for the switch lookup table

### DIFF
--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -444,6 +444,9 @@ func (t *switchTable) _handleMsg(msg *switchMsg, fromPort switchPort, reprocessi
 			}
 		}
 	}
+	if sender.blocked != oldSender.blocked {
+		doUpdate = true
+	}
 	// Update sender
 	t.data.peers[fromPort] = sender
 	// Decide if we should also update our root info to make the sender our parent
@@ -543,7 +546,9 @@ func (t *switchTable) _updateTable() {
 	}
 	newTable._init()
 	for _, pinfo := range t.data.peers {
-		if pinfo.locator.root != newTable.self.root {
+		if pinfo.blocked ||
+			pinfo.locator.root != newTable.self.root ||
+			pinfo.key == t.key {
 			continue
 		}
 		loc := pinfo.locator.clone()

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -171,7 +171,6 @@ type switchData struct {
 	// All data that's mutable and used by exported Table methods
 	// To be read/written with atomic.Value Store/Load calls
 	locator switchLocator
-	seq     uint64 // Sequence number, reported to peers, so they know about changes
 	peers   map[switchPort]peerInfo
 	msg     *switchMsg
 }
@@ -242,7 +241,6 @@ func (t *switchTable) _cleanRoot() {
 		t.parent = switchPort(0)
 		t.time = now
 		if t.data.locator.root != t.key {
-			t.data.seq++
 			defer t.core.router.reset(nil)
 		}
 		t.data.locator = switchLocator{root: t.key, tstamp: now.Unix()}
@@ -521,7 +519,6 @@ func (t *switchTable) _handleMsg(msg *switchMsg, fromPort switchPort, reprocessi
 	if updateRoot {
 		doUpdate = true
 		if !equiv(&sender.locator, &t.data.locator) {
-			t.data.seq++
 			defer t.core.router.reset(t)
 		}
 		if t.data.locator.tstamp != sender.locator.tstamp {

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -528,7 +528,7 @@ func (t *switchTable) _handleMsg(msg *switchMsg, fromPort switchPort, reprocessi
 		t.parent = sender.port
 		defer t.core.peers.sendSwitchMsgs(t)
 	}
-	if doUpdate {
+	if true || doUpdate {
 		defer t._updateTable()
 	}
 	return


### PR DESCRIPTION
Work-in-progress.

I noticed that, at least on my public node, a significant fraction of its time is spent iterating over the map in the current lookup table and doing a dist calculation to find the next hop (the map iteration is actually the more expensive part, it seems, but distance calculations aren't too far behind).

This tries to get rid of the iteration by producing a nested series of maps. Lookups happen by looping over coords and lookup up that coord in the next layer of the nested map, stopping when we either get to the end or run into a dead end in the nested map structure.

I'm not 100% sure this always reproduces exactly the same next-hop selection as the current code in cases where there are multiple valid next hops. If it doesn't, then it's at least not obvious why.