### PR TITLE
Store less in the DHT

### DIFF
--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -260,7 +260,9 @@ func (t *dht) handleRes(res *dhtRes) {
 		key:    res.Key,
 		coords: res.Coords,
 	}
-	t.insert(&rinfo)
+	if _, isIn := t.table[*rinfo.getNodeID()]; isIn || t.isImportant(&rinfo) {
+		t.insert(&rinfo)
+	}
 	for _, info := range res.Infos {
 		if *info.getNodeID() == t.nodeID {
 			continue

--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -260,7 +260,7 @@ func (t *dht) handleRes(res *dhtRes) {
 		key:    res.Key,
 		coords: res.Coords,
 	}
-	if _, isIn := t.table[*rinfo.getNodeID()]; isIn || t.isImportant(&rinfo) {
+	if t.isImportant(&rinfo) {
 		t.insert(&rinfo)
 	}
 	for _, info := range res.Infos {


### PR DESCRIPTION
This reverts a recent(ish) change to the DHT, so we don't cache nodes that respond to DHT lookups unless they're legitimately important for our DHT.

I think the caching may be causing the DHT to become unbalanced, and cache information about unimportant nodes for too long (until they time out, since we won't bother pinging them if they're unimportant). So DHT lookups have more information to work with, but much of it is bad (due to e.g. coord changes). That's not useful, and leads to more DHT traffic (tending towards relatively few nodes), which I think may be causing some of the recent network instability.