### PR TITLE
Faster queue logic

### DIFF
--- a/src/yggdrasil/packetqueue.go
+++ b/src/yggdrasil/packetqueue.go
@@ -1,15 +1,13 @@
 package yggdrasil
 
-/*
 import (
-	"math/rand"
+	"container/heap"
 	"time"
 )
-*/
 
 // TODO separate queues per e.g. traffic flow
 //  For now, we put everything in queue
-/*
+
 type pqStreamID string
 
 type pqPacketInfo struct {
@@ -18,15 +16,13 @@ type pqPacketInfo struct {
 }
 
 type pqStream struct {
-  id   string
+	id    pqStreamID
 	infos []pqPacketInfo
-	size  int
+	size  uint64
 }
-*/
 
 type packetQueue struct {
-	//streams []pqStream
-	packets [][]byte
+	streams []pqStream
 	size    uint64
 }
 
@@ -36,24 +32,79 @@ func (q *packetQueue) drop() bool {
 	if q.size == 0 {
 		return false
 	}
-	packet := q.packets[0]
-	q.packets = q.packets[1:]
-	q.size -= uint64(len(packet))
-	pool_putBytes(packet)
+	var longestIdx int
+	for idx := range q.streams {
+		if q.streams[idx].size > q.streams[longestIdx].size {
+			longestIdx = idx
+		}
+	}
+	stream := heap.Remove(q, longestIdx).(pqStream)
+	info := stream.infos[0]
+	if len(stream.infos) > 1 {
+		stream.infos = stream.infos[1:]
+		stream.size -= uint64(len(info.packet))
+		heap.Push(q, stream)
+	}
+	pool_putBytes(info.packet)
 	return true
 }
 
 func (q *packetQueue) push(packet []byte) {
-	q.packets = append(q.packets, packet)
-	q.size += uint64(len(packet))
+	id := pqStreamID(peer_getPacketCoords(packet)) // just coords for now
+	info := pqPacketInfo{packet: packet, time: time.Now()}
+	for idx := range q.streams {
+		if q.streams[idx].id == id {
+			q.streams[idx].infos = append(q.streams[idx].infos, info)
+			q.streams[idx].size += uint64(len(packet))
+			q.size += uint64(len(packet))
+			return
+		}
+	}
+	stream := pqStream{id: id, size: uint64(len(packet))}
+	stream.infos = append(stream.infos, info)
+	heap.Push(q, stream)
 }
 
 func (q *packetQueue) pop() ([]byte, bool) {
 	if q.size > 0 {
-		packet := q.packets[0]
-		q.packets = q.packets[1:]
-		q.size -= uint64(len(packet))
-		return packet, true
+		stream := heap.Pop(q).(pqStream)
+		info := stream.infos[0]
+		if len(stream.infos) > 1 {
+			stream.infos = stream.infos[1:]
+			stream.size -= uint64(len(info.packet))
+			heap.Push(q, stream)
+		}
+		return info.packet, true
 	}
 	return nil, false
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Interface methods for packetQueue to satisfy heap.Interface
+
+func (q *packetQueue) Len() int {
+	return len(q.streams)
+}
+
+func (q *packetQueue) Less(i, j int) bool {
+	return q.streams[i].infos[0].time.Before(q.streams[j].infos[0].time)
+}
+
+func (q *packetQueue) Swap(i, j int) {
+	q.streams[i], q.streams[j] = q.streams[j], q.streams[i]
+}
+
+func (q *packetQueue) Push(x interface{}) {
+	stream := x.(pqStream)
+	q.streams = append(q.streams, stream)
+	q.size += stream.size
+}
+
+func (q *packetQueue) Pop() interface{} {
+	idx := len(q.streams) - 1
+	stream := q.streams[idx]
+	q.streams = q.streams[:idx]
+	q.size -= stream.size
+	return stream
 }

--- a/src/yggdrasil/packetqueue.go
+++ b/src/yggdrasil/packetqueue.go
@@ -1,10 +1,15 @@
 package yggdrasil
 
+/*
 import (
 	"math/rand"
 	"time"
 )
+*/
 
+// TODO separate queues per e.g. traffic flow
+//  For now, we put everything in queue
+/*
 type pqStreamID string
 
 type pqPacketInfo struct {
@@ -13,13 +18,15 @@ type pqPacketInfo struct {
 }
 
 type pqStream struct {
+  id   string
 	infos []pqPacketInfo
-	size  uint64
+	size  int
 }
+*/
 
-// TODO separate queues per e.g. traffic flow
 type packetQueue struct {
-	streams map[pqStreamID]pqStream
+	//streams []pqStream
+	packets [][]byte
 	size    uint64
 }
 
@@ -29,83 +36,23 @@ func (q *packetQueue) drop() bool {
 	if q.size == 0 {
 		return false
 	}
-	// select a random stream, odds based on stream size
-	offset := rand.Uint64() % q.size
-	var worst pqStreamID
-	var size uint64
-	for id, stream := range q.streams {
-		worst = id
-		size += stream.size
-		if size >= offset {
-			break
-		}
-	}
-	// drop the oldest packet from the stream
-	worstStream := q.streams[worst]
-	packet := worstStream.infos[0].packet
-	worstStream.infos = worstStream.infos[1:]
-	worstStream.size -= uint64(len(packet))
+	packet := q.packets[0]
+	q.packets = q.packets[1:]
 	q.size -= uint64(len(packet))
 	pool_putBytes(packet)
-	// save the modified stream to queues
-	if len(worstStream.infos) > 0 {
-		q.streams[worst] = worstStream
-	} else {
-		delete(q.streams, worst)
-	}
 	return true
 }
 
 func (q *packetQueue) push(packet []byte) {
-	if q.streams == nil {
-		q.streams = make(map[pqStreamID]pqStream)
-	}
-	// get stream
-	id := pqStreamID(peer_getPacketCoords(packet)) // just coords for now
-	stream := q.streams[id]
-	// update stream
-	stream.infos = append(stream.infos, pqPacketInfo{packet, time.Now()})
-	stream.size += uint64(len(packet))
-	// save update to queues
-	q.streams[id] = stream
+	q.packets = append(q.packets, packet)
 	q.size += uint64(len(packet))
 }
 
 func (q *packetQueue) pop() ([]byte, bool) {
-	if len(q.streams) > 0 {
-		// get the stream that uses the least bandwidth
-		now := time.Now()
-		var best pqStreamID
-		for id := range q.streams {
-			best = id
-			break // get a random ID to start
-		}
-		bestStream := q.streams[best]
-		bestSize := float64(bestStream.size)
-		bestAge := now.Sub(bestStream.infos[0].time).Seconds()
-		for id, stream := range q.streams {
-			thisSize := float64(stream.size)
-			thisAge := now.Sub(stream.infos[0].time).Seconds()
-			// cross multiply to avoid division by zero issues
-			if bestSize*thisAge > thisSize*bestAge {
-				// bestSize/bestAge > thisSize/thisAge -> this uses less bandwidth
-				best = id
-				bestStream = stream
-				bestSize = thisSize
-				bestAge = thisAge
-			}
-		}
-		// get the oldest packet from the best stream
-		packet := bestStream.infos[0].packet
-		bestStream.infos = bestStream.infos[1:]
-		bestStream.size -= uint64(len(packet))
+	if q.size > 0 {
+		packet := q.packets[0]
+		q.packets = q.packets[1:]
 		q.size -= uint64(len(packet))
-		// save the modified stream to queues
-		if len(bestStream.infos) > 0 {
-			q.streams[best] = bestStream
-		} else {
-			delete(q.streams, best)
-		}
 		return packet, true
 	}
 	return nil, false


### PR DESCRIPTION
When testing #702 I see that a significant fraction of the remaining CPU time is spent on the packet queues, specifically the steps where queues are iterated over. We need something faster.

Temporarily, this PR replaces the queues with a single FIFO queue that head-drops when the peer struct decides that it has grown too large.

Ideally, we'll still want to keep separate queues per flow, it's mostly a matter of figuring out what pattern works. Historically, we've sent the packet from the queue that's using the least bandwidth, and dropped from queues randomly (with odds based on how much bandwidth the queue is trying to use). The problem with that is, the order of the queues changes as time passes, so we can't keep things sorted in advance. So we need to pick another criteria to decide which queue to forward from. Note that we tried sending from the smallest queue in the past, and this doesn't work -- the larger queues become permanently frozen. But that was with the old switch worker with a fixed queue size. Since we force queues to drop to 0, it wouldn't get stuck *permanently*, but it may still lead to an unfair distribution of bandwidth. An alternative may be to sort queues based on whichever queue's oldest packet is the oldest (without taking queue size into account), so it will tend towards equal latency per packet sent... I *think* that may come closer to equal bandwidth, but I'm not sure.

EDIT: This now uses a heap, and sorts queues based on whichever queue has the oldest packet, instead of the minimum bandwidth, since that keeps the order constant over time. Pop removes the oldest packet in the queue (the first packet from the stream with the oldest first packet). Drop removes the oldest packet from the queue with the largest size. If I'm thinking about this right, then in the case where there's multiple traffic flows between the same pair of nodes, this should keep packets in separate flows from being reordered with respect to eachother (which is important at the crypto session level, since it means we can use a simple always-increasing nonce progression without dropping additional packets due to reordering).