### PR TITLE
More buffer fine-tuning

### DIFF
--- a/src/yggdrasil/link.go
+++ b/src/yggdrasil/link.go
@@ -387,17 +387,12 @@ func (intf *link) notifySending(size int) {
 	intf.Act(&intf.writer, func() {
 		intf.isSending = true
 		intf.sendTimer = time.AfterFunc(sendTime, intf.notifyBlockedSend)
-		intf._cancelStallTimer()
+		if intf.keepAliveTimer != nil {
+			intf.keepAliveTimer.Stop()
+			intf.keepAliveTimer = nil
+		}
 		intf.peer.notifyBlocked(intf)
 	})
-}
-
-// we just sent something, so cancel any pending timer to send keep-alive traffic
-func (intf *link) _cancelStallTimer() {
-	if intf.stallTimer != nil {
-		intf.stallTimer.Stop()
-		intf.stallTimer = nil
-	}
 }
 
 // This gets called from a time.AfterFunc, and notifies the switch that we appear
@@ -441,11 +436,13 @@ func (intf *link) _notifyIdle() {
 // Set the peer as stalled, to prevent them from returning to the switch until a read succeeds
 func (intf *link) notifyStalled() {
 	intf.Act(nil, func() { // Sent from a time.AfterFunc
-		if intf.stallTimer != nil && !intf.blocked {
+		if intf.stallTimer != nil {
 			intf.stallTimer.Stop()
 			intf.stallTimer = nil
-			intf.blocked = true
-			intf.links.core.switchTable.blockPeer(intf, intf.peer.port)
+			if !intf.blocked {
+				intf.blocked = true
+				intf.links.core.switchTable.blockPeer(intf, intf.peer.port)
+			}
 		}
 	})
 }
@@ -480,9 +477,9 @@ func (intf *link) notifyRead(size int) {
 // We need to send keep-alive traffic now
 func (intf *link) notifyDoKeepAlive() {
 	intf.Act(nil, func() { // Sent from a time.AfterFunc
-		if intf.stallTimer != nil {
-			intf.stallTimer.Stop()
-			intf.stallTimer = nil
+		if intf.keepAliveTimer != nil {
+			intf.keepAliveTimer.Stop()
+			intf.keepAliveTimer = nil
 			intf.writer.sendFrom(nil, [][]byte{nil}) // Empty keep-alive traffic
 		}
 	})

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -270,13 +270,13 @@ func (intf *routerInterface) out(bss [][]byte) {
 			intf.router._handlePacket(bs)
 		}
 	})
-	//intf.router.peer.Act(nil, intf.router.peer._handleIdle)
+	// This should now immediately make the peer idle again
+	// So the self-peer shouldn't end up buffering anything
+	// We let backpressure act as a throttle instead
 	intf.router.peer._handleIdle()
 }
 
 func (intf *routerInterface) linkOut(_ []byte) {}
-
-func (intf *routerInterface) notifyQueued(seq uint64) {}
 
 func (intf *routerInterface) close() {}
 


### PR DESCRIPTION
This does 4 things:
1. Simplifies how we detect when a link is blocked.
2. When a peer struct starts dropping, we set the max queue size to something larger, so we don't start dropping *immediately*.
3. When a peer struct is sent an idle notification, instead of dequeuing packets until some size threshold is reached, it dequeues *all* of them. This seems to have little or no effect when a node is bandwidth limited, and improves throughput when the node is CPU limited.
4. Fixes some issues in link.go with how we send keep-alive traffic and decide when to block/unblock a peer in the switch, which was put here because the details depend on changes in 1.