### PR TITLE
Multicast

### DIFF
--- a/src/multicast/multicast.go
+++ b/src/multicast/multicast.go
@@ -259,17 +259,13 @@ func (m *Multicast) _announce() {
 			continue
 		}
 		// Find the interface that matches the listener
-		if intf, err := net.InterfaceByName(name); err == nil {
-			if addrs, err := intf.Addrs(); err == nil {
-				// Loop through the addresses attached to that listener and see if any
-				// of them match the current address of the listener
-				for _, addr := range addrs {
-					if ip, _, err := net.ParseCIDR(addr.String()); err == nil {
-						// Does the interface address match our listener address?
-						if ip.Equal(listenaddr.IP) {
-							found = true
-							break
-						}
+		if info, ok := m._interfaces[name]; ok {
+			for _, addr := range info.addrs {
+				if ip, _, err := net.ParseCIDR(addr.String()); err == nil {
+					// Does the interface address match our listener address?
+					if ip.Equal(listenaddr.IP) {
+						found = true
+						break
 					}
 				}
 			}


### PR DESCRIPTION
In the multicast code, we already pre-compute a map of interface names onto a struct that contains the `net.Interface` and the interface's address. There was a place in the multicast code that I overlooked, where we were still calling `net.InterfaceByName()` and `(*net.Interface).Addrs()` unnecessarily, instead of using the map.

Not tested very extensively on my end (just enough to see that it works between network namespaces).