### PR TITLE
Set default conf file on FreeBSD to /usr/local/etc/yggdrasil.conf

### DIFF
--- a/src/defaults/defaults_freebsd.go
+++ b/src/defaults/defaults_freebsd.go
@@ -10,7 +10,7 @@ func GetDefaults() platformDefaultParameters {
 		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
 
 		// Configuration (used for yggdrasilctl)
-		DefaultConfigFile: "/etc/yggdrasil.conf",
+		DefaultConfigFile: "/usr/local/etc/yggdrasil.conf",
 
 		// Multicast interfaces
 		DefaultMulticastInterfaces: []string{


### PR DESCRIPTION
FreeBSD generally uses /usr/local/ for everything installed in userspace.

May want to put this on hold until we figure out how to solve the main problem with the FreeBSD port (not being able to destroy the interface on shutdown).