### PR TITLE
Fix AppArmor issue & have safe perms for config

### DIFF
--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -83,7 +83,7 @@ then
   echo "Backing up configuration file to /var/backups/yggdrasil.conf.`date +%Y%m%d`"
   cp /etc/yggdrasil.conf /var/backups/yggdrasil.conf.`date +%Y%m%d`
   echo "Normalising and updating /etc/yggdrasil.conf"
-  /usr/bin/yggdrasil -useconffile /var/backups/yggdrasil.conf.`date +%Y%m%d` -normaliseconf > /etc/yggdrasil.conf
+  /usr/bin/yggdrasil -useconf -normaliseconf < /var/backups/yggdrasil.conf.`date +%Y%m%d` > /etc/yggdrasil.conf
   chgrp yggdrasil /etc/yggdrasil.conf
 
   if command -v systemctl >/dev/null; then
@@ -94,7 +94,7 @@ then
 else
   echo "Generating initial configuration file /etc/yggdrasil.conf"
   echo "Please familiarise yourself with this file before starting Yggdrasil"
-  /usr/bin/yggdrasil -genconf > /etc/yggdrasil.conf
+  sh -c 'umask 0027 && /usr/bin/yggdrasil -genconf > /etc/yggdrasil.conf'
   chgrp yggdrasil /etc/yggdrasil.conf
 fi
 EOF


### PR DESCRIPTION
The AppArmor profile in contrib forbids `/usr/bin/yggdrasil` from reading the file in `/var/backups/yggdrasil.conf...`. This works around that restriction by having the shell do the reading of `/var/backups/yggdrasil.conf...` file while providing the same exact functionality without making the AppArmor profile less restrictive. 

Another change is the safe perms for the `/etc/yggdrasil.conf` (so that config will have 0640 permissions). This is important because if we kept the default of 644 then any user (privileged or unprivileged) will have the ability to read the yggdrasil private key. We use a restrictive umask of 0027 to make this possible. 