### PR TITLE
Listener bugfix

### DIFF
--- a/src/multicast/multicast.go
+++ b/src/multicast/multicast.go
@@ -191,7 +191,9 @@ func (m *Multicast) getAllowedInterfaces() map[string]net.Interface {
 	// Ask the system for network interfaces
 	allifaces, err := net.Interfaces()
 	if err != nil {
-		panic(err)
+		// Don't panic, since this may be from e.g. too many open files (from too much connection spam)
+		// TODO? log something
+		return nil
 	}
 	// Work out which interfaces to announce on
 	for _, iface := range allifaces {

--- a/src/yggdrasil/tcp.go
+++ b/src/yggdrasil/tcp.go
@@ -226,7 +226,13 @@ func (t *tcp) listener(l *TcpListener, listenaddr string) {
 		sock, err := l.Listener.Accept()
 		if err != nil {
 			t.links.core.log.Errorln("Failed to accept connection:", err)
-			return
+			select {
+			case <-l.stop:
+				return
+			default:
+			}
+			time.Sleep(time.Second) // So we don't busy loop
+			continue
 		}
 		t.waitgroup.Add(1)
 		options := tcpOptions{


### PR DESCRIPTION
If the listener ever receives an error, then currently it will exit, and there's no mechanism to recover (other than maybe reconfiguring with a `SIGHUP`, I didn't test).

With this patch, instead of exiting when there's an error, check if the listener was stopped. If it wasn't stopped, then assume it's a temporary error, pause for 1 second (to avoid busy loops), and then continue trying to `Accept()` new connections.

Also, within the multicast code, currently we `panic` if we fail to get the list of network interfaces. Instead, return an empty map of interfaces/addresses if we failed to get them, as this can also be caused by temporary problems.

I'm not 100% happy with either of these changes, but they seem to (partially) work around a couple of issues reported in the chat. At the very least, if things enter into a broken state, they should now either recover on their own (eventually) or continue to spam the log with info about the problem.