### PR TITLE
apparmor: allow yggdrasil to resolve hostnames

### DIFF
--- a/contrib/apparmor/usr.bin.yggdrasil
+++ b/contrib/apparmor/usr.bin.yggdrasil
@@ -1,25 +1,17 @@
-# Last Modified: Tue Mar 10 16:38:14 2020
+# Last Modified: Fri Oct 30 11:33:31 2020
 #include <tunables/global>
 
 /usr/bin/yggdrasil {
   #include <abstractions/base>
+  #include <abstractions/nameservice>
 
   capability net_admin,
   capability net_raw,
 
-  network inet stream,
-  network inet dgram,
-  network inet6 dgram,
-  network inet6 stream,
-  network netlink raw,
-
-  /lib/@{multiarch}/ld-*.so mr,
-  /proc/sys/net/core/somaxconn r,
-  owner /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
   /dev/net/tun rw,
+  /proc/sys/net/core/somaxconn r,
+  /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,
 
-  /usr/bin/yggdrasil mr,
   /etc/yggdrasil.conf rw,
   /run/yggdrasil.sock rw,
-
 }


### PR DESCRIPTION
The apparmor profile in it's current state won't allow resolving hostnames. We need `<abstractions/nameservice>` because we simply can't just allow `/etc/resolv.conf`. This is because systemd-resolved, resolvconf, and others rely on symbolic links to `/etc/resolv.conf` which would make this extremely complicated.  `<abstractions/nameservice>` deals with this complexity to allow every single one of those packages (systemd-resolved, resolvconf, ... ).

```
  network inet stream,
  network inet dgram,
  network inet6 dgram,
  network inet6 stream,
  network netlink raw,
```
was removed because it's already included in `<abstractions/nameservice>`. Some permissions that are no longer needed in newer yggdrasil versions were also removed.

`owner /sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,` was changed to `/sys/kernel/mm/transparent_hugepage/hpage_pmd_size r,` because there is no guarantee that yggdrasil will always be run as root. (`owner` makes sure that the process's user and the file have the same owner, in that case, root. This might not always be the case so `owner` was removed)