### PR TITLE
Hybrid

### DIFF
--- a/src/yggdrasil/packetqueue.go
+++ b/src/yggdrasil/packetqueue.go
@@ -54,7 +54,8 @@ func (q *packetQueue) drop() bool {
 }
 
 func (q *packetQueue) push(packet []byte) {
-	id := pqStreamID(peer_getPacketCoords(packet)) // just coords for now
+	_, coords := wire_getTrafficOffsetAndCoords(packet)
+	id := pqStreamID(coords) // just coords for now
 	info := pqPacketInfo{packet: packet, time: time.Now()}
 	for idx := range q.streams {
 		if q.streams[idx].id == id {

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -236,13 +236,6 @@ func (p *peer) _handlePacket(packet []byte) {
 	}
 }
 
-// Get the coords of a packet without decoding
-func peer_getPacketCoords(packet []byte) []byte {
-	_, pTypeLen := wire_decode_uint64(packet)
-	coords, _ := wire_decode_coords(packet[pTypeLen:])
-	return coords
-}
-
 // Called to handle traffic or protocolTraffic packets.
 // In either case, this reads from the coords of the packet header, does a switch lookup, and forwards to the next node.
 func (p *peer) _handleTraffic(packet []byte) {
@@ -250,7 +243,7 @@ func (p *peer) _handleTraffic(packet []byte) {
 		// Drop traffic if the peer isn't in the switch
 		return
 	}
-	coords := peer_getPacketCoords(packet)
+	_, coords := wire_getTrafficOffsetAndCoords(packet)
 	next := p.table.lookup(coords)
 	if nPeer, isIn := p.ports[next]; isIn {
 		nPeer.sendPacketFrom(p, packet)

--- a/src/yggdrasil/version.go
+++ b/src/yggdrasil/version.go
@@ -24,7 +24,7 @@ func version_getBaseMetadata() version_metadata {
 	return version_metadata{
 		meta:     [4]byte{'m', 'e', 't', 'a'},
 		ver:      0,
-		minorVer: 2,
+		minorVer: 0,
 	}
 }
 


### PR DESCRIPTION
This is work-in-progress of a proof-of-concept (backwards incompatible) change to the routing scheme. The protocol version info has been set to a dummy value (0.0) to avoid peering with existing nodes.

Currently, we use greedy routing in all cases. This means we forward to the peer that minimizes the expected distance to the destination, where the expected distance is the distance on the spanning tree.

In this hybrid approach, we check if we're an ancestor of the destination (that is to say, if their coords in the tree are equal to our coords plus some additional hops). If we're their ancestor then we switch to source routing, using their coords (which are a source routed path from the root to the destination) as the source routed path.

In some cases where coord change, this *may* prevent packet loss as the cost of (possibly) routing along a suboptimal path. In particular, if the root stays the same and all of the old root->destination links are still active, then traffic *should* still be able to reach the destination after its coords are changed.

The source routing logic here can be reused (or slightly adapted) for more general source routing if/when we implement a full source routing pathfinder.