### PR TITLE
Fix DefaultIfName for OpenBSD

### DIFF
--- a/src/defaults/defaults_openbsd.go
+++ b/src/defaults/defaults_openbsd.go
@@ -20,6 +20,6 @@ func GetDefaults() platformDefaultParameters {
 		// TUN/TAP
 		MaximumIfMTU:  16384,
 		DefaultIfMTU:  16384,
-		DefaultIfName: "/dev/tun0",
+		DefaultIfName: "tun0",
 	}
 }


### PR DESCRIPTION
Specifying the full path to the interface in OpenBSD would result in:
panic: Interface name must be tun[0-9]*

Therefore, DefaultIfName should be changed to tun0 in order to make yggdrasil work out of the box.