### PR TITLE
Source routing (proof-of-concept)

### DIFF
--- a/src/yggdrasil/dht.go
+++ b/src/yggdrasil/dht.go
@@ -94,7 +94,6 @@ func (t *dht) reset() {
 			t.ping(info, nil)
 		}
 	}
-	t.reqs = make(map[dhtReqKey]time.Time)
 	t.table = make(map[crypto.NodeID]*dhtInfo)
 	t.imp = nil
 }

--- a/src/yggdrasil/packetqueue.go
+++ b/src/yggdrasil/packetqueue.go
@@ -54,7 +54,8 @@ func (q *packetQueue) drop() bool {
 }
 
 func (q *packetQueue) push(packet []byte) {
-	id := pqStreamID(peer_getPacketCoords(packet)) // just coords for now
+	_, coords := wire_getTrafficOffsetAndCoords(packet)
+	id := pqStreamID(coords) // just coords for now
 	info := pqPacketInfo{packet: packet, time: time.Now()}
 	for idx := range q.streams {
 		if q.streams[idx].id == id {

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -245,7 +245,7 @@ func (p *peer) _handleTraffic(packet []byte) {
 	}
 	obs, coords := wire_getTrafficOffsetAndCoords(packet)
 	offset, _ := wire_decode_uint64(obs)
-	ports := p.table.getPorts(coords)
+	ports := switch_getPorts(coords)
 	if offset == 0 {
 		offset = p.table.getOffset(ports)
 	}
@@ -262,7 +262,7 @@ func (p *peer) _handleTraffic(packet []byte) {
 			wire_put_uint64(offset, obs[:0])
 		}
 	}
-	packet = wire_put_uint64(uint64(next), packet)
+	packet = wire_put_uint64(uint64(p.port), packet)
 	if nPeer, isIn := p.ports[next]; isIn {
 		nPeer.sendPacketFrom(p, packet)
 	}

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -236,13 +236,6 @@ func (p *peer) _handlePacket(packet []byte) {
 	}
 }
 
-// Get the coords of a packet without decoding
-func peer_getPacketCoords(packet []byte) []byte {
-	_, pTypeLen := wire_decode_uint64(packet)
-	coords, _ := wire_decode_coords(packet[pTypeLen:])
-	return coords
-}
-
 // Called to handle traffic or protocolTraffic packets.
 // In either case, this reads from the coords of the packet header, does a switch lookup, and forwards to the next node.
 func (p *peer) _handleTraffic(packet []byte) {
@@ -250,7 +243,7 @@ func (p *peer) _handleTraffic(packet []byte) {
 		// Drop traffic if the peer isn't in the switch
 		return
 	}
-	coords := peer_getPacketCoords(packet)
+	_, coords := wire_getTrafficOffsetAndCoords(packet)
 	next := p.table.lookup(coords)
 	if nPeer, isIn := p.ports[next]; isIn {
 		nPeer.sendPacketFrom(p, packet)

--- a/src/yggdrasil/peer.go
+++ b/src/yggdrasil/peer.go
@@ -262,6 +262,7 @@ func (p *peer) _handleTraffic(packet []byte) {
 			wire_put_uint64(offset, obs[:0])
 		}
 	}
+	packet = wire_put_uint64(uint64(next), packet)
 	if nPeer, isIn := p.ports[next]; isIn {
 		nPeer.sendPacketFrom(p, packet)
 	}

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -206,7 +206,7 @@ func (r *router) _handleProto(packet []byte) {
 	case wire_DHTLookupRequest:
 		r._handleDHTReq(bs, &p.FromKey, p.RPath)
 	case wire_DHTLookupResponse:
-		r._handleDHTRes(bs, &p.FromKey)
+		r._handleDHTRes(bs, &p.FromKey, p.RPath)
 	default:
 	}
 }
@@ -237,13 +237,13 @@ func (r *router) _handleDHTReq(bs []byte, fromKey *crypto.BoxPubKey, rpath []byt
 }
 
 // Decodes dht responses and passes them to dht.handleRes to update the DHT table and further pass them to the search code (if applicable).
-func (r *router) _handleDHTRes(bs []byte, fromKey *crypto.BoxPubKey) {
+func (r *router) _handleDHTRes(bs []byte, fromKey *crypto.BoxPubKey, rpath []byte) {
 	res := dhtRes{}
 	if !res.decode(bs) {
 		return
 	}
 	res.Key = *fromKey
-	r.dht.handleRes(&res)
+	r.dht.handleRes(&res, rpath)
 }
 
 // Decodes nodeinfo request

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -196,9 +196,9 @@ func (r *router) _handleProto(packet []byte) {
 	}
 	switch bsType {
 	case wire_SessionPing:
-		r._handlePing(bs, &p.FromKey)
+		r._handlePing(bs, &p.FromKey, p.RPath)
 	case wire_SessionPong:
-		r._handlePong(bs, &p.FromKey)
+		r._handlePong(bs, &p.FromKey, p.RPath)
 	case wire_NodeInfoRequest:
 		fallthrough
 	case wire_NodeInfoResponse:
@@ -212,18 +212,18 @@ func (r *router) _handleProto(packet []byte) {
 }
 
 // Decodes session pings from wire format and passes them to sessions.handlePing where they either create or update a session.
-func (r *router) _handlePing(bs []byte, fromKey *crypto.BoxPubKey) {
+func (r *router) _handlePing(bs []byte, fromKey *crypto.BoxPubKey, rpath []byte) {
 	ping := sessionPing{}
 	if !ping.decode(bs) {
 		return
 	}
 	ping.SendPermPub = *fromKey
-	r.sessions.handlePing(&ping)
+	r.sessions.handlePing(&ping, rpath)
 }
 
 // Handles session pongs (which are really pings with an extra flag to prevent acknowledgement).
-func (r *router) _handlePong(bs []byte, fromKey *crypto.BoxPubKey) {
-	r._handlePing(bs, fromKey)
+func (r *router) _handlePong(bs []byte, fromKey *crypto.BoxPubKey, rpath []byte) {
+	r._handlePing(bs, fromKey, rpath)
 }
 
 // Decodes dht requests and passes them to dht.handleReq to trigger a lookup/response.

--- a/src/yggdrasil/router.go
+++ b/src/yggdrasil/router.go
@@ -204,7 +204,7 @@ func (r *router) _handleProto(packet []byte) {
 	case wire_NodeInfoResponse:
 		r._handleNodeInfo(bs, &p.FromKey)
 	case wire_DHTLookupRequest:
-		r._handleDHTReq(bs, &p.FromKey)
+		r._handleDHTReq(bs, &p.FromKey, p.RPath)
 	case wire_DHTLookupResponse:
 		r._handleDHTRes(bs, &p.FromKey)
 	default:
@@ -227,13 +227,13 @@ func (r *router) _handlePong(bs []byte, fromKey *crypto.BoxPubKey, rpath []byte)
 }
 
 // Decodes dht requests and passes them to dht.handleReq to trigger a lookup/response.
-func (r *router) _handleDHTReq(bs []byte, fromKey *crypto.BoxPubKey) {
+func (r *router) _handleDHTReq(bs []byte, fromKey *crypto.BoxPubKey, rpath []byte) {
 	req := dhtReq{}
 	if !req.decode(bs) {
 		return
 	}
 	req.Key = *fromKey
-	r.dht.handleReq(&req)
+	r.dht.handleReq(&req, rpath)
 }
 
 // Decodes dht responses and passes them to dht.handleRes to update the DHT table and further pass them to the search code (if applicable).

--- a/src/yggdrasil/stream.go
+++ b/src/yggdrasil/stream.go
@@ -114,7 +114,7 @@ func (s *stream) readMsgFromBuffer() ([]byte, error) {
 		return nil, errors.New("oversized message")
 	}
 	msg := pool_getBytes(int(msgLen + 10)) // Extra padding for up to 1 more switchPort
-	msg = msg[msgLen:]
+	msg = msg[:msgLen]
 	_, err = io.ReadFull(s.inputBuffer, msg)
 	return msg, err
 }

--- a/src/yggdrasil/stream.go
+++ b/src/yggdrasil/stream.go
@@ -113,7 +113,8 @@ func (s *stream) readMsgFromBuffer() ([]byte, error) {
 	if msgLen > streamMsgSize {
 		return nil, errors.New("oversized message")
 	}
-	msg := pool_getBytes(int(msgLen))
+	msg := pool_getBytes(int(msgLen + 10)) // Extra padding for up to 1 more switchPort
+	msg = msg[msgLen:]
 	_, err = io.ReadFull(s.inputBuffer, msg)
 	return msg, err
 }

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -644,7 +644,7 @@ func (t *lookupTable) lookup(ports []switchPort) switchPort {
 	return here.port
 }
 
-func (t *lookupTable) getPorts(coords []byte) []switchPort {
+func switch_getPorts(coords []byte) []switchPort {
 	var ports []switchPort
 	var offset int
 	for offset < len(coords) {

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -655,6 +655,19 @@ func switch_getPorts(coords []byte) []switchPort {
 	return ports
 }
 
+func switch_reverseCoordBytes(coords []byte) []byte {
+	a := switch_getPorts(coords)
+	for i := len(a)/2 - 1; i >= 0; i-- {
+		opp := len(a) - 1 - i
+		a[i], a[opp] = a[opp], a[i]
+	}
+	var reversed []byte
+	for _, sPort := range a {
+		reversed = wire_put_uint64(uint64(sPort), reversed)
+	}
+	return reversed
+}
+
 func (t *lookupTable) isDescendant(ports []switchPort) bool {
 	// Note that this returns true for anyone in the subtree that starts at us
 	// That includes ourself, so we are our own descendant by this logic...

--- a/src/yggdrasil/switch.go
+++ b/src/yggdrasil/switch.go
@@ -20,10 +20,9 @@ import (
 )
 
 const (
-	switch_timeout          = time.Minute
-	switch_updateInterval   = switch_timeout / 2
-	switch_throttle         = switch_updateInterval / 2
-	switch_faster_threshold = 240 //Number of switch updates before switching to a faster parent
+	switch_timeout        = time.Minute
+	switch_updateInterval = switch_timeout / 2
+	switch_throttle       = switch_updateInterval / 2
 )
 
 // The switch locator represents the topology and network state dependent info about a node, minus the signatures that go with it.
@@ -136,15 +135,14 @@ func (x *switchLocator) isAncestorOf(y *switchLocator) bool {
 
 // Information about a peer, used by the switch to build the tree and eventually make routing decisions.
 type peerInfo struct {
-	key        crypto.SigPubKey      // ID of this peer
-	locator    switchLocator         // Should be able to respond with signatures upon request
-	degree     uint64                // Self-reported degree
-	time       time.Time             // Time this node was last seen
-	faster     map[switchPort]uint64 // Counter of how often a node is faster than the current parent, penalized extra if slower
-	port       switchPort            // Interface number of this peer
-	msg        switchMsg             // The wire switchMsg used
-	readBlock  bool                  // True if the link notified us of a read that blocked too long
-	writeBlock bool                  // True of the link notified us of a write that blocked too long
+	key        crypto.SigPubKey // ID of this peer
+	locator    switchLocator    // Should be able to respond with signatures upon request
+	degree     uint64           // Self-reported degree
+	time       time.Time        // Time this node was last seen
+	port       switchPort       // Interface number of this peer
+	msg        switchMsg        // The wire switchMsg used
+	readBlock  bool             // True if the link notified us of a read that blocked too long
+	writeBlock bool             // True of the link notified us of a write that blocked too long
 }
 
 func (pinfo *peerInfo) blocked() bool {
@@ -427,37 +425,12 @@ func (t *switchTable) _handleMsg(msg *switchMsg, fromPort switchPort, reprocessi
 	doUpdate := false
 	oldSender := t.data.peers[fromPort]
 	if !equiv(&sender.locator, &oldSender.locator) {
-		// Reset faster info, we'll start refilling it right after this
-		sender.faster = nil
 		doUpdate = true
 	}
-	// Update the matrix of peer "faster" thresholds
 	if reprocessing {
-		sender.faster = oldSender.faster
 		sender.time = oldSender.time
 		sender.readBlock = oldSender.readBlock
 		sender.writeBlock = oldSender.writeBlock
-	} else {
-		sender.faster = make(map[switchPort]uint64, len(oldSender.faster))
-		for port, peer := range t.data.peers {
-			if port == fromPort {
-				continue
-			} else if sender.locator.root != peer.locator.root || sender.locator.tstamp > peer.locator.tstamp {
-				// We were faster than this node, so increment, as long as we don't overflow because of it
-				if oldSender.faster[peer.port] < switch_faster_threshold {
-					sender.faster[port] = oldSender.faster[peer.port] + 1
-				} else {
-					sender.faster[port] = switch_faster_threshold
-				}
-			} else {
-				// Slower than this node, penalize (more than the reward amount)
-				if oldSender.faster[port] > 1 {
-					sender.faster[port] = oldSender.faster[peer.port] - 2
-				} else {
-					sender.faster[port] = 0
-				}
-			}
-		}
 	}
 	if sender.blocked() != oldSender.blocked() {
 		doUpdate = true
@@ -496,35 +469,11 @@ func (t *switchTable) _handleMsg(msg *switchMsg, fromPort switchPort, reprocessi
 	case noParent:
 		// We currently have no working parent, and at this point in the switch statement, anything is better than nothing.
 		updateRoot = true
-	case sender.faster[t.parent] >= switch_faster_threshold:
-		// The is reliably faster than the current parent.
-		updateRoot = true
 	case !sender.blocked() && oldParent.blocked():
 		// Replace a blocked parent
 		updateRoot = true
 	case reprocessing && sender.blocked() && !oldParent.blocked():
 		// Don't replace an unblocked parent when reprocessing
-	case reprocessing && sender.faster[t.parent] > oldParent.faster[sender.port]:
-		// The sender seems to be reliably faster than the current parent, so switch to them instead.
-		updateRoot = true
-	case sender.port != t.parent:
-		// Ignore further cases if the sender isn't our parent.
-	case !reprocessing && !equiv(&sender.locator, &t.data.locator):
-		// Special case:
-		// If coords changed, then we need to penalize this node somehow, to prevent flapping.
-		// First, reset all faster-related info to 0.
-		// Then, de-parent the node and reprocess all messages to find a new parent.
-		t.parent = 0
-		for _, peer := range t.data.peers {
-			if peer.port == sender.port {
-				continue
-			}
-			t._handleMsg(&peer.msg, peer.port, true)
-		}
-		// Process the sender last, to avoid keeping them as a parent if at all possible.
-		t._handleMsg(&sender.msg, sender.port, true)
-	case now.Sub(t.time) < switch_throttle:
-		// We've already gotten an update from this root recently, so ignore this one to avoid flooding.
 	case sender.locator.tstamp > t.data.locator.tstamp:
 		// The timestamp was updated, so we need to update locally and send to our peers.
 		updateRoot = true

--- a/src/yggdrasil/version.go
+++ b/src/yggdrasil/version.go
@@ -24,7 +24,7 @@ func version_getBaseMetadata() version_metadata {
 	return version_metadata{
 		meta:     [4]byte{'m', 'e', 't', 'a'},
 		ver:      0,
-		minorVer: 2,
+		minorVer: 0,
 	}
 }
 

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -269,7 +269,7 @@ func (p *wire_trafficPacket) decode(bs []byte) bool {
 	case !wire_chop_vslice(&p.RPath, &bs):
 		return false
 	}
-	p.Path = bs
+	p.Path = append(p.Path[:0], bs...)
 	return true
 }
 
@@ -322,7 +322,7 @@ func (p *wire_protoTrafficPacket) decode(bs []byte) bool {
 	case !wire_chop_vslice(&p.RPath, &bs):
 		return false
 	}
-	p.Path = bs
+	p.Path = append(p.Path[:0], bs...)
 	return true
 }
 

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -96,9 +96,9 @@ func wire_encode_coords(coords []byte) []byte {
 
 // Puts a length prefix and the coords into bs, returns the wire formatted coords.
 // Useful in hot loops where we don't want to allocate and we know the rest of the later parts of the slice are safe to overwrite.
-func wire_put_coords(coords []byte, bs []byte) []byte {
-	bs = wire_put_uint64(uint64(len(coords)), bs)
-	bs = append(bs, coords...)
+func wire_put_vslice(slice []byte, bs []byte) []byte {
+	bs = wire_put_uint64(uint64(len(slice)), bs)
+	bs = append(bs, slice...)
 	return bs
 }
 
@@ -194,14 +194,14 @@ func wire_chop_slice(toSlice []byte, fromSlice *[]byte) bool {
 	return true
 }
 
-// A utility function to extract coords from a slice and advance the source slices, returning true if successful.
-func wire_chop_coords(toCoords *[]byte, fromSlice *[]byte) bool {
-	coords, coordLen := wire_decode_coords(*fromSlice)
-	if coordLen == 0 {
+// A utility function to extract a length-prefixed slice (such as coords) from a slice and advance the source slices, returning true if successful.
+func wire_chop_vslice(toSlice *[]byte, fromSlice *[]byte) bool {
+	slice, sliceLen := wire_decode_coords(*fromSlice)
+	if sliceLen == 0 { // sliceLen is length-prefix size + slice size, in bytes
 		return false
 	}
-	*toCoords = append((*toCoords)[:0], coords...)
-	*fromSlice = (*fromSlice)[coordLen:]
+	*toSlice = append((*toSlice)[:0], slice...)
+	*fromSlice = (*fromSlice)[sliceLen:]
 	return true
 }
 
@@ -227,6 +227,8 @@ type wire_trafficPacket struct {
 	Handle  crypto.Handle
 	Nonce   crypto.BoxNonce
 	Payload []byte
+	RPath   []byte
+	Path    []byte
 }
 
 // Encodes a wire_trafficPacket into its wire format.
@@ -235,10 +237,12 @@ func (p *wire_trafficPacket) encode() []byte {
 	bs := pool_getBytes(0)
 	bs = wire_put_uint64(wire_Traffic, bs)
 	bs = wire_put_uint64(p.Offset, bs)
-	bs = wire_put_coords(p.Coords, bs)
+	bs = wire_put_vslice(p.Coords, bs)
 	bs = append(bs, p.Handle[:]...)
 	bs = append(bs, p.Nonce[:]...)
-	bs = append(bs, p.Payload...)
+	bs = wire_put_vslice(p.Payload, bs)
+	bs = wire_put_vslice(p.RPath, bs)
+	bs = append(bs, p.Path...)
 	return bs
 }
 
@@ -254,14 +258,18 @@ func (p *wire_trafficPacket) decode(bs []byte) bool {
 		return false
 	case !wire_chop_uint64(&p.Offset, &bs):
 		return false
-	case !wire_chop_coords(&p.Coords, &bs):
+	case !wire_chop_vslice(&p.Coords, &bs):
 		return false
 	case !wire_chop_slice(p.Handle[:], &bs):
 		return false
 	case !wire_chop_slice(p.Nonce[:], &bs):
 		return false
+	case !wire_chop_vslice(&p.Payload, &bs):
+		return false
+	case !wire_chop_vslice(&p.RPath, &bs):
+		return false
 	}
-	p.Payload = append(p.Payload, bs...)
+	p.Path = bs
 	return true
 }
 
@@ -273,18 +281,21 @@ type wire_protoTrafficPacket struct {
 	FromKey crypto.BoxPubKey
 	Nonce   crypto.BoxNonce
 	Payload []byte
+	RPath   []byte
+	Path    []byte
 }
 
 // Encodes a wire_protoTrafficPacket into its wire format.
 func (p *wire_protoTrafficPacket) encode() []byte {
-	coords := wire_encode_coords(p.Coords)
 	bs := wire_encode_uint64(wire_ProtocolTraffic)
 	bs = wire_put_uint64(p.Offset, bs)
-	bs = append(bs, coords...)
+	bs = wire_put_vslice(p.Coords, bs)
 	bs = append(bs, p.ToKey[:]...)
 	bs = append(bs, p.FromKey[:]...)
 	bs = append(bs, p.Nonce[:]...)
-	bs = append(bs, p.Payload...)
+	bs = wire_put_vslice(p.Payload, bs)
+	bs = wire_put_vslice(p.RPath, bs)
+	bs = append(bs, p.Path...)
 	return bs
 }
 
@@ -298,7 +309,7 @@ func (p *wire_protoTrafficPacket) decode(bs []byte) bool {
 		return false
 	case !wire_chop_uint64(&p.Offset, &bs):
 		return false
-	case !wire_chop_coords(&p.Coords, &bs):
+	case !wire_chop_vslice(&p.Coords, &bs):
 		return false
 	case !wire_chop_slice(p.ToKey[:], &bs):
 		return false
@@ -306,8 +317,12 @@ func (p *wire_protoTrafficPacket) decode(bs []byte) bool {
 		return false
 	case !wire_chop_slice(p.Nonce[:], &bs):
 		return false
+	case !wire_chop_vslice(&p.Payload, &bs):
+		return false
+	case !wire_chop_vslice(&p.RPath, &bs):
+		return false
 	}
-	p.Payload = bs
+	p.Path = bs
 	return true
 }
 
@@ -391,7 +406,7 @@ func (p *sessionPing) decode(bs []byte) bool {
 		return false
 	case !wire_chop_uint64(&tstamp, &bs):
 		return false
-	case !wire_chop_coords(&p.Coords, &bs):
+	case !wire_chop_vslice(&p.Coords, &bs):
 		return false
 	case !wire_chop_uint64(&mtu, &bs):
 		mtu = 1280
@@ -415,7 +430,7 @@ func (p *nodeinfoReqRes) encode() []byte {
 		pTypeVal = wire_NodeInfoRequest
 	}
 	bs := wire_encode_uint64(pTypeVal)
-	bs = wire_put_coords(p.SendCoords, bs)
+	bs = wire_put_vslice(p.SendCoords, bs)
 	if pTypeVal == wire_NodeInfoResponse {
 		bs = append(bs, p.NodeInfo...)
 	}
@@ -430,7 +445,7 @@ func (p *nodeinfoReqRes) decode(bs []byte) bool {
 		return false
 	case pType != wire_NodeInfoRequest && pType != wire_NodeInfoResponse:
 		return false
-	case !wire_chop_coords(&p.SendCoords, &bs):
+	case !wire_chop_vslice(&p.SendCoords, &bs):
 		return false
 	}
 	if p.IsResponse = pType == wire_NodeInfoResponse; p.IsResponse {
@@ -464,7 +479,7 @@ func (r *dhtReq) decode(bs []byte) bool {
 		return false
 	case pType != wire_DHTLookupRequest:
 		return false
-	case !wire_chop_coords(&r.Coords, &bs):
+	case !wire_chop_vslice(&r.Coords, &bs):
 		return false
 	case !wire_chop_slice(r.Dest[:], &bs):
 		return false
@@ -495,7 +510,7 @@ func (r *dhtRes) decode(bs []byte) bool {
 		return false
 	case pType != wire_DHTLookupResponse:
 		return false
-	case !wire_chop_coords(&r.Coords, &bs):
+	case !wire_chop_vslice(&r.Coords, &bs):
 		return false
 	case !wire_chop_slice(r.Dest[:], &bs):
 		return false
@@ -505,7 +520,7 @@ func (r *dhtRes) decode(bs []byte) bool {
 		switch {
 		case !wire_chop_slice(info.key[:], &bs):
 			return false
-		case !wire_chop_coords(&info.coords, &bs):
+		case !wire_chop_vslice(&info.coords, &bs):
 			return false
 		}
 		r.Infos = append(r.Infos, &info)

--- a/src/yggdrasil/wire.go
+++ b/src/yggdrasil/wire.go
@@ -228,7 +228,6 @@ type wire_trafficPacket struct {
 	Nonce   crypto.BoxNonce
 	Payload []byte
 	RPath   []byte
-	Path    []byte
 }
 
 // Encodes a wire_trafficPacket into its wire format.
@@ -241,8 +240,7 @@ func (p *wire_trafficPacket) encode() []byte {
 	bs = append(bs, p.Handle[:]...)
 	bs = append(bs, p.Nonce[:]...)
 	bs = wire_put_vslice(p.Payload, bs)
-	bs = wire_put_vslice(p.RPath, bs)
-	bs = append(bs, p.Path...)
+	bs = append(bs, p.RPath...)
 	return bs
 }
 
@@ -266,10 +264,8 @@ func (p *wire_trafficPacket) decode(bs []byte) bool {
 		return false
 	case !wire_chop_vslice(&p.Payload, &bs):
 		return false
-	case !wire_chop_vslice(&p.RPath, &bs):
-		return false
 	}
-	p.Path = append(p.Path[:0], bs...)
+	p.RPath = append(p.RPath[:0], bs...)
 	return true
 }
 
@@ -282,7 +278,6 @@ type wire_protoTrafficPacket struct {
 	Nonce   crypto.BoxNonce
 	Payload []byte
 	RPath   []byte
-	Path    []byte
 }
 
 // Encodes a wire_protoTrafficPacket into its wire format.
@@ -294,8 +289,7 @@ func (p *wire_protoTrafficPacket) encode() []byte {
 	bs = append(bs, p.FromKey[:]...)
 	bs = append(bs, p.Nonce[:]...)
 	bs = wire_put_vslice(p.Payload, bs)
-	bs = wire_put_vslice(p.RPath, bs)
-	bs = append(bs, p.Path...)
+	bs = append(bs, p.RPath...)
 	return bs
 }
 
@@ -319,10 +313,8 @@ func (p *wire_protoTrafficPacket) decode(bs []byte) bool {
 		return false
 	case !wire_chop_vslice(&p.Payload, &bs):
 		return false
-	case !wire_chop_vslice(&p.RPath, &bs):
-		return false
 	}
-	p.Path = append(p.Path[:0], bs...)
+	p.RPath = append(p.RPath[:0], bs...)
 	return true
 }
 


### PR DESCRIPTION
This patch builds on #741 by adding source routing to Yggdrasil. This is not meant for actual use, as certain aspects are incomplete and/or insecure (i.e. a node could lie by corrupting the source route, and there's nothing in the protocol that event attempts to detect this, nevermind fix or work around it, though in principle we could probably add something to do that if we decide to go with this approach).

This is mainly intended for performance studies, so we can compare how well source routing would do compared to hybrid routing or the current greedy routing scheme, using something like [meshnet-lab](https://github.com/mwarning/meshnet-lab) for example.

Some quick notes about how it works:
1. Any time traffic is forwarded through the network, the port number back to the previous hop is appended to a new (variable-sized) field at the end of the packet.
2. When certain types of protocol traffic are received (currently session pings and dht requests), the response traffic is sent back via the source route.
3. When the response traffic is received, the new reverse-route at the end of the packet corresponds to the route that the original hybrid-routed packet followed (i.e. when you receive a session pong, the reverse route is the same route that your session ping followed to reach the destination -- the route all your greedy/hybrid routing traffic should follow if you don't do anything with the source route).
4. In the case of session traffic, we cache the route we receive from session pongs. If we want to send session traffic, and we have a route cached, then we source route the traffic instead of depending on greedy/hybrid routing.
5. A handful of other things in the network have been retuned now that source routes are available. For example, we update parents in the tree *much* more aggressively (since existing sessions will continue to source route to reach us).
6. The way source routes are used is by replacing the coords with the source route, but with a pointless leading 0 added as padding at the beginning, and then setting the hybrid routing offset to 1 (so it skips over the pointless 0). That tricks the hybrid routing logic into source routing instead. I honestly can't decide if this is an ugly hack or a beautiful demonstration of how versatile the hybrid routing packets can be (given that we also continue to sneak traffic flow / congestion control information into the same field of the packet).

It should go without saying that all of this is backwards incompatible with the live network.