### PR TITLE
Preallocate memory when deriving address from key

### DIFF
--- a/src/address/address.go
+++ b/src/address/address.go
@@ -64,7 +64,7 @@ func AddrForKey(publicKey ed25519.PublicKey) *Address {
 		buf[idx] = ^buf[idx]
 	}
 	var addr Address
-	var temp []byte
+	var temp = make([]byte, 0, 32)
 	done := false
 	ones := byte(0)
 	bits := byte(0)


### PR DESCRIPTION
This makes `src/address.AddrForKey` preallocate 128 bytes for `temp` before starting the address derivation. As [benches](https://git.tdem.in/tdemin/syg_go/src/commit/f5ca266cf10d01faf60a775f8a69e003f5bb5798/crypto_test.go#L35) versus the [version that already does that](https://git.tdem.in/tdemin/syg_go/src/commit/f5ca266cf10d01faf60a775f8a69e003f5bb5798/crypto.go#L31) in syg_go show, reallocating `temp` each time in the loop takes ~ 20% of the function runtime.

The change has no impact on function behaviour.

![Benchmark results](https://user-images.githubusercontent.com/26599554/124635773-41349c80-dea1-11eb-9299-9d9bf6d754f9.png)
