### PR TITLE
Split yggdrasilctl code into separate functions (refactoring)

### DIFF
--- a/cmd/yggdrasilctl/cmd_line_env.go
+++ b/cmd/yggdrasilctl/cmd_line_env.go
@@ -15,8 +15,8 @@ import (
 )
 
 type CmdLineEnv struct {
-	args []string
-	endpoint, server string
+	args                 []string
+	endpoint, server     string
 	injson, verbose, ver bool
 }
 
@@ -26,7 +26,7 @@ func newCmdLineEnv() CmdLineEnv {
 	return cmdLineEnv
 }
 
-func (cmdLineEnv *CmdLineEnv)parseFlagsAndArgs() {
+func (cmdLineEnv *CmdLineEnv) parseFlagsAndArgs() {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] command [key=value] [key=value] ...\n\n", os.Args[0])
 		fmt.Println("Options:")
@@ -59,7 +59,7 @@ func (cmdLineEnv *CmdLineEnv)parseFlagsAndArgs() {
 	cmdLineEnv.ver = *ver
 }
 
-func (cmdLineEnv *CmdLineEnv)setEndpoint(logger *log.Logger) {
+func (cmdLineEnv *CmdLineEnv) setEndpoint(logger *log.Logger) {
 	if cmdLineEnv.server == cmdLineEnv.endpoint {
 		if config, err := ioutil.ReadFile(defaults.GetDefaults().DefaultConfigFile); err == nil {
 			if bytes.Equal(config[0:2], []byte{0xFF, 0xFE}) ||

--- a/cmd/yggdrasilctl/cmd_line_env.go
+++ b/cmd/yggdrasilctl/cmd_line_env.go
@@ -1,4 +1,4 @@
-package cmd_line_env
+package main
 
 import (
 	"bytes"
@@ -15,18 +15,18 @@ import (
 )
 
 type CmdLineEnv struct {
-	Args []string
-	Endpoint, Server string
-	Injson, Verbose, Ver bool
+	args []string
+	endpoint, server string
+	injson, verbose, ver bool
 }
 
-func New() CmdLineEnv {
+func newCmdLineEnv() CmdLineEnv {
 	var cmdLineEnv CmdLineEnv
-	cmdLineEnv.Endpoint = defaults.GetDefaults().DefaultAdminListen
+	cmdLineEnv.endpoint = defaults.GetDefaults().DefaultAdminListen
 	return cmdLineEnv
 }
 
-func (cmdLineEnv *CmdLineEnv)ParseFlagsAndArgs() {
+func (cmdLineEnv *CmdLineEnv)parseFlagsAndArgs() {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] command [key=value] [key=value] ...\n\n", os.Args[0])
 		fmt.Println("Options:")
@@ -45,22 +45,22 @@ func (cmdLineEnv *CmdLineEnv)ParseFlagsAndArgs() {
 		fmt.Println("  - ", os.Args[0], "-endpoint=unix:///var/run/ygg.sock getDHT")
 	}
 
-	server := flag.String("endpoint", cmdLineEnv.Endpoint, "Admin socket endpoint")
+	server := flag.String("endpoint", cmdLineEnv.endpoint, "Admin socket endpoint")
 	injson := flag.Bool("json", false, "Output in JSON format (as opposed to pretty-print)")
 	verbose := flag.Bool("v", false, "Verbose output (includes public keys)")
 	ver := flag.Bool("version", false, "Prints the version of this build")
 
 	flag.Parse()
 
-	cmdLineEnv.Args = flag.Args()
-	cmdLineEnv.Server = *server
-	cmdLineEnv.Injson = *injson
-	cmdLineEnv.Verbose = *verbose
-	cmdLineEnv.Ver = *ver
+	cmdLineEnv.args = flag.Args()
+	cmdLineEnv.server = *server
+	cmdLineEnv.injson = *injson
+	cmdLineEnv.verbose = *verbose
+	cmdLineEnv.ver = *ver
 }
 
-func (cmdLineEnv *CmdLineEnv)SetEndpoint(logger *log.Logger) {
-	if cmdLineEnv.Server == cmdLineEnv.Endpoint {
+func (cmdLineEnv *CmdLineEnv)setEndpoint(logger *log.Logger) {
+	if cmdLineEnv.server == cmdLineEnv.endpoint {
 		if config, err := ioutil.ReadFile(defaults.GetDefaults().DefaultConfigFile); err == nil {
 			if bytes.Equal(config[0:2], []byte{0xFF, 0xFE}) ||
 				bytes.Equal(config[0:2], []byte{0xFE, 0xFF}) {
@@ -76,9 +76,9 @@ func (cmdLineEnv *CmdLineEnv)SetEndpoint(logger *log.Logger) {
 				panic(err)
 			}
 			if ep, ok := dat["AdminListen"].(string); ok && (ep != "none" && ep != "") {
-				cmdLineEnv.Endpoint = ep
+				cmdLineEnv.endpoint = ep
 				logger.Println("Found platform default config file", defaults.GetDefaults().DefaultConfigFile)
-				logger.Println("Using endpoint", cmdLineEnv.Endpoint, "from AdminListen")
+				logger.Println("Using endpoint", cmdLineEnv.endpoint, "from AdminListen")
 			} else {
 				logger.Println("Configuration file doesn't contain appropriate AdminListen option")
 				logger.Println("Falling back to platform default", defaults.GetDefaults().DefaultAdminListen)
@@ -88,7 +88,7 @@ func (cmdLineEnv *CmdLineEnv)SetEndpoint(logger *log.Logger) {
 			logger.Println("Falling back to platform default", defaults.GetDefaults().DefaultAdminListen)
 		}
 	} else {
-		cmdLineEnv.Endpoint = cmdLineEnv.Server
-		logger.Println("Using endpoint", cmdLineEnv.Endpoint, "from command line")
+		cmdLineEnv.endpoint = cmdLineEnv.server
+		logger.Println("Using endpoint", cmdLineEnv.endpoint, "from command line")
 	}
 }

--- a/cmd/yggdrasilctl/cmd_line_env/cmd_line_env.go
+++ b/cmd/yggdrasilctl/cmd_line_env/cmd_line_env.go
@@ -1,0 +1,94 @@
+package cmd_line_env
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/hjson/hjson-go"
+	"golang.org/x/text/encoding/unicode"
+
+	"github.com/yggdrasil-network/yggdrasil-go/src/defaults"
+)
+
+type CmdLineEnv struct {
+	Args []string
+	Endpoint, Server string
+	Injson, Verbose, Ver bool
+}
+
+func New() CmdLineEnv {
+	var cmdLineEnv CmdLineEnv
+	cmdLineEnv.Endpoint = defaults.GetDefaults().DefaultAdminListen
+	return cmdLineEnv
+}
+
+func (cmdLineEnv *CmdLineEnv)ParseFlagsAndArgs() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] command [key=value] [key=value] ...\n\n", os.Args[0])
+		fmt.Println("Options:")
+		flag.PrintDefaults()
+		fmt.Println()
+		fmt.Println("Please note that options must always specified BEFORE the command\non the command line or they will be ignored.")
+		fmt.Println()
+		fmt.Println("Commands:\n  - Use \"list\" for a list of available commands")
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  - ", os.Args[0], "list")
+		fmt.Println("  - ", os.Args[0], "getPeers")
+		fmt.Println("  - ", os.Args[0], "-v getSelf")
+		fmt.Println("  - ", os.Args[0], "setTunTap name=auto mtu=1500 tap_mode=false")
+		fmt.Println("  - ", os.Args[0], "-endpoint=tcp://localhost:9001 getDHT")
+		fmt.Println("  - ", os.Args[0], "-endpoint=unix:///var/run/ygg.sock getDHT")
+	}
+
+	server := flag.String("endpoint", cmdLineEnv.Endpoint, "Admin socket endpoint")
+	injson := flag.Bool("json", false, "Output in JSON format (as opposed to pretty-print)")
+	verbose := flag.Bool("v", false, "Verbose output (includes public keys)")
+	ver := flag.Bool("version", false, "Prints the version of this build")
+
+	flag.Parse()
+
+	cmdLineEnv.Args = flag.Args()
+	cmdLineEnv.Server = *server
+	cmdLineEnv.Injson = *injson
+	cmdLineEnv.Verbose = *verbose
+	cmdLineEnv.Ver = *ver
+}
+
+func (cmdLineEnv *CmdLineEnv)SetEndpoint(logger *log.Logger) {
+	if cmdLineEnv.Server == cmdLineEnv.Endpoint {
+		if config, err := ioutil.ReadFile(defaults.GetDefaults().DefaultConfigFile); err == nil {
+			if bytes.Equal(config[0:2], []byte{0xFF, 0xFE}) ||
+				bytes.Equal(config[0:2], []byte{0xFE, 0xFF}) {
+				utf := unicode.UTF16(unicode.BigEndian, unicode.UseBOM)
+				decoder := utf.NewDecoder()
+				config, err = decoder.Bytes(config)
+				if err != nil {
+					panic(err)
+				}
+			}
+			var dat map[string]interface{}
+			if err := hjson.Unmarshal(config, &dat); err != nil {
+				panic(err)
+			}
+			if ep, ok := dat["AdminListen"].(string); ok && (ep != "none" && ep != "") {
+				cmdLineEnv.Endpoint = ep
+				logger.Println("Found platform default config file", defaults.GetDefaults().DefaultConfigFile)
+				logger.Println("Using endpoint", cmdLineEnv.Endpoint, "from AdminListen")
+			} else {
+				logger.Println("Configuration file doesn't contain appropriate AdminListen option")
+				logger.Println("Falling back to platform default", defaults.GetDefaults().DefaultAdminListen)
+			}
+		} else {
+			logger.Println("Can't open config file from default location", defaults.GetDefaults().DefaultConfigFile)
+			logger.Println("Falling back to platform default", defaults.GetDefaults().DefaultAdminListen)
+		}
+	} else {
+		cmdLineEnv.Endpoint = cmdLineEnv.Server
+		logger.Println("Using endpoint", cmdLineEnv.Endpoint, "from command line")
+	}
+}

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -32,6 +32,7 @@ func main() {
 func run() int {
 	logbuffer := &bytes.Buffer{}
 	logger := log.New(logbuffer, "", log.Flags())
+
 	defer func() int {
 		if r := recover(); r != nil {
 			logger.Println("Fatal error:", r)
@@ -60,6 +61,7 @@ func run() int {
 		fmt.Println("  - ", os.Args[0], "-endpoint=tcp://localhost:9001 getDHT")
 		fmt.Println("  - ", os.Args[0], "-endpoint=unix:///var/run/ygg.sock getDHT")
 	}
+
 	server := flag.String("endpoint", endpoint, "Admin socket endpoint")
 	injson := flag.Bool("json", false, "Output in JSON format (as opposed to pretty-print)")
 	verbose := flag.Bool("v", false, "Verbose output (includes public keys)")
@@ -113,6 +115,7 @@ func run() int {
 
 	var conn net.Conn
 	u, err := url.Parse(endpoint)
+
 	if err == nil {
 		switch strings.ToLower(u.Scheme) {
 		case "unix":
@@ -129,9 +132,11 @@ func run() int {
 		logger.Println("Connecting to TCP socket", u.Host)
 		conn, err = net.Dial("tcp", endpoint)
 	}
+
 	if err != nil {
 		panic(err)
 	}
+
 	logger.Println("Connected")
 	defer conn.Close()
 
@@ -176,7 +181,9 @@ func run() int {
 	if err := encoder.Encode(&send); err != nil {
 		panic(err)
 	}
+
 	logger.Printf("Request sent")
+
 	if err := decoder.Decode(&recv); err == nil {
 		logger.Printf("Response received")
 		if recv["status"] == "error" {
@@ -212,6 +219,7 @@ func run() int {
 	if v, ok := recv["status"]; ok && v != "success" {
 		return 1
 	}
+
 	return 0
 }
 

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -26,11 +26,8 @@ type admin_info map[string]interface{}
 
 type CmdLineEnv struct {
 	args []string
-	endpoint string
-	server string
-	injson bool
-	verbose bool
-	ver bool
+	endpoint, server string
+	injson, verbose, ver bool
 }
 
 func main() {

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -50,7 +50,7 @@ func run() int {
 
 	cmdLineEnv := createCmdLineEnv()
 
-	parseFlagsAndArgs(&cmdLineEnv)
+	cmdLineEnv.parseFlagsAndArgs()
 
 	if cmdLineEnv.ver {
 		fmt.Println("Build name:", version.BuildName())
@@ -64,7 +64,7 @@ func run() int {
 		return 0
 	}
 
-	setEndpoint(&cmdLineEnv, logger)
+	cmdLineEnv.setEndpoint(logger)
 
 	var conn net.Conn
 	u, err := url.Parse(cmdLineEnv.endpoint)
@@ -182,7 +182,7 @@ func createCmdLineEnv() CmdLineEnv {
 	return cmdLineEnv
 }
 
-func parseFlagsAndArgs(cmdLineEnv *CmdLineEnv) {
+func (cmdLineEnv *CmdLineEnv)parseFlagsAndArgs() {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] command [key=value] [key=value] ...\n\n", os.Args[0])
 		fmt.Println("Options:")
@@ -215,7 +215,7 @@ func parseFlagsAndArgs(cmdLineEnv *CmdLineEnv) {
 	cmdLineEnv.ver = *ver
 }
 
-func setEndpoint(cmdLineEnv *CmdLineEnv, logger *log.Logger) {
+func (cmdLineEnv *CmdLineEnv)setEndpoint(logger *log.Logger) {
 	if cmdLineEnv.server == cmdLineEnv.endpoint {
 		if config, err := ioutil.ReadFile(defaults.GetDefaults().DefaultConfigFile); err == nil {
 			if bytes.Equal(config[0:2], []byte{0xFF, 0xFE}) ||

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -38,7 +38,7 @@ func main() {
 	os.Exit(run())
 }
 
-func parseCmdLine(cmdLineEnv *CmdLineEnv) {
+func parseFlagsAndArgs(cmdLineEnv *CmdLineEnv) {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] command [key=value] [key=value] ...\n\n", os.Args[0])
 		fmt.Println("Options:")
@@ -86,7 +86,7 @@ func run() int {
 
 	var cmdLineEnv CmdLineEnv
 	cmdLineEnv.endpoint = defaults.GetDefaults().DefaultAdminListen
-	parseCmdLine(&cmdLineEnv)
+	parseFlagsAndArgs(&cmdLineEnv)
 
 	if cmdLineEnv.ver {
 		fmt.Println("Build name:", version.BuildName())

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -195,7 +195,6 @@ func run() int {
 			fmt.Println("Missing response body (malformed response?)")
 			return 1
 		}
-		req := recv["request"].(map[string]interface{})
 		res := recv["response"].(map[string]interface{})
 
 		if *injson {
@@ -205,36 +204,7 @@ func run() int {
 			return 0
 		}
 
-		switch strings.ToLower(req["request"].(string)) {
-		case "dot":
-			runDot(res)
-		case "list", "getpeers", "getswitchpeers", "getdht", "getsessions", "dhtping":
-			runVariousInfo(res, verbose)
-		case "gettuntap", "settuntap":
-			runGetAndSetTunTap(res)
-		case "getself":
-			runGetSelf(res, verbose)
-		case "getswitchqueues":
-			runGetSwitchQueues(res)
-		case "addpeer", "removepeer", "addallowedencryptionpublickey", "removeallowedencryptionpublickey", "addsourcesubnet", "addroute", "removesourcesubnet", "removeroute":
-			runAddsAndRemoves(res)
-		case "getallowedencryptionpublickeys":
-			runGetAllowedEncryptionPublicKeys(res)
-		case "getmulticastinterfaces":
-			runGetMulticastInterfaces(res)
-		case "getsourcesubnets":
-			runGetSourceSubnets(res)
-		case "getroutes":
-			runGetRoutes(res)
-		case "settunnelrouting":
-			fallthrough
-		case "gettunnelrouting":
-			runGetTunnelRouting(res)
-		default:
-			if json, err := json.MarshalIndent(recv["response"], "", "  "); err == nil {
-				fmt.Println(string(json))
-			}
-		}
+		runAll(recv, verbose)
 	} else {
 		logger.Println("Error receiving response:", err)
 	}
@@ -243,6 +213,42 @@ func run() int {
 		return 1
 	}
 	return 0
+}
+
+func runAll(recv map[string]interface{}, verbose *bool) {
+	req := recv["request"].(map[string]interface{})
+	res := recv["response"].(map[string]interface{})
+
+	switch strings.ToLower(req["request"].(string)) {
+	case "dot":
+		runDot(res)
+	case "list", "getpeers", "getswitchpeers", "getdht", "getsessions", "dhtping":
+		runVariousInfo(res, verbose)
+	case "gettuntap", "settuntap":
+		runGetAndSetTunTap(res)
+	case "getself":
+		runGetSelf(res, verbose)
+	case "getswitchqueues":
+		runGetSwitchQueues(res)
+	case "addpeer", "removepeer", "addallowedencryptionpublickey", "removeallowedencryptionpublickey", "addsourcesubnet", "addroute", "removesourcesubnet", "removeroute":
+		runAddsAndRemoves(res)
+	case "getallowedencryptionpublickeys":
+		runGetAllowedEncryptionPublicKeys(res)
+	case "getmulticastinterfaces":
+		runGetMulticastInterfaces(res)
+	case "getsourcesubnets":
+		runGetSourceSubnets(res)
+	case "getroutes":
+		runGetRoutes(res)
+	case "settunnelrouting":
+		fallthrough
+	case "gettunnelrouting":
+		runGetTunnelRouting(res)
+	default:
+		if json, err := json.MarshalIndent(recv["response"], "", "  "); err == nil {
+			fmt.Println(string(json))
+		}
+	}
 }
 
 func runDot(res map[string]interface{}) {

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -38,7 +38,6 @@ func run() int {
 	}()
 
 	cmdLineEnv := newCmdLineEnv()
-
 	cmdLineEnv.parseFlagsAndArgs()
 
 	if cmdLineEnv.ver {

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -38,6 +38,12 @@ func main() {
 	os.Exit(run())
 }
 
+func createCmdLineEnv() CmdLineEnv {
+	var cmdLineEnv CmdLineEnv
+	cmdLineEnv.endpoint = defaults.GetDefaults().DefaultAdminListen
+	return cmdLineEnv
+}
+
 func parseFlagsAndArgs(cmdLineEnv *CmdLineEnv) {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] command [key=value] [key=value] ...\n\n", os.Args[0])
@@ -118,8 +124,8 @@ func run() int {
 		return 0
 	}()
 
-	var cmdLineEnv CmdLineEnv
-	cmdLineEnv.endpoint = defaults.GetDefaults().DefaultAdminListen
+	cmdLineEnv := createCmdLineEnv()
+
 	parseFlagsAndArgs(&cmdLineEnv)
 
 	if cmdLineEnv.ver {

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -38,79 +38,6 @@ func main() {
 	os.Exit(run())
 }
 
-func createCmdLineEnv() CmdLineEnv {
-	var cmdLineEnv CmdLineEnv
-	cmdLineEnv.endpoint = defaults.GetDefaults().DefaultAdminListen
-	return cmdLineEnv
-}
-
-func parseFlagsAndArgs(cmdLineEnv *CmdLineEnv) {
-	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] command [key=value] [key=value] ...\n\n", os.Args[0])
-		fmt.Println("Options:")
-		flag.PrintDefaults()
-		fmt.Println()
-		fmt.Println("Please note that options must always specified BEFORE the command\non the command line or they will be ignored.")
-		fmt.Println()
-		fmt.Println("Commands:\n  - Use \"list\" for a list of available commands")
-		fmt.Println()
-		fmt.Println("Examples:")
-		fmt.Println("  - ", os.Args[0], "list")
-		fmt.Println("  - ", os.Args[0], "getPeers")
-		fmt.Println("  - ", os.Args[0], "-v getSelf")
-		fmt.Println("  - ", os.Args[0], "setTunTap name=auto mtu=1500 tap_mode=false")
-		fmt.Println("  - ", os.Args[0], "-endpoint=tcp://localhost:9001 getDHT")
-		fmt.Println("  - ", os.Args[0], "-endpoint=unix:///var/run/ygg.sock getDHT")
-	}
-
-	server := flag.String("endpoint", cmdLineEnv.endpoint, "Admin socket endpoint")
-	injson := flag.Bool("json", false, "Output in JSON format (as opposed to pretty-print)")
-	verbose := flag.Bool("v", false, "Verbose output (includes public keys)")
-	ver := flag.Bool("version", false, "Prints the version of this build")
-
-	flag.Parse()
-
-	cmdLineEnv.args = flag.Args()
-	cmdLineEnv.server = *server
-	cmdLineEnv.injson = *injson
-	cmdLineEnv.verbose = *verbose
-	cmdLineEnv.ver = *ver
-}
-
-func setEndpoint(cmdLineEnv *CmdLineEnv, logger *log.Logger) {
-	if cmdLineEnv.server == cmdLineEnv.endpoint {
-		if config, err := ioutil.ReadFile(defaults.GetDefaults().DefaultConfigFile); err == nil {
-			if bytes.Equal(config[0:2], []byte{0xFF, 0xFE}) ||
-				bytes.Equal(config[0:2], []byte{0xFE, 0xFF}) {
-				utf := unicode.UTF16(unicode.BigEndian, unicode.UseBOM)
-				decoder := utf.NewDecoder()
-				config, err = decoder.Bytes(config)
-				if err != nil {
-					panic(err)
-				}
-			}
-			var dat map[string]interface{}
-			if err := hjson.Unmarshal(config, &dat); err != nil {
-				panic(err)
-			}
-			if ep, ok := dat["AdminListen"].(string); ok && (ep != "none" && ep != "") {
-				cmdLineEnv.endpoint = ep
-				logger.Println("Found platform default config file", defaults.GetDefaults().DefaultConfigFile)
-				logger.Println("Using endpoint", cmdLineEnv.endpoint, "from AdminListen")
-			} else {
-				logger.Println("Configuration file doesn't contain appropriate AdminListen option")
-				logger.Println("Falling back to platform default", defaults.GetDefaults().DefaultAdminListen)
-			}
-		} else {
-			logger.Println("Can't open config file from default location", defaults.GetDefaults().DefaultConfigFile)
-			logger.Println("Falling back to platform default", defaults.GetDefaults().DefaultAdminListen)
-		}
-	} else {
-		cmdLineEnv.endpoint = cmdLineEnv.server
-		logger.Println("Using endpoint", cmdLineEnv.endpoint, "from command line")
-	}
-}
-
 func run() int {
 	logbuffer := &bytes.Buffer{}
 	logger := log.New(logbuffer, "", log.Flags())
@@ -250,6 +177,79 @@ func run() int {
 	}
 
 	return 0
+}
+
+func createCmdLineEnv() CmdLineEnv {
+	var cmdLineEnv CmdLineEnv
+	cmdLineEnv.endpoint = defaults.GetDefaults().DefaultAdminListen
+	return cmdLineEnv
+}
+
+func parseFlagsAndArgs(cmdLineEnv *CmdLineEnv) {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] command [key=value] [key=value] ...\n\n", os.Args[0])
+		fmt.Println("Options:")
+		flag.PrintDefaults()
+		fmt.Println()
+		fmt.Println("Please note that options must always specified BEFORE the command\non the command line or they will be ignored.")
+		fmt.Println()
+		fmt.Println("Commands:\n  - Use \"list\" for a list of available commands")
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  - ", os.Args[0], "list")
+		fmt.Println("  - ", os.Args[0], "getPeers")
+		fmt.Println("  - ", os.Args[0], "-v getSelf")
+		fmt.Println("  - ", os.Args[0], "setTunTap name=auto mtu=1500 tap_mode=false")
+		fmt.Println("  - ", os.Args[0], "-endpoint=tcp://localhost:9001 getDHT")
+		fmt.Println("  - ", os.Args[0], "-endpoint=unix:///var/run/ygg.sock getDHT")
+	}
+
+	server := flag.String("endpoint", cmdLineEnv.endpoint, "Admin socket endpoint")
+	injson := flag.Bool("json", false, "Output in JSON format (as opposed to pretty-print)")
+	verbose := flag.Bool("v", false, "Verbose output (includes public keys)")
+	ver := flag.Bool("version", false, "Prints the version of this build")
+
+	flag.Parse()
+
+	cmdLineEnv.args = flag.Args()
+	cmdLineEnv.server = *server
+	cmdLineEnv.injson = *injson
+	cmdLineEnv.verbose = *verbose
+	cmdLineEnv.ver = *ver
+}
+
+func setEndpoint(cmdLineEnv *CmdLineEnv, logger *log.Logger) {
+	if cmdLineEnv.server == cmdLineEnv.endpoint {
+		if config, err := ioutil.ReadFile(defaults.GetDefaults().DefaultConfigFile); err == nil {
+			if bytes.Equal(config[0:2], []byte{0xFF, 0xFE}) ||
+				bytes.Equal(config[0:2], []byte{0xFE, 0xFF}) {
+				utf := unicode.UTF16(unicode.BigEndian, unicode.UseBOM)
+				decoder := utf.NewDecoder()
+				config, err = decoder.Bytes(config)
+				if err != nil {
+					panic(err)
+				}
+			}
+			var dat map[string]interface{}
+			if err := hjson.Unmarshal(config, &dat); err != nil {
+				panic(err)
+			}
+			if ep, ok := dat["AdminListen"].(string); ok && (ep != "none" && ep != "") {
+				cmdLineEnv.endpoint = ep
+				logger.Println("Found platform default config file", defaults.GetDefaults().DefaultConfigFile)
+				logger.Println("Using endpoint", cmdLineEnv.endpoint, "from AdminListen")
+			} else {
+				logger.Println("Configuration file doesn't contain appropriate AdminListen option")
+				logger.Println("Falling back to platform default", defaults.GetDefaults().DefaultAdminListen)
+			}
+		} else {
+			logger.Println("Can't open config file from default location", defaults.GetDefaults().DefaultConfigFile)
+			logger.Println("Falling back to platform default", defaults.GetDefaults().DefaultAdminListen)
+		}
+	} else {
+		cmdLineEnv.endpoint = cmdLineEnv.server
+		logger.Println("Using endpoint", cmdLineEnv.endpoint, "from command line")
+	}
 }
 
 func runAll(recv map[string]interface{}, verbose bool) {

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/yggdrasil-network/yggdrasil-go/cmd/yggdrasilctl/cmd_line_env"
 	"github.com/yggdrasil-network/yggdrasil-go/src/version"
 )
 
@@ -38,25 +37,25 @@ func run() int {
 		return 0
 	}()
 
-	cmdLineEnv := cmd_line_env.New()
+	cmdLineEnv := newCmdLineEnv()
 
-	cmdLineEnv.ParseFlagsAndArgs()
+	cmdLineEnv.parseFlagsAndArgs()
 
-	if cmdLineEnv.Ver {
+	if cmdLineEnv.ver {
 		fmt.Println("Build name:", version.BuildName())
 		fmt.Println("Build version:", version.BuildVersion())
 		fmt.Println("To get the version number of the running Yggdrasil node, run", os.Args[0], "getSelf")
 		return 0
 	}
 
-	if len(cmdLineEnv.Args) == 0 {
+	if len(cmdLineEnv.args) == 0 {
 		flag.Usage()
 		return 0
 	}
 
-	cmdLineEnv.SetEndpoint(logger)
+	cmdLineEnv.setEndpoint(logger)
 
-	conn := connect(cmdLineEnv.Endpoint, logger)
+	conn := connect(cmdLineEnv.endpoint, logger)
 	logger.Println("Connected")
 	defer conn.Close()
 
@@ -65,7 +64,7 @@ func run() int {
 	send := make(admin_info)
 	recv := make(admin_info)
 
-	for c, a := range cmdLineEnv.Args {
+	for c, a := range cmdLineEnv.args {
 		if c == 0 {
 			if strings.HasPrefix(a, "-") {
 				logger.Printf("Ignoring flag %s as it should be specified before other parameters\n", a)
@@ -124,14 +123,14 @@ func run() int {
 		}
 		res := recv["response"].(map[string]interface{})
 
-		if cmdLineEnv.Injson {
+		if cmdLineEnv.injson {
 			if json, err := json.MarshalIndent(res, "", "  "); err == nil {
 				fmt.Println(string(json))
 			}
 			return 0
 		}
 
-		handleAll(recv, cmdLineEnv.Verbose)
+		handleAll(recv, cmdLineEnv.verbose)
 	} else {
 		logger.Println("Error receiving response:", err)
 	}

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -37,21 +37,7 @@ func main() {
 	os.Exit(run())
 }
 
-func run() int {
-	logbuffer := &bytes.Buffer{}
-	logger := log.New(logbuffer, "", log.Flags())
-
-	defer func() int {
-		if r := recover(); r != nil {
-			logger.Println("Fatal error:", r)
-			fmt.Print(logbuffer)
-			return 1
-		}
-		return 0
-	}()
-
-	endpoint := defaults.GetDefaults().DefaultAdminListen
-
+func createCmdLine(endpoint string) CmdLine {
 	flag.Usage = func() {
 		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] command [key=value] [key=value] ...\n\n", os.Args[0])
 		fmt.Println("Options:")
@@ -77,6 +63,25 @@ func run() int {
 	cmdline.ver = flag.Bool("version", false, "Prints the version of this build")
 	flag.Parse()
 	cmdline.args = flag.Args()
+	return cmdline
+}
+
+func run() int {
+	logbuffer := &bytes.Buffer{}
+	logger := log.New(logbuffer, "", log.Flags())
+
+	defer func() int {
+		if r := recover(); r != nil {
+			logger.Println("Fatal error:", r)
+			fmt.Print(logbuffer)
+			return 1
+		}
+		return 0
+	}()
+
+	endpoint := defaults.GetDefaults().DefaultAdminListen
+
+	cmdline := createCmdLine(endpoint)
 
 	if *cmdline.ver {
 		fmt.Println("Build name:", version.BuildName())

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -141,7 +141,7 @@ func run() int {
 			return 0
 		}
 
-		runAll(recv, cmdLineEnv.verbose)
+		handleAll(recv, cmdLineEnv.verbose)
 	} else {
 		logger.Println("Error receiving response:", err)
 	}
@@ -255,35 +255,35 @@ func connect(endpoint string, logger *log.Logger) net.Conn {
 	return conn
 }
 
-func runAll(recv map[string]interface{}, verbose bool) {
+func handleAll(recv map[string]interface{}, verbose bool) {
 	req := recv["request"].(map[string]interface{})
 	res := recv["response"].(map[string]interface{})
 
 	switch strings.ToLower(req["request"].(string)) {
 	case "dot":
-		runDot(res)
+		handleDot(res)
 	case "list", "getpeers", "getswitchpeers", "getdht", "getsessions", "dhtping":
-		runVariousInfo(res, verbose)
+		handleVariousInfo(res, verbose)
 	case "gettuntap", "settuntap":
-		runGetAndSetTunTap(res)
+		handleGetAndSetTunTap(res)
 	case "getself":
-		runGetSelf(res, verbose)
+		handleGetSelf(res, verbose)
 	case "getswitchqueues":
-		runGetSwitchQueues(res)
+		handleGetSwitchQueues(res)
 	case "addpeer", "removepeer", "addallowedencryptionpublickey", "removeallowedencryptionpublickey", "addsourcesubnet", "addroute", "removesourcesubnet", "removeroute":
-		runAddsAndRemoves(res)
+		handleAddsAndRemoves(res)
 	case "getallowedencryptionpublickeys":
-		runGetAllowedEncryptionPublicKeys(res)
+		handleGetAllowedEncryptionPublicKeys(res)
 	case "getmulticastinterfaces":
-		runGetMulticastInterfaces(res)
+		handleGetMulticastInterfaces(res)
 	case "getsourcesubnets":
-		runGetSourceSubnets(res)
+		handleGetSourceSubnets(res)
 	case "getroutes":
-		runGetRoutes(res)
+		handleGetRoutes(res)
 	case "settunnelrouting":
 		fallthrough
 	case "gettunnelrouting":
-		runGetTunnelRouting(res)
+		handleGetTunnelRouting(res)
 	default:
 		if json, err := json.MarshalIndent(recv["response"], "", "  "); err == nil {
 			fmt.Println(string(json))
@@ -291,11 +291,11 @@ func runAll(recv map[string]interface{}, verbose bool) {
 	}
 }
 
-func runDot(res map[string]interface{}) {
+func handleDot(res map[string]interface{}) {
 	fmt.Println(res["dot"])
 }
 
-func runVariousInfo(res map[string]interface{}, verbose bool) {
+func handleVariousInfo(res map[string]interface{}, verbose bool) {
 	maxWidths := make(map[string]int)
 	var keyOrder []string
 	keysOrdered := false
@@ -358,7 +358,7 @@ func runVariousInfo(res map[string]interface{}, verbose bool) {
 	}
 }
 
-func runGetAndSetTunTap(res map[string]interface{}) {
+func handleGetAndSetTunTap(res map[string]interface{}) {
 	for k, v := range res {
 		fmt.Println("Interface name:", k)
 		if mtu, ok := v.(map[string]interface{})["mtu"].(float64); ok {
@@ -370,7 +370,7 @@ func runGetAndSetTunTap(res map[string]interface{}) {
 	}
 }
 
-func runGetSelf(res map[string]interface{}, verbose bool) {
+func handleGetSelf(res map[string]interface{}, verbose bool) {
 	for k, v := range res["self"].(map[string]interface{}) {
 		if buildname, ok := v.(map[string]interface{})["build_name"].(string); ok && buildname != "unknown" {
 			fmt.Println("Build name:", buildname)
@@ -402,7 +402,7 @@ func runGetSelf(res map[string]interface{}, verbose bool) {
 	}
 }
 
-func runGetSwitchQueues(res map[string]interface{}) {
+func handleGetSwitchQueues(res map[string]interface{}) {
 	maximumqueuesize := float64(4194304)
 	portqueues := make(map[float64]float64)
 	portqueuesize := make(map[float64]float64)
@@ -452,7 +452,7 @@ func runGetSwitchQueues(res map[string]interface{}) {
 	}
 }
 
-func runAddsAndRemoves(res map[string]interface{}) {
+func handleAddsAndRemoves(res map[string]interface{}) {
 	if _, ok := res["added"]; ok {
 		for _, v := range res["added"].([]interface{}) {
 			fmt.Println("Added:", fmt.Sprint(v))
@@ -475,7 +475,7 @@ func runAddsAndRemoves(res map[string]interface{}) {
 	}
 }
 
-func runGetAllowedEncryptionPublicKeys(res map[string]interface{}) {
+func handleGetAllowedEncryptionPublicKeys(res map[string]interface{}) {
 	if _, ok := res["allowed_box_pubs"]; !ok {
 		fmt.Println("All connections are allowed")
 	} else if res["allowed_box_pubs"] == nil {
@@ -488,7 +488,7 @@ func runGetAllowedEncryptionPublicKeys(res map[string]interface{}) {
 	}
 }
 
-func runGetMulticastInterfaces(res map[string]interface{}) {
+func handleGetMulticastInterfaces(res map[string]interface{}) {
 	if _, ok := res["multicast_interfaces"]; !ok {
 		fmt.Println("No multicast interfaces found")
 	} else if res["multicast_interfaces"] == nil {
@@ -501,7 +501,7 @@ func runGetMulticastInterfaces(res map[string]interface{}) {
 	}
 }
 
-func runGetSourceSubnets(res map[string]interface{}) {
+func handleGetSourceSubnets(res map[string]interface{}) {
 	if _, ok := res["source_subnets"]; !ok {
 		fmt.Println("No source subnets found")
 	} else if res["source_subnets"] == nil {
@@ -514,7 +514,7 @@ func runGetSourceSubnets(res map[string]interface{}) {
 	}
 }
 
-func runGetRoutes(res map[string]interface{}) {
+func handleGetRoutes(res map[string]interface{}) {
 	if routes, ok := res["routes"].(map[string]interface{}); !ok {
 		fmt.Println("No routes found")
 	} else {
@@ -531,7 +531,7 @@ func runGetRoutes(res map[string]interface{}) {
 	}
 }
 
-func runGetTunnelRouting(res map[string]interface{}) {
+func handleGetTunnelRouting(res map[string]interface{}) {
 	if enabled, ok := res["enabled"].(bool); !ok {
 		fmt.Println("Tunnel routing is disabled")
 	} else if !enabled {


### PR DESCRIPTION
It's always recommended to split code into small units such as functions because this makes it more understandable. Many code linting tools ([RuboCop](https://rubocop.org) for Ruby programming language for example) have metrics which warn about too long functions: Assigment-Branch-Condition size, methods length, etc. Also this opens the opportunity of testing the code in future.

The previous PR (#814) have been accidentally closed by GitHub when I renamed the branch.