### PR TITLE
[Security] do not run as root.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - in case of vulnerabilities.
 -->
 
+## [future]
+
+### Changed
+- The `AdminListen` option and `yggdrasilctl` now default to `unix:///var/run/yggdrasil/yggdrasil.sock` on Linux
+
+
 ## [0.4.2] - 2021-11-03
 ### Fixed
 - Reverted a dependency update which resulted in problems building with Go 1.16 and running on Windows

--- a/contrib/systemd/yggdrasil.service
+++ b/contrib/systemd/yggdrasil.service
@@ -6,8 +6,6 @@ After=network-online.target
 After=yggdrasil-default-config.service
 
 [Service]
-User=yggdrasil
-Group=yggdrasil
 ProtectHome=true
 ProtectSystem=true
 SyslogIdentifier=yggdrasil
@@ -16,6 +14,12 @@ ExecStart=/usr/bin/yggdrasil -useconffile /etc/yggdrasil.conf
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 TimeoutStopSec=5
+Group=yggdrasil
+User=yggdrasil-dyn
+DynamicUser=true
+ProtectSystem=strict
+NoNewPrivileges=true
+ReadWritePaths=/var/run/yggdrasil /run/yggdrasil
 
 # make sure /var/run/yggdrasil/ is created writable for the user.
 RuntimeDirectory=yggdrasil

--- a/contrib/systemd/yggdrasil.service
+++ b/contrib/systemd/yggdrasil.service
@@ -6,16 +6,21 @@ After=network-online.target
 After=yggdrasil-default-config.service
 
 [Service]
+User=yggdrasil
 Group=yggdrasil
 ProtectHome=true
 ProtectSystem=true
 SyslogIdentifier=yggdrasil
-CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
 ExecStartPre=+-/sbin/modprobe tun
 ExecStart=/usr/bin/yggdrasil -useconffile /etc/yggdrasil.conf
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 TimeoutStopSec=5
+
+# make sure /var/run/yggdrasil/ is created writable for the user.
+RuntimeDirectory=yggdrasil
+# the small list of admin capabilities we need to do our job
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/systemd/yggdrasil.sysusers
+++ b/contrib/systemd/yggdrasil.sysusers
@@ -1,0 +1,1 @@
+u yggdrasil - "Yggdrasil network daemon"

--- a/contrib/systemd/yggdrasil.sysusers
+++ b/contrib/systemd/yggdrasil.sysusers
@@ -1,1 +1,0 @@
-u yggdrasil - "Yggdrasil network daemon"

--- a/src/defaults/defaults_linux.go
+++ b/src/defaults/defaults_linux.go
@@ -8,7 +8,7 @@ package defaults
 func GetDefaults() platformDefaultParameters {
 	return platformDefaultParameters{
 		// Admin
-		DefaultAdminListen: "unix:///var/run/yggdrasil.sock",
+		DefaultAdminListen: "unix:///var/run/yggdrasil/yggdrasil.sock",
 
 		// Configuration (used for yggdrasilctl)
 		DefaultConfigFile: "/etc/yggdrasil.conf",


### PR DESCRIPTION
An Internet accessible service should aim to have as little as
possible attack surface, which is much easier to do when running
with the absolute minimum number of priviledges at all times.

This makes the systemd setup run the service as a user 'yggdrasil'
and uses the systemd feature `RuntimeDirectory` to auto-create
the /var/run/yggdrasil dir so our non-elevated client can still
create the socket. (see #802)

The sysusers file will cause the user be created on first install
using the sysusers subsystem, this can be used by packagers as well.