### PR TITLE
[revised] Add -uid and -uid flags to drop permissions

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -376,12 +376,18 @@ func run(args yggArgs, ctx context.Context, done chan struct{}) {
 	// Lower permissions from root to something else, if the user wants to
 	if syscall.Getuid() == 0 {
 		if args.rungid > 0 {
-			fmt.Println("Dropping gid to ", args.rungid)
-			syscall.Setgid(args.rungid)
+			logger.Infoln("Setting gid to:", args.rungid)
+			if err := setgid(args.rungid); err != nil {
+				logger.Errorln("Failed to set gid:", err)
+				return
+			}
 		}
 		if args.runuid > 0 {
-			fmt.Println("Dropping uid to ", args.rungid)
-			syscall.Setuid(args.runuid)
+			logger.Infoln("Setting uid to:", args.runuid)
+			if err := setuid(args.runuid); err != nil {
+				logger.Errorln("Failed to set uid:", err)
+				return
+			}
 		}
 	}
 	logger.Infof("Your public key is %s", hex.EncodeToString(public[:]))

--- a/cmd/yggdrasil/setids_other.go
+++ b/cmd/yggdrasil/setids_other.go
@@ -1,0 +1,13 @@
+// +build !linux,!darwin,!freebsd,!openbsd
+
+package main
+
+import "errors"
+
+func setuid(uid int) error {
+	return errors.New("setting uid not supported on this platform")
+}
+
+func setgid(gid int) error {
+	return errors.New("setting gid not supported on this platform")
+}

--- a/cmd/yggdrasil/setids_other.go
+++ b/cmd/yggdrasil/setids_other.go
@@ -1,4 +1,4 @@
-// +build !unix
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
 
 package main
 

--- a/cmd/yggdrasil/setids_other.go
+++ b/cmd/yggdrasil/setids_other.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!freebsd,!openbsd
+// +build !unix
 
 package main
 

--- a/cmd/yggdrasil/setids_posix.go
+++ b/cmd/yggdrasil/setids_posix.go
@@ -1,0 +1,13 @@
+// +build linux darwin freebsd openbsd
+
+package main
+
+import "syscall"
+
+func setuid(uid int) error {
+	return syscall.Setuid(uid)
+}
+
+func setgid(gid int) error {
+	return syscall.Setgid(gid)
+}

--- a/cmd/yggdrasil/setids_unix.go
+++ b/cmd/yggdrasil/setids_unix.go
@@ -1,4 +1,4 @@
-// +build unix
+// +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package main
 

--- a/cmd/yggdrasil/setids_unix.go
+++ b/cmd/yggdrasil/setids_unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd openbsd
+// +build unix
 
 package main
 


### PR DESCRIPTION
This is built on #804 (thanks @tsuraan)

It's essentially identical to that PR, except it wraps the syscalls in a separate function, so we can return an error on platforms where this isn't supported (which seems to at least include windows).

I'm not sure exactly what build directives make the most sense here... at the moment, it only supports `linux`, `darwin`, `freebsd`, and `openbsd`, but maybe `!windows` is more correct.

We should probably think a bit about what behavior we want. If we always want to drop permissions, then we could maybe skip the `-uid` and `-gid` args, and hard code a specific user to switch to (`nobody` or whatever makes the most sense).