### PR TITLE
Make it possible to override the default AdminListen option at compile time

### DIFF
--- a/src/defaults/defaults.go
+++ b/src/defaults/defaults.go
@@ -2,6 +2,8 @@ package defaults
 
 import "github.com/yggdrasil-network/yggdrasil-go/src/config"
 
+var adminListen string
+
 type MulticastInterfaceConfig = config.MulticastInterfaceConfig
 
 // Defines which parameters are expected by default for configuration on a
@@ -31,7 +33,12 @@ func GenerateConfig() *config.NodeConfig {
 	cfg := new(config.NodeConfig)
 	cfg.NewKeys()
 	cfg.Listen = []string{}
-	cfg.AdminListen = GetDefaults().DefaultAdminListen
+	if adminListen == "" {
+		// TODO? "none" for all platforms?
+		cfg.AdminListen = GetDefaults().DefaultAdminListen
+	} else {
+		cfg.AdminListen = adminListen
+	}
 	cfg.Peers = []string{}
 	cfg.InterfacePeers = map[string][]string{}
 	cfg.AllowedPublicKeys = []string{}


### PR DESCRIPTION
Related to #816 

The intent here is to make it possible for package maintainers to set the default admin listen value to something appropriate for the distribution. At the moment, the existing default values are unchanged, but I'm considering "none" for all platforms (just to be consistent). I'm not sure I like this approach, but if we go this route, then it probably makes sense to make some of the other default configurable at compile time (and clean up this code, there's probably a better way to do it).

Usage:
`./build -l '-X github.com/yggdrasil-network/yggdrasil-go/src/defaults.adminListen=whatever'`