### PR TITLE
Change systemd service unit file path to /usr/lib

### DIFF
--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -38,7 +38,7 @@ echo "Building $PKGFILE"
 mkdir -p /tmp/$PKGNAME/
 mkdir -p /tmp/$PKGNAME/debian/
 mkdir -p /tmp/$PKGNAME/usr/bin/
-mkdir -p /tmp/$PKGNAME/etc/systemd/system/
+mkdir -p /tmp/$PKGNAME/usr/lib/systemd/system/
 
 cat > /tmp/$PKGNAME/debian/changelog << EOF
 Please see https://github.com/yggdrasil-network/yggdrasil-go/
@@ -68,7 +68,7 @@ EOF
 cat > /tmp/$PKGNAME/debian/install << EOF
 usr/bin/yggdrasil usr/bin
 usr/bin/yggdrasilctl usr/bin
-etc/systemd/system/*.service etc/systemd/system
+usr/lib/systemd/system/*.service usr/lib/systemd/system
 EOF
 cat > /tmp/$PKGNAME/debian/postinst << EOF
 #!/bin/sh
@@ -110,12 +110,12 @@ EOF
 
 cp yggdrasil /tmp/$PKGNAME/usr/bin/
 cp yggdrasilctl /tmp/$PKGNAME/usr/bin/
-cp contrib/systemd/*.service /tmp/$PKGNAME/etc/systemd/system/
+cp contrib/systemd/*.service /tmp/$PKGNAME/usr/lib/systemd/system/
 
 tar -czvf /tmp/$PKGNAME/data.tar.gz -C /tmp/$PKGNAME/ \
   usr/bin/yggdrasil usr/bin/yggdrasilctl \
-  etc/systemd/system/yggdrasil.service \
-  etc/systemd/system/yggdrasil-default-config.service
+  usr/lib/systemd/system/yggdrasil.service \
+  usr/lib/systemd/system/yggdrasil-default-config.service
 tar -czvf /tmp/$PKGNAME/control.tar.gz -C /tmp/$PKGNAME/debian .
 echo 2.0 > /tmp/$PKGNAME/debian-binary
 


### PR DESCRIPTION
As noted in #820, systemd service unit files installed by package managers should be residing in /usr/lib/systemd/system. This little PR makes .deb packages built with the contrib script to be in line with the manpage description. 

Resolves #820.