### PR TITLE
TLS Server Name Indication

### DIFF
--- a/src/core/link.go
+++ b/src/core/link.go
@@ -103,8 +103,8 @@ func (l *links) call(u *url.URL, sintf string) error {
 		// the host-port combo from the query option and then seeing if it parses to an
 		// IP address successfully or not.
 		if sni := u.Query().Get("sni"); sni != "" {
-			if host, _, err := net.SplitHostPort(sni); err == nil && net.ParseIP(host) == nil {
-				tcpOpts.tlsSNI = host
+			if net.ParseIP(sni) == nil {
+				tcpOpts.tlsSNI = sni
 			}
 		}
 		// If the SNI is not configured still because the above failed then we'll try

--- a/src/core/link.go
+++ b/src/core/link.go
@@ -98,10 +98,18 @@ func (l *links) call(u *url.URL, sintf string) error {
 		l.tcp.call(pathtokens[0], tcpOpts, sintf)
 	case "tls":
 		tcpOpts.upgrade = l.tcp.tls.forDialer
-		tcpOpts.tlsSNI = u.Query().Get("sni")
+		// SNI headers must contain hostnames and not IP addresses, so we must make sure
+		// that we do not populate the SNI with an IP literal. We do this by splitting
+		// the host-port combo from the query option and then seeing if it parses to an
+		// IP address successfully or not.
+		if sni := u.Query().Get("sni"); sni != "" {
+			if host, _, err := net.SplitHostPort(sni); err == nil && net.ParseIP(host) == nil {
+				tcpOpts.tlsSNI = host
+			}
+		}
+		// If the SNI is not configured still because the above failed then we'll try
+		// again but this time we'll use the host part of the peering URI instead.
 		if tcpOpts.tlsSNI == "" {
-			// SNI headers must contain hostnames and not IP addresses, so we must make sure
-			// that we do not populate the SNI with an IP literal.
 			if host, _, err := net.SplitHostPort(u.Host); err == nil && net.ParseIP(host) == nil {
 				tcpOpts.tlsSNI = host
 			}

--- a/src/core/link.go
+++ b/src/core/link.go
@@ -98,6 +98,7 @@ func (l *links) call(u *url.URL, sintf string) error {
 		l.tcp.call(pathtokens[0], tcpOpts, sintf)
 	case "tls":
 		tcpOpts.upgrade = l.tcp.tls.forDialer
+		tcpOpts.tlsSNI = u.Query().Get("sni")
 		l.tcp.call(u.Host, tcpOpts, sintf)
 	default:
 		return errors.New("unknown call scheme: " + u.Scheme)

--- a/src/core/link.go
+++ b/src/core/link.go
@@ -99,6 +99,13 @@ func (l *links) call(u *url.URL, sintf string) error {
 	case "tls":
 		tcpOpts.upgrade = l.tcp.tls.forDialer
 		tcpOpts.tlsSNI = u.Query().Get("sni")
+		if tcpOpts.tlsSNI == "" {
+			// SNI headers must contain hostnames and not IP addresses, so we must make sure
+			// that we do not populate the SNI with an IP literal.
+			if host, _, err := net.SplitHostPort(u.Host); err == nil && net.ParseIP(host) == nil {
+				tcpOpts.tlsSNI = host
+			}
+		}
 		l.tcp.call(u.Host, tcpOpts, sintf)
 	default:
 		return errors.New("unknown call scheme: " + u.Scheme)

--- a/src/core/tcp.go
+++ b/src/core/tcp.go
@@ -64,6 +64,7 @@ type tcpOptions struct {
 	socksProxyAddr string
 	socksProxyAuth *proxy.Auth
 	socksPeerAddr  string
+	tlsSNI         string
 }
 
 func (l *TcpListener) Stop() {

--- a/src/core/tls.go
+++ b/src/core/tls.go
@@ -77,7 +77,7 @@ func (t *tcptls) init(tcp *tcp) {
 	}
 }
 
-func (t *tcptls) configForOptions(options *tcpOptions, serverName string) *tls.Config {
+func (t *tcptls) configForOptions(options *tcpOptions) *tls.Config {
 	config := t.config.Clone()
 	config.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 		if len(rawCerts) != 1 {
@@ -103,14 +103,11 @@ func (t *tcptls) configForOptions(options *tcpOptions, serverName string) *tls.C
 		}
 		return nil
 	}
-	if serverName != "" {
-		config.ServerName = serverName
-	}
 	return config
 }
 
 func (t *tcptls) upgradeListener(c net.Conn, options *tcpOptions) (net.Conn, error) {
-	config := t.configForOptions(options, "")
+	config := t.configForOptions(options)
 	conn := tls.Server(c, config)
 	if err := conn.Handshake(); err != nil {
 		return c, err
@@ -119,7 +116,8 @@ func (t *tcptls) upgradeListener(c net.Conn, options *tcpOptions) (net.Conn, err
 }
 
 func (t *tcptls) upgradeDialer(c net.Conn, options *tcpOptions) (net.Conn, error) {
-	config := t.configForOptions(options, options.tlsSNI)
+	config := t.configForOptions(options)
+	config.ServerName = options.tlsSNI
 	conn := tls.Client(c, config)
 	if err := conn.Handshake(); err != nil {
 		return c, err


### PR DESCRIPTION
This PR does two things:

* Sets the TLS SNI on TLS peerings to the hostname in the peering URI (but *not* naked IP address literals)
* Allows overriding the SNI with a custom value by specifying the query string `?sni=...`