### PR TITLE
network.target → network-online.target

### DIFF
--- a/contrib/systemd/yggdrasil.service
+++ b/contrib/systemd/yggdrasil.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=yggdrasil
-Wants=network.target
+Wants=network-online.target
 Wants=yggdrasil-default-config.service
-After=network.target
+After=network-online.target
 After=yggdrasil-default-config.service
 
 [Service]


### PR DESCRIPTION
Service starts after the network is really on-line. Otherwise, in some cases, the firewall may not see TUN Yggdrasil.