### PR TITLE
add command to convert pubkey to ipv6 addr

### DIFF
--- a/cmd/addrforkey/main.go
+++ b/cmd/addrforkey/main.go
@@ -1,0 +1,26 @@
+/*
+
+This file converts a public to to an IPv6 address. Example:
+$ go run main.go <pubkey>.
+IP: <ipv6ip>
+
+*/
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"github.com/yggdrasil-network/yggdrasil-go/src/address"
+)
+
+func main() {
+        pub, err := hex.DecodeString(os.Args[1])
+	if err != nil {
+                fmt.Println("Failed to decode provided public key")
+                os.Exit(1)
+	}
+        addr := address.AddrForKey(pub)
+        fmt.Println("IP:", net.IP(addr[:]).String())
+}

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -6,12 +6,14 @@ WORKDIR /src
 ENV CGO_ENABLED=0
 
 RUN apk add git && ./build && go build -o /src/genkeys cmd/genkeys/main.go
+RUN apk add git && ./build && go build -o /src/addrforkey cmd/addrforkey/main.go
 
 FROM docker.io/alpine
 
 COPY --from=builder /src/yggdrasil /usr/bin/yggdrasil
 COPY --from=builder /src/yggdrasilctl /usr/bin/yggdrasilctl
 COPY --from=builder /src/genkeys /usr/bin/genkeys
+COPY --from=builder /src/addrforkey /usr/bin/addrforkey
 COPY contrib/docker/entrypoint.sh /usr/bin/entrypoint.sh
 
 # RUN addgroup -g 1000 -S yggdrasil-network \


### PR DESCRIPTION
standalone cli tool like genkeys/main.go that uses
the address.AddrForKey function to convert a pubkey
to an IPv6 address.

```
$ go run main.go <thepubkey>.
IP: <theipv6ip>
```