### PR TITLE
Fix regression in Path MTU discovery

### DIFF
--- a/src/ipv6rwc/ipv6rwc.go
+++ b/src/ipv6rwc/ipv6rwc.go
@@ -237,11 +237,11 @@ func (k *keyStore) readPC(p []byte) (int, error) {
 		k.mutex.Unlock()
 		if len(bs) > mtu {
 			// Using bs would make it leak off the stack, so copy to buf
-			buf := make([]byte, 40)
-			copy(buf, bs)
+			buf := make([]byte, 512)
+			cn := copy(buf, bs)
 			ptb := &icmp.PacketTooBig{
 				MTU:  mtu,
-				Data: buf[:40],
+				Data: buf[:cn],
 			}
 			if packet, err := CreateICMPv6(buf[8:24], buf[24:40], ipv6.ICMPTypePacketTooBig, 0, ptb); err == nil {
 				_, _ = k.writePC(packet)


### PR DESCRIPTION
In the past we used to send back anything up to 900 bytes of the packet in the ICMPv6 Packet Too Big response, whereas now we seemingly only send back 40 bytes.

It turns out that sending back only the 40 bytes of IPv6 headers isn't enough for most operating systems to positively ID the flow to reduce the MTU. This PR updates it so that we can send up to 512 bytes instead (900 is probably excessive) — that should leave plenty of room for any number of IPv6 extension headers and the next protocol headers and some of the payload.

This seems to fix the problem in my testing.