### PR TITLE
Build fails on go 1.16, update docs to say 1.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ or tools in the `contrib` folder.
 If you want to build from source, as opposed to installing one of the pre-built
 packages:
 
-1. Install [Go](https://golang.org) (requires Go 1.16 or later)
+1. Install [Go](https://golang.org) (requires Go 1.17 or later)
 2. Clone this repository
 2. Run `./build`
 

--- a/go.mod
+++ b/go.mod
@@ -1,26 +1,35 @@
 module github.com/yggdrasil-network/yggdrasil-go
 
-go 1.16
+go 1.17
 
 require (
 	github.com/Arceliar/ironwood v0.0.0-20211125050254-8951369625d0
 	github.com/Arceliar/phony v0.0.0-20210209235338-dde1a8dca979
-	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/cheggaaa/pb/v3 v3.0.8
-	github.com/fatih/color v1.12.0 // indirect
 	github.com/gologme/log v1.2.0
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hjson/hjson-go v3.1.0+incompatible
 	github.com/kardianos/minwinsvc v1.0.0
-	github.com/mattn/go-isatty v0.0.13 // indirect
-	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/vishvananda/netlink v1.1.0
-	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
 	golang.org/x/mobile v0.0.0-20220112015953-858099ff7816
 	golang.org/x/net v0.0.0-20211101193420-4a448f8816b3
 	golang.org/x/sys v0.0.0-20211102192858-4dd72447c267
 	golang.org/x/text v0.3.8-0.20211004125949-5bd84dd9b33b
 	golang.zx2c4.com/wireguard v0.0.0-20211017052713-f87e87af0d9a
 	golang.zx2c4.com/wireguard/windows v0.4.12
+)
+
+require (
+	github.com/VividCortex/ewma v1.2.0 // indirect
+	github.com/fatih/color v1.12.0 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.13 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
+	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/tools v0.1.8-0.20211022200916-316ba0b74098 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 )


### PR DESCRIPTION
Trying to build with go 1.16 fails with the error

```
Building: yggdrasil
../go/pkg/mod/golang.zx2c4.com/wireguard@v0.0.0-20211017052713-f87e87af0d9a/tun/tun_linux.go:24:2: //go:build comment without // +build comment
src/tuntap/tun.go:20:2: //go:build comment without // +build comment
```

Upgrading to go 1.17 fixes this.

I'm guessing that the 1.16 version in the readme is documentation of what works more than a target, if that's wrong sorry for not filing as an issue.