### PR TITLE
Refactor. Delete unused param

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -366,7 +366,7 @@ func run(args yggArgs, ctx context.Context, done chan struct{}) {
 	} else if err := n.admin.Start(); err != nil {
 		logger.Errorln("An error occurred starting admin socket:", err)
 	}
-	n.admin.SetupAdminHandlers(n.admin)
+	n.admin.SetupAdminHandlers()
 	// Start the multicast interface
 	if err := n.multicast.Init(n.core, cfg, logger, nil); err != nil {
 		logger.Errorln("An error occurred initialising multicast:", err)

--- a/src/admin/admin.go
+++ b/src/admin/admin.go
@@ -86,7 +86,7 @@ func (a *AdminSocket) Init(c *core.Core, nc *config.NodeConfig, log *log.Logger,
 	return a.core.SetAdmin(a)
 }
 
-func (a *AdminSocket) SetupAdminHandlers(na *AdminSocket) {
+func (a *AdminSocket) SetupAdminHandlers() {
 	_ = a.AddHandler("getSelf", []string{}, func(in json.RawMessage) (interface{}, error) {
 		req := &GetSelfRequest{}
 		res := &GetSelfResponse{}


### PR DESCRIPTION
It is useless to pass to method param to itself.