### PR TITLE
Refactor ipv6rwc to interface instead of double struct

### DIFF
--- a/contrib/mobile/mobile.go
+++ b/contrib/mobile/mobile.go
@@ -26,7 +26,7 @@ import (
 // in Swift therefore we use the "dummy" TUN interface instead.
 type Yggdrasil struct {
 	core      *core.Core
-	iprwc     *ipv6rwc.ReadWriteCloser
+	iprwc     ipv6rwc.ReadWriteCloser
 	config    *config.NodeConfig
 	multicast multicast.Multicast
 	log       MobileLogger

--- a/src/tuntap/tun.go
+++ b/src/tuntap/tun.go
@@ -32,7 +32,7 @@ type MTU uint16
 // should pass this object to the yggdrasil.SetRouterAdapter() function before
 // calling yggdrasil.Start().
 type TunAdapter struct {
-	rwc         *ipv6rwc.ReadWriteCloser
+	rwc         ipv6rwc.ReadWriteCloser
 	config      *config.NodeConfig
 	log         *log.Logger
 	addr        address.Address
@@ -93,7 +93,7 @@ func MaximumMTU() uint64 {
 
 // Init initialises the TUN module. You must have acquired a Listener from
 // the Yggdrasil core before this point and it must not be in use elsewhere.
-func (tun *TunAdapter) Init(rwc *ipv6rwc.ReadWriteCloser, config *config.NodeConfig, log *log.Logger, options interface{}) error {
+func (tun *TunAdapter) Init(rwc ipv6rwc.ReadWriteCloser, config *config.NodeConfig, log *log.Logger, options interface{}) error {
 	tun.rwc = rwc
 	tun.config = config
 	tun.log = log


### PR DESCRIPTION
IMO it is better to use interface instead of struct which is another struct.