### PR TITLE
Connect first peer from config on demand.

### DIFF
--- a/contrib/mobile/mobile.go
+++ b/contrib/mobile/mobile.go
@@ -169,6 +169,11 @@ func GenerateConfigJSON() []byte {
 	return nil
 }
 
+// Connects first peer from config, just to reconnect fast after network switch
+func (m *Yggdrasil) ConnectFirstPeer() {
+	m.core.ConnectFirstPeer()
+}
+
 // GetAddressString gets the node's IPv6 address
 func (m *Yggdrasil) GetAddressString() string {
 	ip := m.core.Address()

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -121,6 +121,27 @@ func (c *Core) _addPeerLoop() {
 	})
 }
 
+// Connects first peer from config, just to reconnect fast after network switch
+// Used in mobile
+func (c *Core) ConnectFirstPeer() {
+	select {
+	case <-c.ctx.Done():
+		return
+	default:
+	}
+	// Add peers from the Peers section
+	for peer := range c.config._peers {
+	    u, err := url.Parse(peer.URI)
+        if err != nil {
+            c.log.Errorln("Failed to parse peer url:", peer, err)
+        }
+        if err := c.CallPeer(u, peer.SourceInterface); err != nil {
+            c.log.Errorln("Failed to add peer:", err)
+        }
+        break
+	}
+}
+
 // Stop shuts down the Yggdrasil node.
 func (c *Core) Stop() {
 	phony.Block(c, func() {


### PR DESCRIPTION
Now we have a timer that is trying to connect configured peers every minute.
But if you switch network just after that you will need to wait 59 seconds until Yggdrasil will become available again.

I've introduced a new function that will reconnect the first (and often only) peer from config on demand. It will be called from Kotlin side when network becomes available.

(Patch for yggdrasil-android will follow)