### PR TITLE
Redial failed peering if possible

### DIFF
--- a/contrib/mobile/mobile.go
+++ b/contrib/mobile/mobile.go
@@ -159,6 +159,11 @@ func (m *Yggdrasil) Stop() error {
 	return nil
 }
 
+// Retry resets the peer connection timer and tries to dial them immediately.
+func (m *Yggdrasil) RetryPeersNow() {
+	m.core.RetryPeersNow()
+}
+
 // GenerateConfigJSON generates mobile-friendly configuration in JSON format
 func GenerateConfigJSON() []byte {
 	nc := defaults.GenerateConfig()

--- a/src/core/api.go
+++ b/src/core/api.go
@@ -194,7 +194,7 @@ func (c *Core) AddPeer(uri string, sourceInterface string) error {
 	if err != nil {
 		return err
 	}
-	info, err := c.links.call(u, sourceInterface)
+	info, err := c.links.call(u, sourceInterface, nil)
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func (c *Core) RemovePeer(uri string, sourceInterface string) error {
 // This does not add the peer to the peer list, so if the connection drops, the
 // peer will not be called again automatically.
 func (c *Core) CallPeer(u *url.URL, sintf string) error {
-	_, err := c.links.call(u, sintf)
+	_, err := c.links.call(u, sintf, nil)
 	return err
 }
 

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -121,6 +121,13 @@ func (c *Core) _addPeerLoop() {
 	})
 }
 
+func (c *Core) RetryPeersNow() {
+	if c.addPeerTimer != nil && !c.addPeerTimer.Stop() {
+		<-c.addPeerTimer.C
+	}
+	c.Act(nil, c._addPeerLoop)
+}
+
 // Stop shuts down the Yggdrasil node.
 func (c *Core) Stop() {
 	phony.Block(c, func() {

--- a/src/core/link.go
+++ b/src/core/link.go
@@ -113,6 +113,7 @@ func (l *links) isConnectedTo(info linkInfo) bool {
 func (l *links) call(u *url.URL, sintf string, errch chan<- error) (info linkInfo, err error) {
 	info = linkInfoFor(u.Scheme, sintf, u.Host)
 	if l.isConnectedTo(info) {
+		close(errch) // already connected, no error
 		return info, nil
 	}
 	options := linkOptions{
@@ -121,6 +122,7 @@ func (l *links) call(u *url.URL, sintf string, errch chan<- error) (info linkInf
 	for _, pubkey := range u.Query()["key"] {
 		sigPub, err := hex.DecodeString(pubkey)
 		if err != nil {
+			close(errch)
 			return info, fmt.Errorf("pinned key contains invalid hex characters")
 		}
 		var sigPubKey keyArray
@@ -130,6 +132,7 @@ func (l *links) call(u *url.URL, sintf string, errch chan<- error) (info linkInf
 	if p := u.Query().Get("priority"); p != "" {
 		pi, err := strconv.ParseUint(p, 10, 8)
 		if err != nil {
+			close(errch)
 			return info, fmt.Errorf("priority invalid: %w", err)
 		}
 		options.priority = uint8(pi)
@@ -205,6 +208,7 @@ func (l *links) call(u *url.URL, sintf string, errch chan<- error) (info linkInf
 		}()
 
 	default:
+		close(errch)
 		return info, errors.New("unknown call scheme: " + u.Scheme)
 	}
 	return info, nil

--- a/src/core/link.go
+++ b/src/core/link.go
@@ -34,6 +34,11 @@ type linkInfo struct {
 	remote   string // Remote name or address
 }
 
+type linkDial struct {
+	url   *url.URL
+	sintf string
+}
+
 type link struct {
 	lname    string
 	links    *links
@@ -105,8 +110,8 @@ func (l *links) isConnectedTo(info linkInfo) bool {
 	return isConnected
 }
 
-func (l *links) call(u *url.URL, sintf string) (linkInfo, error) {
-	info := linkInfoFor(u.Scheme, sintf, u.Host)
+func (l *links) call(u *url.URL, sintf string, errch chan<- error) (info linkInfo, err error) {
+	info = linkInfoFor(u.Scheme, sintf, u.Host)
 	if l.isConnectedTo(info) {
 		return info, nil
 	}
@@ -132,15 +137,27 @@ func (l *links) call(u *url.URL, sintf string) (linkInfo, error) {
 	switch info.linkType {
 	case "tcp":
 		go func() {
+			if errch != nil {
+				defer close(errch)
+			}
 			if err := l.tcp.dial(u, options, sintf); err != nil && err != io.EOF {
 				l.core.log.Warnf("Failed to dial TCP %s: %s\n", u.Host, err)
+				if errch != nil {
+					errch <- err
+				}
 			}
 		}()
 
 	case "socks":
 		go func() {
+			if errch != nil {
+				defer close(errch)
+			}
 			if err := l.socks.dial(u, options); err != nil && err != io.EOF {
 				l.core.log.Warnf("Failed to dial SOCKS %s: %s\n", u.Host, err)
+				if errch != nil {
+					errch <- err
+				}
 			}
 		}()
 
@@ -163,15 +180,27 @@ func (l *links) call(u *url.URL, sintf string) (linkInfo, error) {
 			}
 		}
 		go func() {
+			if errch != nil {
+				defer close(errch)
+			}
 			if err := l.tls.dial(u, options, sintf, tlsSNI); err != nil && err != io.EOF {
 				l.core.log.Warnf("Failed to dial TLS %s: %s\n", u.Host, err)
+				if errch != nil {
+					errch <- err
+				}
 			}
 		}()
 
 	case "unix":
 		go func() {
+			if errch != nil {
+				defer close(errch)
+			}
 			if err := l.unix.dial(u, options, sintf); err != nil && err != io.EOF {
 				l.core.log.Warnf("Failed to dial UNIX %s: %s\n", u.Host, err)
+				if errch != nil {
+					errch <- err
+				}
 			}
 		}()
 
@@ -197,7 +226,7 @@ func (l *links) listen(u *url.URL, sintf string) (*Listener, error) {
 	return listener, err
 }
 
-func (l *links) create(conn net.Conn, name string, info linkInfo, incoming, force bool, options linkOptions) error {
+func (l *links) create(conn net.Conn, dial *linkDial, name string, info linkInfo, incoming, force bool, options linkOptions) error {
 	intf := link{
 		conn: &linkConn{
 			Conn: conn,
@@ -211,14 +240,14 @@ func (l *links) create(conn net.Conn, name string, info linkInfo, incoming, forc
 		force:    force,
 	}
 	go func() {
-		if err := intf.handler(); err != nil {
+		if err := intf.handler(dial); err != nil {
 			l.core.log.Errorf("Link handler %s error (%s): %s", name, conn.RemoteAddr(), err)
 		}
 	}()
 	return nil
 }
 
-func (intf *link) handler() error {
+func (intf *link) handler(dial *linkDial) error {
 	defer intf.conn.Close() // nolint:errcheck
 
 	// Don't connect to this link more than once.
@@ -321,6 +350,30 @@ func (intf *link) handler() error {
 		intf.links.core.log.Infof("Disconnected %s %s: %s, source %s; error: %s",
 			dir, strings.ToUpper(intf.info.linkType), remoteStr, localStr, err)
 	}
+
+	if !intf.incoming && dial != nil {
+		// The connection was one that we dialled, so wait a second and try to
+		// dial it again.
+		var retry func(attempt int)
+		retry = func(attempt int) {
+			// intf.links.core.log.Infof("Retrying %s (attempt %d of 5)...", dial.url.String(), attempt)
+			errch := make(chan error, 1)
+			if _, err := intf.links.call(dial.url, dial.sintf, errch); err != nil {
+				return
+			}
+			if err := <-errch; err != nil {
+				if attempt < 3 {
+					time.AfterFunc(time.Second, func() {
+						retry(attempt + 1)
+					})
+				}
+			}
+		}
+		time.AfterFunc(time.Second, func() {
+			retry(1)
+		})
+	}
+
 	return nil
 }
 

--- a/src/core/link_socks.go
+++ b/src/core/link_socks.go
@@ -37,16 +37,20 @@ func (l *linkSOCKS) dial(url *url.URL, options linkOptions) error {
 	if err != nil {
 		return err
 	}
-	return l.handler(url.String(), info, conn, options, false)
+	dial := &linkDial{
+		url: url,
+	}
+	return l.handler(dial, info, conn, options, false)
 }
 
-func (l *linkSOCKS) handler(name string, info linkInfo, conn net.Conn, options linkOptions, incoming bool) error {
+func (l *linkSOCKS) handler(dial *linkDial, info linkInfo, conn net.Conn, options linkOptions, incoming bool) error {
 	return l.links.create(
-		conn,     // connection
-		name,     // connection name
-		info,     // connection info
-		incoming, // not incoming
-		false,    // not forced
-		options,  // connection options
+		conn,              // connection
+		dial,              // connection URL
+		dial.url.String(), // connection name
+		info,              // connection info
+		incoming,          // not incoming
+		false,             // not forced
+		options,           // connection options
 	)
 }

--- a/src/multicast/multicast.go
+++ b/src/multicast/multicast.go
@@ -30,6 +30,7 @@ type Multicast struct {
 	_isOpen     bool
 	_listeners  map[string]*listenerInfo
 	_interfaces map[string]*interfaceInfo
+	_timer      *time.Timer
 	config      struct {
 		_groupAddr  GroupAddress
 		_interfaces map[MulticastInterface]struct{}
@@ -207,6 +208,15 @@ func (m *Multicast) _getAllowedInterfaces() map[string]*interfaceInfo {
 	return interfaces
 }
 
+func (m *Multicast) AnnounceNow() {
+	phony.Block(m, func() {
+		if m._timer != nil && !m._timer.Stop() {
+			<-m._timer.C
+		}
+		m.Act(nil, m._announce)
+	})
+}
+
 func (m *Multicast) _announce() {
 	if !m._isOpen {
 		return
@@ -329,7 +339,7 @@ func (m *Multicast) _announce() {
 			break
 		}
 	}
-	time.AfterFunc(time.Second, func() {
+	m._timer = time.AfterFunc(time.Second, func() {
 		m.Act(nil, m._announce)
 	})
 }


### PR DESCRIPTION
Right now if an outbound peering drops, it can take up to a minute to retry dialling. This speeds things up so that we attempt to redial after a single second in case the blip was transient, and we attempt it a couple more times to make sure.