### PR TITLE
Add output for threadcount and key generation time to cmd/genkey

### DIFF
--- a/cmd/genkeys/main.go
+++ b/cmd/genkeys/main.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"runtime"
+	"time"
 
 	"github.com/yggdrasil-network/yggdrasil-go/src/address"
 )
@@ -29,6 +30,8 @@ type keySet struct {
 
 func main() {
 	threads := runtime.GOMAXPROCS(0)
+	fmt.Println("Threads:", threads)
+	start := time.Now()
 	var currentBest ed25519.PublicKey
 	newKeys := make(chan keySet, threads)
 	for i := 0; i < threads; i++ {
@@ -38,7 +41,7 @@ func main() {
 		newKey := <-newKeys
 		if isBetter(currentBest, newKey.pub) || len(currentBest) == 0 {
 			currentBest = newKey.pub
-			fmt.Println("-----")
+			fmt.Println("-----", time.Since(start))
 			fmt.Println("Priv:", hex.EncodeToString(newKey.priv))
 			fmt.Println("Pub:", hex.EncodeToString(newKey.pub))
 			addr := address.AddrForKey(newKey.pub)


### PR DESCRIPTION
This change is to display information about the key generation process.

Specifically, two bits of information are now displayed
 * The number of threads created to search for keys, and
 * The time taken to generate a successful "next best" key