### PR TITLE
Revise multicast format to include protocol version, discriminator for TLS roots

### DIFF
--- a/src/multicast/advertisement.go
+++ b/src/multicast/advertisement.go
@@ -7,22 +7,33 @@ import (
 )
 
 type multicastAdvertisement struct {
-	PublicKey ed25519.PublicKey
-	Port      uint16
+	MajorVersion  uint16
+	MinorVersion  uint16
+	PublicKey     ed25519.PublicKey
+	Port          uint16
+	Discriminator []byte
 }
 
 func (m *multicastAdvertisement) MarshalBinary() ([]byte, error) {
-	b := make([]byte, 0, ed25519.PublicKeySize+2)
+	b := make([]byte, 0, ed25519.PublicKeySize+8+len(m.Discriminator))
+	b = binary.BigEndian.AppendUint16(b, m.MajorVersion)
+	b = binary.BigEndian.AppendUint16(b, m.MinorVersion)
 	b = append(b, m.PublicKey...)
 	b = binary.BigEndian.AppendUint16(b, m.Port)
+	b = binary.BigEndian.AppendUint16(b, uint16(len(m.Discriminator)))
+	b = append(b, m.Discriminator...)
 	return b, nil
 }
 
 func (m *multicastAdvertisement) UnmarshalBinary(b []byte) error {
-	if len(b) < ed25519.PublicKeySize+2 {
+	if len(b) < ed25519.PublicKeySize+8 {
 		return fmt.Errorf("invalid multicast beacon")
 	}
-	m.PublicKey = b[:ed25519.PublicKeySize]
-	m.Port = binary.BigEndian.Uint16(b[ed25519.PublicKeySize:])
+	m.MajorVersion = binary.BigEndian.Uint16(b[0:2])
+	m.MinorVersion = binary.BigEndian.Uint16(b[2:4])
+	m.PublicKey = append(m.PublicKey[:0], b[4:4+ed25519.PublicKeySize]...)
+	m.Port = binary.BigEndian.Uint16(b[4+ed25519.PublicKeySize : 6+ed25519.PublicKeySize])
+	dl := binary.BigEndian.Uint16(b[6+ed25519.PublicKeySize : 8+ed25519.PublicKeySize])
+	m.Discriminator = append(m.Discriminator[:0], b[8+ed25519.PublicKeySize:8+ed25519.PublicKeySize+dl]...)
 	return nil
 }

--- a/src/multicast/advertisement_test.go
+++ b/src/multicast/advertisement_test.go
@@ -1,0 +1,38 @@
+package multicast
+
+import (
+	"crypto/ed25519"
+	"reflect"
+	"testing"
+)
+
+func TestMulticastAdvertisementRoundTrip(t *testing.T) {
+	pk, sk, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	orig := multicastAdvertisement{
+		MajorVersion:  1,
+		MinorVersion:  2,
+		PublicKey:     pk,
+		Port:          3,
+		Discriminator: sk, // any bytes will do
+	}
+
+	ob, err := orig.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var new multicastAdvertisement
+	if err := new.UnmarshalBinary(ob); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(orig, new) {
+		t.Logf("original: %+v", orig)
+		t.Logf("new:      %+v", new)
+		t.Fatalf("differences found after round-trip")
+	}
+}

--- a/src/multicast/options.go
+++ b/src/multicast/options.go
@@ -8,6 +8,10 @@ func (m *Multicast) _applyOption(opt SetupOption) {
 		m.config._interfaces[v] = struct{}{}
 	case GroupAddress:
 		m.config._groupAddr = v
+	case Discriminator:
+		m.config._discriminator = append(m.config._discriminator[:0], v...)
+	case DiscriminatorMatch:
+		m.config._discriminatorMatch = v
 	}
 }
 
@@ -24,6 +28,10 @@ type MulticastInterface struct {
 }
 
 type GroupAddress string
+type Discriminator []byte
+type DiscriminatorMatch func([]byte) bool
 
 func (a MulticastInterface) isSetupOption() {}
 func (a GroupAddress) isSetupOption()       {}
+func (a Discriminator) isSetupOption()      {}
+func (a DiscriminatorMatch) isSetupOption() {}


### PR DESCRIPTION
This should make it easier for us to ignore nodes that we don't want to peer with automatically, either because they are a different node version to us altogether or because they don't have any configured TLS root CAs in common (for identifying closed networks).