### PR TITLE
Reduce allocations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/yggdrasil-network/yggdrasil-go
 go 1.19
 
 require (
-	github.com/Arceliar/ironwood v0.0.0-20230515022317-31b976732ebe
+	github.com/Arceliar/ironwood v0.0.0-20230521173602-97ee6b09b8e0
 	github.com/Arceliar/phony v0.0.0-20220903101357-530938a4b13d
 	github.com/cheggaaa/pb/v3 v3.0.8
 	github.com/gologme/log v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/yggdrasil-network/yggdrasil-go
 go 1.19
 
 require (
-	github.com/Arceliar/ironwood v0.0.0-20230521173602-97ee6b09b8e0
+	github.com/Arceliar/ironwood v0.0.0-20230521174855-fdfa6326d125
 	github.com/Arceliar/phony v0.0.0-20220903101357-530938a4b13d
 	github.com/cheggaaa/pb/v3 v3.0.8
 	github.com/gologme/log v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Arceliar/ironwood v0.0.0-20230515022317-31b976732ebe h1:u69sr6Y9jqu6sk43Yyt+izLnLGgqCw3OYh2HU+jYUBw=
-github.com/Arceliar/ironwood v0.0.0-20230515022317-31b976732ebe/go.mod h1:MIfrhR4b+U6gurd5pln622Zwaf2kzpIvXcnvRZMvlRI=
+github.com/Arceliar/ironwood v0.0.0-20230521173602-97ee6b09b8e0 h1:u0BeMjhq0+jU+zaL6zlaBo9Z5KuG26bMtm+XM2e6dSQ=
+github.com/Arceliar/ironwood v0.0.0-20230521173602-97ee6b09b8e0/go.mod h1:5x7fWW0mshe9WQ1lvSMmmHBYC3BeHH9gpwW5tz7cbfw=
 github.com/Arceliar/phony v0.0.0-20220903101357-530938a4b13d h1:UK9fsWbWqwIQkMCz1CP+v5pGbsGoWAw6g4AyvMpm1EM=
 github.com/Arceliar/phony v0.0.0-20220903101357-530938a4b13d/go.mod h1:BCnxhRf47C/dy/e/D2pmB8NkB3dQVIrkD98b220rx5Q=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Arceliar/ironwood v0.0.0-20230521173602-97ee6b09b8e0 h1:u0BeMjhq0+jU+zaL6zlaBo9Z5KuG26bMtm+XM2e6dSQ=
-github.com/Arceliar/ironwood v0.0.0-20230521173602-97ee6b09b8e0/go.mod h1:5x7fWW0mshe9WQ1lvSMmmHBYC3BeHH9gpwW5tz7cbfw=
+github.com/Arceliar/ironwood v0.0.0-20230521174855-fdfa6326d125 h1:l2elyrosw63mTqZzwR0Nv8vPZWZC/0Hvwl8Iuva5htM=
+github.com/Arceliar/ironwood v0.0.0-20230521174855-fdfa6326d125/go.mod h1:5x7fWW0mshe9WQ1lvSMmmHBYC3BeHH9gpwW5tz7cbfw=
 github.com/Arceliar/phony v0.0.0-20220903101357-530938a4b13d h1:UK9fsWbWqwIQkMCz1CP+v5pGbsGoWAw6g4AyvMpm1EM=
 github.com/Arceliar/phony v0.0.0-20220903101357-530938a4b13d/go.mod h1:BCnxhRf47C/dy/e/D2pmB8NkB3dQVIrkD98b220rx5Q=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -183,7 +183,8 @@ func (c *Core) MTU() uint64 {
 }
 
 func (c *Core) ReadFrom(p []byte) (n int, from net.Addr, err error) {
-	buf := make([]byte, c.PacketConn.MTU())
+	buf := allocBytes(int(c.PacketConn.MTU()))
+	defer freeBytes(buf)
 	for {
 		bs := buf
 		n, from, err = c.PacketConn.ReadFrom(bs)
@@ -217,7 +218,8 @@ func (c *Core) ReadFrom(p []byte) (n int, from net.Addr, err error) {
 }
 
 func (c *Core) WriteTo(p []byte, addr net.Addr) (n int, err error) {
-	buf := make([]byte, 0, 65535)
+	buf := allocBytes(0)
+	defer freeBytes(buf)
 	buf = append(buf, typeSessionTraffic)
 	buf = append(buf, p...)
 	n, err = c.PacketConn.WriteTo(buf, addr)

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -184,7 +184,7 @@ func (c *Core) MTU() uint64 {
 
 func (c *Core) ReadFrom(p []byte) (n int, from net.Addr, err error) {
 	buf := allocBytes(int(c.PacketConn.MTU()))
-	defer freeBytes(buf) //nolint:staticcheck
+	defer freeBytes(buf)
 	for {
 		bs := buf
 		n, from, err = c.PacketConn.ReadFrom(bs)
@@ -219,7 +219,7 @@ func (c *Core) ReadFrom(p []byte) (n int, from net.Addr, err error) {
 
 func (c *Core) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 	buf := allocBytes(0)
-	defer freeBytes(buf) //nolint:staticcheck
+	defer freeBytes(buf)
 	buf = append(buf, typeSessionTraffic)
 	buf = append(buf, p...)
 	n, err = c.PacketConn.WriteTo(buf, addr)

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -184,7 +184,7 @@ func (c *Core) MTU() uint64 {
 
 func (c *Core) ReadFrom(p []byte) (n int, from net.Addr, err error) {
 	buf := allocBytes(int(c.PacketConn.MTU()))
-	defer freeBytes(buf)
+	defer freeBytes(buf) //nolint:staticcheck
 	for {
 		bs := buf
 		n, from, err = c.PacketConn.ReadFrom(bs)
@@ -219,7 +219,7 @@ func (c *Core) ReadFrom(p []byte) (n int, from net.Addr, err error) {
 
 func (c *Core) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 	buf := allocBytes(0)
-	defer freeBytes(buf)
+	defer freeBytes(buf) //nolint:staticcheck
 	buf = append(buf, typeSessionTraffic)
 	buf = append(buf, p...)
 	n, err = c.PacketConn.WriteTo(buf, addr)

--- a/src/core/pool.go
+++ b/src/core/pool.go
@@ -13,5 +13,5 @@ func allocBytes(size int) []byte {
 }
 
 func freeBytes(bs []byte) {
-	bytePool.Put(bs[:0])
+	bytePool.Put(bs[:0]) //nolint:staticcheck
 }

--- a/src/core/pool.go
+++ b/src/core/pool.go
@@ -1,0 +1,17 @@
+package core
+
+import "sync"
+
+var bytePool = sync.Pool{New: func() interface{} { return []byte(nil) }}
+
+func allocBytes(size int) []byte {
+	bs := bytePool.Get().([]byte)
+	if cap(bs) < size {
+		bs = make([]byte, size)
+	}
+	return bs[:size]
+}
+
+func freeBytes(bs []byte) {
+	bytePool.Put(bs[:0])
+}


### PR DESCRIPTION
This helps remove a few allocations from slices that no longer fit on the stack. It also pulls in an update to ironwood that reduces allocations in the `encrypted` package, and brings back @neilalexander's change that limited how fast keys can rotate.

All together, this increases iperf3 speeds between network namespaces on my machine from about 2.5 Gbps to about 3.5 Gbps. There's probably still more improvement to be gained (my old machine was getting >4 Gbps in v0.3.X), but it's a start.