### PR TITLE
cmd/yggdrasil: do not log timestamps to syslog

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	case "syslog":
 		if syslogger, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, "DAEMON", version.BuildName()); err == nil {
-			logger = log.New(syslogger, "", log.Flags())
+			logger = log.New(syslogger, "", log.Flags() &^ (log.Ldate | log.Ltime))
 		}
 
 	default:


### PR DESCRIPTION
It is expected a `syslog` implementation be it `rsyslog` or `journald` to have their own timestamping, so there's no point in duplicating that info.