### PR TITLE
core/link_tcp_linux: drop trying to set BBR

### DIFF
--- a/src/core/link_tcp_linux.go
+++ b/src/core/link_tcp_linux.go
@@ -12,22 +12,6 @@ import (
 // WARNING: This context is used both by net.Dialer and net.Listen in tcp.go
 
 func (t *linkTCP) tcpContext(network, address string, c syscall.RawConn) error {
-	var control error
-	var bbr error
-
-	control = c.Control(func(fd uintptr) {
-		bbr = unix.SetsockoptString(int(fd), unix.IPPROTO_TCP, unix.TCP_CONGESTION, "bbr")
-	})
-
-	// Log any errors
-	if bbr != nil {
-		t.links.core.log.Debugln("Failed to set tcp_congestion_control to bbr for socket, SetsockoptString error:", bbr)
-	}
-	if control != nil {
-		t.links.core.log.Debugln("Failed to set tcp_congestion_control to bbr for socket, Control error:", control)
-	}
-
-	// Return nil because errors here are not considered fatal for the connection, it just means congestion control is suboptimal
 	return nil
 }
 


### PR DESCRIPTION
Instead of implementing an ability to select arbitrary TCP congestion control algorithm (#776), drop setting it altogether as suggested by @link2xt in #754.

Link: https://github.com/yggdrasil-network/yggdrasil-go/pull/776
Fixes: https://github.com/yggdrasil-network/yggdrasil-go/issues/754