### PR TITLE
Fix duplicate connections

### DIFF
--- a/src/multicast/multicast.go
+++ b/src/multicast/multicast.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"math/rand"
 	"net"
 	"net/url"
 	"time"
@@ -337,7 +338,8 @@ func (m *Multicast) _announce() {
 			break
 		}
 	}
-	m._timer = time.AfterFunc(time.Second, func() {
+	annInterval := time.Second + time.Microsecond*(time.Duration(rand.Intn(1048576))) // Randomize delay
+	m._timer = time.AfterFunc(annInterval, func() {
 		m.Act(nil, m._announce)
 	})
 }


### PR DESCRIPTION
This seems to fix the issue I was having where I was getting duplicate connections to the same peer, with only 1 of those connections being attached to a link struct (so we were leaking conns).

It removes the mutex and switches back to using an actor to manage the `links` object state. There's still more that could be done here to improve things. In particular, we could do something like get rid of the long lived goroutines and just periodically send a signal (with `time.AfterFunc`) to the `links` actor to retry the dead persistent links as needed (or fire up a new goroutine to call `add`, I guess), to avoid keeping idle goroutines around. Also fixes a race in the api where a non-atomic read was used to get the rx/tx bytes.

I noticed that, out of the box, fixing the link means my network namespace tests never open multicast peers. They both attempt to dial out, and then both ignore the "listen" side of the connection, so we keep getting timeouts in the handler. I've added a bit of a hack to fix that in the multicast code, by randomizing the delay between attempts to send announcements. The underlying problem is still there, and could affect manually configured peers any time both nodes try to open a connection concurrently, so we should think about a better way to break the symmetry.