### PR TITLE
Tweak link handshake

### DIFF
--- a/src/core/version_test.go
+++ b/src/core/version_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"math/rand"
 	"reflect"
@@ -22,7 +23,7 @@ func TestVersionRoundtrip(t *testing.T) {
 		test.publicKey = make(ed25519.PublicKey, ed25519.PublicKeySize)
 		rand.Read(test.publicKey)
 
-		encoded := test.encode()
+		encoded := bytes.NewBuffer(test.encode())
 		decoded := &version_metadata{}
 		if !decoded.decode(encoded) {
 			t.Fatalf("failed to decode")


### PR DESCRIPTION
The handshake format is already mostly extensible but including the total length of the data in the handshake lets us read the exact amount of bytes from the wire precisely. Previously both the sent and received handshakes had to be the same length.