### PR TITLE
Re-add `PublicKey` to configuration file

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -136,8 +136,7 @@ func main() {
 		return
 	}
 
-	privateKey := ed25519.PrivateKey(cfg.PrivateKey)
-	publicKey := privateKey.Public().(ed25519.PublicKey)
+	publicKey := ed25519.PublicKey(cfg.PublicKey)
 
 	switch {
 	case *getaddr:


### PR DESCRIPTION
This PR does two things:
* Re-adds the `PublicKey` to the configuration file — technically it does nothing but `-normaliseconf` will update it
* Cuts down `PrivateKey` to the seed length only and updates things to expect the seed only