### PR TITLE
Don't panic when connect returns `nil` (fixes #1086)

### DIFF
--- a/src/core/link.go
+++ b/src/core/link.go
@@ -274,6 +274,9 @@ func (l *links) add(u *url.URL, sintf string, linkType linkType) error {
 
 				conn, err := l.connect(state.ctx, u, info, options)
 				if err != nil || conn == nil {
+					if err == nil && conn == nil {
+						l.core.log.Warnf("Link %q reached inconsistent error state", u.String())
+					}
 					if linkType == linkTypePersistent {
 						// If the link is a persistent configured peering,
 						// store information about the connection error so

--- a/src/core/link.go
+++ b/src/core/link.go
@@ -273,7 +273,7 @@ func (l *links) add(u *url.URL, sintf string, linkType linkType) error {
 				}
 
 				conn, err := l.connect(state.ctx, u, info, options)
-				if err != nil {
+				if err != nil || conn == nil {
 					if linkType == linkTypePersistent {
 						// If the link is a persistent configured peering,
 						// store information about the connection error so


### PR DESCRIPTION
It isn't clear to me why this would happen but let's guard the condition anyway.