### PR TITLE
Report errors during handshake stage

### DIFF
--- a/src/core/link.go
+++ b/src/core/link.go
@@ -546,8 +546,9 @@ func (l *links) handler(linkType linkType, options linkOptions, conn net.Conn) e
 	}
 	meta = version_metadata{}
 	base := version_getBaseMetadata()
-	if !meta.decode(conn, options.password) {
-		return conn.Close()
+	if err := meta.decode(conn, options.password); err != nil {
+		_ = conn.Close()
+		return err
 	}
 	if !meta.check() {
 		return fmt.Errorf("remote node incompatible version (local %s, remote %s)",

--- a/src/core/version_test.go
+++ b/src/core/version_test.go
@@ -34,7 +34,7 @@ func TestVersionPasswordAuth(t *testing.T) {
 		}
 
 		var decoded version_metadata
-		if allowed := decoded.decode(bytes.NewBuffer(encoded), tt.password2); allowed != tt.allowed {
+		if allowed := decoded.decode(bytes.NewBuffer(encoded), tt.password2) == nil; allowed != tt.allowed {
 			t.Fatalf("Permutation %q -> %q should have been %v but was %v", tt.password1, tt.password2, tt.allowed, allowed)
 		}
 	}
@@ -67,8 +67,8 @@ func TestVersionRoundtrip(t *testing.T) {
 			}
 			encoded := bytes.NewBuffer(meta)
 			decoded := &version_metadata{}
-			if !decoded.decode(encoded, password) {
-				t.Fatalf("failed to decode")
+			if err := decoded.decode(encoded, password); err != nil {
+				t.Fatalf("failed to decode: %s", err)
 			}
 			if !reflect.DeepEqual(test, decoded) {
 				t.Fatalf("round-trip failed\nwant: %+v\n got: %+v", test, decoded)


### PR DESCRIPTION
Right now, many handshake errors are not reported through the admin socket correctly, showing as `0s ago:` in `getPeers`. This should fix that.