### PR TITLE
Update rc script for FreeBSD and fix logging

### DIFF
--- a/contrib/freebsd/yggdrasil
+++ b/contrib/freebsd/yggdrasil
@@ -1,10 +1,12 @@
 #!/bin/sh
 #
 # Put the yggdrasil and yggdrasilctl binaries into /usr/local/bin
-# Then copy this script into /etc/rc.d/yggdrasil
+# Then copy this script into /usr/local/etc/rc.d/yggdrasil
+# yggdrasil_syslog.conf into /usr/local/etc/syslog.d/yggdrasil.conf
+# and yggdrasil_newsyslog.conf into /usr/local/etc/newsyslog.conf.d/yggdrasil.conf
 # Finally, run:
 #   1. chmod +x /etc/rc.d/yggdrasil /usr/local/bin/{yggdrasil,yggdrasilctl}
-#   2. echo "yggdrasil_enable=yes" >> /etc/rc.d
+#   2. sysrc yggdrasil_enable=YES
 #   3. service yggdrasil start
 #
 # PROVIDE: yggdrasil
@@ -19,9 +21,10 @@ rcvar="yggdrasil_enable"
 start_cmd="${name}_start"
 stop_cmd="${name}_stop"
 
+yggdrasil_command="/usr/local/bin/yggdrasil"
 pidfile="/var/run/yggdrasil/${name}.pid"
 command="/usr/sbin/daemon"
-command_args="-P ${pidfile} -r -f ${yggdrasil_command}"
+command_args="-P ${pidfile} -r -S -m 3 -s info -T yggdrasil ${yggdrasil_command}"
 
 yggdrasil_start()
 {
@@ -31,25 +34,15 @@ yggdrasil_start()
 		return 1
 	)
 
-	test ! -f /etc/yggdrasil.conf && (
-		logger -s -t yggdrasil "Generating new configuration file into /etc/yggdrasil.conf"
-		/usr/local/bin/yggdrasil -genconf > /etc/yggdrasil.conf
+	test ! -f /usr/local/etc/yggdrasil.conf && (
+		logger -s -t yggdrasil "Generating new configuration file into /usr/local/etc/yggdrasil.conf"
+		/usr/local/bin/yggdrasil -genconf > /usr/local/etc/yggdrasil.conf
 	)
 
-	tap_path="$(cat /etc/yggdrasil.conf | egrep -o '/dev/tap[0-9]{1,2}$')"
-	tap_name="$(echo -n ${tap_path} | tr -d '/dev/')"
-
-	/sbin/ifconfig ${tap_name} >/dev/null 2>&1 || (
-		logger -s -t yggdrasil "Creating ${tap_name} adapter"
-		/sbin/ifconfig ${tap_name} create || logger -s -t yggdrasil "Failed to create ${tap_name} adapter"
-	)
-
-	test ! -d /var/run/yggdrasil && mkdir -p /var/run/yggdrasil
+	mkdir -p /var/run/yggdrasil
 
 	logger -s -t yggdrasil "Starting yggdrasil"
-	${command} ${command_args} /usr/local/bin/yggdrasil -useconffile /etc/yggdrasil.conf \
-		1>/var/log/yggdrasil.stdout.log \
-		2>/var/log/yggdrasil.stderr.log &
+	${command} ${command_args} -useconffile /usr/local/etc/yggdrasil.conf &
 }
 
 yggdrasil_stop()
@@ -57,8 +50,7 @@ yggdrasil_stop()
 	logger -s -t yggdrasil "Stopping yggdrasil"
 	test -f /var/run/yggdrasil/${name}.pid && kill -TERM $(cat /var/run/yggdrasil/${name}.pid)
 
-	tap_path="$(cat /etc/yggdrasil.conf | grep /dev/tap | egrep -o '/dev/.*$')"
-        tap_name="$(echo -n ${tap_path} | tr -d '/dev/')"
+	tap_name="$(egrep '^[ \t]+IfName:' /usr/local/etc/yggdrasil.conf | sed 's/[ \t]*IfName:[ \t]*//')"
 
 	/sbin/ifconfig ${tap_name} >/dev/null 2>&1 && (
 		logger -s -t yggdrasil "Destroying ${tap_name} adapter"

--- a/contrib/freebsd/yggdrasil_newsyslog.conf
+++ b/contrib/freebsd/yggdrasil_newsyslog.conf
@@ -1,0 +1,1 @@
+/var/log/yggdrasil.log			644  3	   1000	*     JC

--- a/contrib/freebsd/yggdrasil_syslog.conf
+++ b/contrib/freebsd/yggdrasil_syslog.conf
@@ -1,0 +1,2 @@
+!yggdrasil
+*.*						/var/log/yggdrasil.log


### PR DESCRIPTION
This commit updates rc script for FreeBSD and fixes logging. syslog is now used and messages are saved to /var/log/yggdrasil.log instead of empty /var/log/yggdrasil.stdout.log and /var/log/yggdrasil.stderr.log. Log rotation has been added via newsyslog.