### PR TITLE
[RFC] Bump minimum required go version to 1.20 in documentation as required by quic-go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,7 +189,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-* Go 1.17 is now required to build Yggdrasil
+* Go 1.20 is now required to build Yggdrasil
 
 ## [0.4.3] - 2022-02-06
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ or tools in the `contrib` folder.
 If you want to build from source, as opposed to installing one of the pre-built
 packages:
 
-1. Install [Go](https://golang.org) (requires Go 1.17 or later)
+1. Install [Go](https://golang.org) (requires Go 1.20 or later)
 2. Clone this repository
 2. Run `./build`
 

--- a/contrib/msi/build-msi.sh
+++ b/contrib/msi/build-msi.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # This script generates an MSI file for Yggdrasil for a given architecture. It
-# needs to run on Windows within MSYS2 and Go 1.17 or later must be installed on
+# needs to run on Windows within MSYS2 and Go 1.20 or later must be installed on
 # the system and within the PATH. This is ran currently by GitHub Actions (see
 # the workflows in the repository).
 #


### PR DESCRIPTION
As of now, compiling in any golang versions older than 1.20 yields the following error:
```
# github.com/quic-go/quic-go/internal/qtls
../go/pkg/mod/github.com/quic-go/quic-go@v0.40.1/internal/qtls/go_oldversion.go:5:13: cannot use "The version of quic-go you're using can't be built using outdated Go versions. For more details, please see https://github.com/quic-go/quic-go/wiki/quic-go-and-Go-versions." (untyped string constant "The version of quic-go you're using can't be built using outdated Go...) as int value in variable declaration
note: module requires Go 1.20
```