### PR TITLE
TUN vectorised reads/writes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	golang.org/x/net v0.25.0
 	golang.org/x/sys v0.20.0
 	golang.org/x/text v0.15.0
-	golang.zx2c4.com/wireguard v0.0.0-20230223181233-21636207a675
+	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	golang.zx2c4.com/wireguard/windows v0.5.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/gologme/log v1.3.0 h1:l781G4dE+pbigClDSDzSaaYKtiueHCILUa/qSDsmHAo=
 github.com/gologme/log v1.3.0/go.mod h1:yKT+DvIPdDdDoPtqFrFxheooyVmoqi0BAsw+erN3wA4=
+github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
@@ -137,8 +139,8 @@ golang.org/x/tools v0.21.0/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeunTOisW56dUokqW/FOteYJJ/yg=
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
-golang.zx2c4.com/wireguard v0.0.0-20230223181233-21636207a675 h1:/J/RVnr7ng4fWPRH3xa4WtBJ1Jp+Auu4YNLmGiPv5QU=
-golang.zx2c4.com/wireguard v0.0.0-20230223181233-21636207a675/go.mod h1:whfbyDBt09xhCYQWtO2+3UVjlaq6/9hDZrjg2ZE6SyA=
+golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uIfPMv78iAJGcPKDeqAFnaLBropIC4=
+golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
 golang.zx2c4.com/wireguard/windows v0.5.3 h1:On6j2Rpn3OEMXqBq00QEDC7bWSZrPIHKIus8eIuExIE=
 golang.zx2c4.com/wireguard/windows v0.5.3/go.mod h1:9TEe8TJmtwyQebdFwAkEWOPr3prrtqm+REGFifP60hI=
 google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
@@ -147,3 +149,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 h1:TbRPT0HtzFP3Cno1zZo7yPzEEnfu8EjLfl6IU9VfqkQ=
+gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259/go.mod h1:AVgIgHMwK63XvmAzWG9vLQ41YnVHN0du0tEC46fI7yY=

--- a/src/ipv6rwc/ipv6rwc.go
+++ b/src/ipv6rwc/ipv6rwc.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ed25519"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"sync"
 	"time"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/yggdrasil-network/yggdrasil-go/src/address"
 	"github.com/yggdrasil-network/yggdrasil-go/src/core"
-	"github.com/yggdrasil-network/yggdrasil-go/src/tun"
 )
 
 const keyStoreTimeout = 2 * time.Minute
@@ -339,40 +337,11 @@ func (k *keyStore) MTU() uint64 {
 
 type ReadWriteCloser struct {
 	keyStore
-	ch    chan []byte
-	errch chan error
-}
-
-const bufPoolSize = tun.TUN_OFFSET_BYTES + 65535
-
-var bufPool = sync.Pool{
-	New: func() any {
-		b := [bufPoolSize]byte{}
-		return b[:]
-	},
 }
 
 func NewReadWriteCloser(c *core.Core) *ReadWriteCloser {
 	rwc := new(ReadWriteCloser)
 	rwc.init(c)
-	rwc.ch = make(chan []byte, tun.TUN_MAX_VECTOR)
-	rwc.errch = make(chan error, 1)
-	go func() {
-		for {
-			p := bufPool.Get().([]byte)[:bufPoolSize]
-			n, err := rwc.readPC(p[:])
-			if err != nil || n == 0 {
-				if err == nil {
-					err = io.EOF
-				}
-				rwc.errch <- err
-				close(rwc.errch)
-				close(rwc.ch)
-				return
-			}
-			rwc.ch <- p[:n]
-		}
-	}()
 	return rwc
 }
 
@@ -385,32 +354,7 @@ func (rwc *ReadWriteCloser) Subnet() address.Subnet {
 }
 
 func (rwc *ReadWriteCloser) Read(p []byte) (n int, err error) {
-	msg := <-rwc.ch
-	if msg == nil {
-		return 0, <-rwc.errch
-	}
-	return copy(p, msg), nil
-}
-
-func (rwc *ReadWriteCloser) ReadMany(b [][]byte, sizes []int, offset int) (c int, err error) {
-	var lb int
-	if c, lb = len(rwc.ch), len(b); c > lb {
-		c = lb
-	}
-	if c == 0 {
-		// If nothing is waiting yet then we should block
-		// for the next packet only.
-		c = 1
-	}
-	for i := 0; i < c; i++ {
-		msg := <-rwc.ch
-		if msg == nil {
-			return i, <-rwc.errch
-		}
-		sizes[i] = offset + copy(b[i][offset:], msg)
-		bufPool.Put(msg) // nolint:staticcheck
-	}
-	return
+	return rwc.readPC(p)
 }
 
 func (rwc *ReadWriteCloser) Write(p []byte) (n int, err error) {

--- a/src/tun/iface.go
+++ b/src/tun/iface.go
@@ -1,17 +1,9 @@
 package tun
 
 const TUN_OFFSET_BYTES = 80 // sizeof(virtio_net_hdr)
-const TUN_MAX_VECTOR = 16
-
-func (tun *TunAdapter) idealBatchSize() int {
-	if b := tun.iface.BatchSize(); b <= TUN_MAX_VECTOR {
-		return b
-	}
-	return TUN_MAX_VECTOR
-}
 
 func (tun *TunAdapter) read() {
-	vs := tun.idealBatchSize()
+	vs := tun.iface.BatchSize()
 	bufs := make([][]byte, vs)
 	sizes := make([]int, vs)
 	for i := range bufs {

--- a/src/tun/iface.go
+++ b/src/tun/iface.go
@@ -31,23 +31,38 @@ func (tun *TunAdapter) read() {
 	}
 }
 
-func (tun *TunAdapter) write() {
-	vs := tun.idealBatchSize()
-	bufs := make([][]byte, vs)
-	sizes := make([]int, vs)
-	for i := range bufs {
-		bufs[i] = make([]byte, TUN_OFFSET_BYTES+65535)
-	}
+func (tun *TunAdapter) queue() {
 	for {
-		n, err := tun.rwc.ReadMany(bufs, sizes, TUN_OFFSET_BYTES)
+		p := bufPool.Get().([]byte)[:bufPoolSize]
+		n, err := tun.rwc.Read(p)
 		if err != nil {
 			tun.log.Errorln("Exiting TUN writer due to core read error:", err)
 			return
 		}
+		tun.ch <- p[:n]
+	}
+}
+
+func (tun *TunAdapter) write() {
+	vs := cap(tun.ch)
+	bufs := make([][]byte, vs)
+	for i := range bufs {
+		bufs[i] = make([]byte, TUN_OFFSET_BYTES+65535)
+	}
+	for {
+		n := len(tun.ch)
+		if n == 0 {
+			n = 1 // Nothing queued up yet, wait for it instead
+		}
+		for i := 0; i < n; i++ {
+			msg := <-tun.ch
+			bufs[i] = append(bufs[i][:TUN_OFFSET_BYTES], msg...)
+			bufPool.Put(msg) // nolint:staticcheck
+		}
 		if !tun.isEnabled {
 			continue // Nothing to do, the tun isn't enabled
 		}
-		if _, err = tun.iface.Write(bufs[:n], TUN_OFFSET_BYTES); err != nil {
+		if _, err := tun.iface.Write(bufs[:n], TUN_OFFSET_BYTES); err != nil {
 			tun.Act(nil, func() {
 				if !tun.isOpen {
 					tun.log.Errorln("TUN iface write error:", err)

--- a/src/tun/iface.go
+++ b/src/tun/iface.go
@@ -1,9 +1,5 @@
 package tun
 
-import (
-	"net"
-)
-
 const TUN_OFFSET_BYTES = 80 // sizeof(virtio_net_hdr)
 const TUN_MAX_VECTOR = 16
 
@@ -16,7 +12,7 @@ func (tun *TunAdapter) idealBatchSize() int {
 
 func (tun *TunAdapter) read() {
 	vs := tun.idealBatchSize()
-	bufs := make(net.Buffers, vs)
+	bufs := make([][]byte, vs)
 	sizes := make([]int, vs)
 	for i := range bufs {
 		bufs[i] = make([]byte, TUN_OFFSET_BYTES+65535)
@@ -36,13 +32,14 @@ func (tun *TunAdapter) read() {
 }
 
 func (tun *TunAdapter) write() {
-	vs := 1 // One at a time for now... eventually use tun.idealBatchSize()
-	bufs := make(net.Buffers, vs)
+	vs := tun.idealBatchSize()
+	bufs := make([][]byte, vs)
+	sizes := make([]int, vs)
 	for i := range bufs {
 		bufs[i] = make([]byte, TUN_OFFSET_BYTES+65535)
 	}
 	for {
-		n, err := tun.rwc.Read(bufs[0][TUN_OFFSET_BYTES : TUN_OFFSET_BYTES+65535])
+		n, err := tun.rwc.ReadMany(bufs, sizes, TUN_OFFSET_BYTES)
 		if err != nil {
 			tun.log.Errorln("Exiting TUN writer due to core read error:", err)
 			return
@@ -50,8 +47,7 @@ func (tun *TunAdapter) write() {
 		if !tun.isEnabled {
 			continue // Nothing to do, the tun isn't enabled
 		}
-		bufs[0] = bufs[0][:TUN_OFFSET_BYTES+n]
-		if _, err = tun.iface.Write(bufs, TUN_OFFSET_BYTES); err != nil {
+		if _, err = tun.iface.Write(bufs[:n], TUN_OFFSET_BYTES); err != nil {
 			tun.Act(nil, func() {
 				if !tun.isOpen {
 					tun.log.Errorln("TUN iface write error:", err)

--- a/src/tun/tun.go
+++ b/src/tun/tun.go
@@ -24,6 +24,7 @@ type MTU uint16
 
 type ReadWriteCloser interface {
 	io.ReadWriteCloser
+	ReadMany([][]byte, []int, int) (int, error) // Vectorised reads
 	Address() address.Address
 	Subnet() address.Subnet
 	MaxMTU() uint64

--- a/src/tun/tun.go
+++ b/src/tun/tun.go
@@ -162,7 +162,7 @@ func (tun *TunAdapter) _start() error {
 	tun.rwc.SetMTU(tun.MTU())
 	tun.isOpen = true
 	tun.isEnabled = true
-	tun.ch = make(chan []byte, tun.idealBatchSize())
+	tun.ch = make(chan []byte, tun.iface.BatchSize())
 	go tun.queue()
 	go tun.read()
 	go tun.write()

--- a/src/tun/tun_bsd.go
+++ b/src/tun/tun_bsd.go
@@ -80,6 +80,9 @@ func (tun *TunAdapter) setup(ifname string, addr string, mtu uint64) error {
 	if err != nil {
 		return fmt.Errorf("failed to create TUN: %w", err)
 	}
+	if !waitForTUNUp(iface.Events()) {
+		return fmt.Errorf("TUN did not come up in time")
+	}
 	tun.iface = iface
 	if mtu, err := iface.MTU(); err == nil {
 		tun.mtu = getSupportedMTU(uint64(mtu))

--- a/src/tun/tun_darwin.go
+++ b/src/tun/tun_darwin.go
@@ -27,6 +27,9 @@ func (tun *TunAdapter) setup(ifname string, addr string, mtu uint64) error {
 	if err != nil {
 		return fmt.Errorf("failed to create TUN: %w", err)
 	}
+	if !waitForTUNUp(iface.Events()) {
+		return fmt.Errorf("TUN did not come up in time")
+	}
 	tun.iface = iface
 	if m, err := iface.MTU(); err == nil {
 		tun.mtu = getSupportedMTU(uint64(m))
@@ -54,6 +57,9 @@ func (tun *TunAdapter) setupFD(fd int32, addr string, mtu uint64) error {
 	if err != nil {
 		unix.Close(dfd)
 		return fmt.Errorf("failed to create TUN from FD: %w", err)
+	}
+	if !waitForTUNUp(iface.Events()) {
+		return fmt.Errorf("TUN did not come up in time")
 	}
 	tun.iface = iface
 	if m, err := iface.MTU(); err == nil {

--- a/src/tun/tun_linux.go
+++ b/src/tun/tun_linux.go
@@ -21,6 +21,9 @@ func (tun *TunAdapter) setup(ifname string, addr string, mtu uint64) error {
 	if err != nil {
 		return fmt.Errorf("failed to create TUN: %w", err)
 	}
+	if !waitForTUNUp(iface.Events()) {
+		return fmt.Errorf("TUN did not come up in time")
+	}
 	tun.iface = iface
 	if mtu, err := iface.MTU(); err == nil {
 		tun.mtu = getSupportedMTU(uint64(mtu))

--- a/src/tun/tun_other.go
+++ b/src/tun/tun_other.go
@@ -18,6 +18,9 @@ func (tun *TunAdapter) setup(ifname string, addr string, mtu uint64) error {
 	if err != nil {
 		return fmt.Errorf("failed to create TUN: %w", err)
 	}
+	if !waitForTUNUp(iface.Events()) {
+		return fmt.Errorf("TUN did not come up in time")
+	}
 	tun.iface = iface
 	if mtu, err := iface.MTU(); err == nil {
 		tun.mtu = getSupportedMTU(uint64(mtu))

--- a/src/tun/tun_windows.go
+++ b/src/tun/tun_windows.go
@@ -34,6 +34,9 @@ func (tun *TunAdapter) setup(ifname string, addr string, mtu uint64) error {
 		if iface, err = wgtun.CreateTUNWithRequestedGUID(ifname, &guid, int(mtu)); err != nil {
 			return err
 		}
+		if !waitForTUNUp(iface.Events()) {
+			return fmt.Errorf("TUN did not come up in time")
+		}
 		tun.iface = iface
 		if addr != "" {
 			if err = tun.setupAddress(addr); err != nil {


### PR DESCRIPTION
This PR updates the Wireguard dependency and updates to use new vectorised reads/writes, which should reduce the number of syscalls and improve performance.

This will only make a difference on Linux as this is the only platform for which the Wireguard TUN library supports vectorised reads/writes. For other platforms, single reads and writes will be performed as usual.