### PR TITLE
Notify service manager when start up is completed

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -272,6 +272,10 @@ func main() {
 		}
 	}
 
+	if _, err = notifyStartupCompleted(); err != nil {
+		log.Warnln("Error while sending start up notification:", err)
+	}
+
 	// Block until we are told to shut down.
 	<-ctx.Done()
 

--- a/cmd/yggdrasil/notify_startup_linux.go
+++ b/cmd/yggdrasil/notify_startup_linux.go
@@ -1,0 +1,50 @@
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"net"
+	"os"
+)
+
+// Notify systemd daemon when start up is completed.
+// Required to ensure that dependent services are started only after TUN interface is ready.
+//
+// One of the following is returned:
+// (false, nil) - notification not supported (i.e. `notifySocketEnv` is unset)
+// (false, err) - notification supported, but failure happened (e.g. error connecting to `notifySocketEnv` or while sending data)
+// (true, nil) - notification supported, data has been sent
+//
+// Based on `SdNotify` from [`coreos/go-systemd`](https://github.com/coreos/go-systemd/blob/7d375ecc2b092916968b5601f74cca28a8de45dd/daemon/sdnotify.go#L56)
+func notifyStartupCompleted() (bool, error) {
+	const (
+		notifyReady     = "READY=1"
+		notifySocketEnv = "NOTIFY_SOCKET"
+	)
+
+	socketAddr := &net.UnixAddr{
+		Name: os.Getenv(notifySocketEnv),
+		Net:  "unixgram",
+	}
+
+	// `notifySocketEnv` not set
+	if socketAddr.Name == "" {
+		return false, nil
+	}
+
+	os.Unsetenv(notifySocketEnv)
+
+	conn, err := net.DialUnix(socketAddr.Net, nil, socketAddr)
+	// Error connecting to `notifySocketEnv`
+	if err != nil {
+		return false, err
+	}
+	defer conn.Close()
+
+	if _, err = conn.Write([]byte(notifyReady)); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/cmd/yggdrasil/notify_startup_other.go
+++ b/cmd/yggdrasil/notify_startup_other.go
@@ -1,0 +1,8 @@
+//go:build !linux
+// +build !linux
+
+package main
+
+func notifyStartupCompleted() (bool, error) {
+	return false, nil
+}

--- a/contrib/systemd/yggdrasil.service
+++ b/contrib/systemd/yggdrasil.service
@@ -6,6 +6,10 @@ After=network-online.target
 After=yggdrasil-default-config.service
 
 [Service]
+Type=notify
+# Allow forked off processes to send notifications.
+# Uncomment if e.g. yggdrasil is started by a script.
+#NotifyAccess=all
 Group=yggdrasil
 ProtectHome=true
 ProtectSystem=true

--- a/contrib/systemd/yggdrasil.service.debian
+++ b/contrib/systemd/yggdrasil.service.debian
@@ -6,6 +6,7 @@ After=network-online.target
 After=yggdrasil-default-config.service
 
 [Service]
+Type=notify
 Group=yggdrasil
 ProtectHome=true
 ProtectSystem=strict


### PR DESCRIPTION
Currently there is no way to notify service manager when yggdrasil start up process is truly completed, i.e its TUN interface and admin API endpoints are up and running. This makes naive services, set to depend on the yggdrasil network, periodically crash on startup, requiring sub-optimal complications for trivial tasks.

This PR solves the issue by notifying the service manager after TUN interface and admin sockets are ready. Systemd support is implemented by sending a short `READY=1` message to a UNIX datagram socket defined in a `NOTIFY_SOCKET` environment variable, see `sd_notify(3)`.

### Changes

- `cmd/yggdrasil/main.go` - Added invocation for `notifyStartupCompleted` right after TUN interface and admin sockets are set up.
- `cmd/yggdrasil/notify_startup_*.go` - Added `notifyStartupCompleted` function handling the process on linux and immediately returning on other platforms.
- `contrib/systemd/yggdrasil.service*` - Service `Type` is changed to `notify`, added a comment about `NotifyAccess` property.