### PR TITLE
Avoid duplicate multicast peerings by having the higher key dial the lower one only

### DIFF
--- a/src/multicast/multicast.go
+++ b/src/multicast/multicast.go
@@ -403,7 +403,7 @@ func (m *Multicast) listen() {
 			continue
 		case adv.MinorVersion != core.ProtocolVersionMinor:
 			continue
-		case adv.PublicKey.Equal(m.core.PublicKey()):
+		case bytes.Compare(adv.PublicKey, m.core.PublicKey()) >= 0:
 			continue
 		}
 		from := fromAddr.(*net.UDPAddr)


### PR DESCRIPTION
This should avoid situations where nodes of the same (or newer) versions will try to create two link-local peerings via multicast discovery.