### PR TITLE
Fix Android build with Go 1.23.0 or later

### DIFF
--- a/contrib/mobile/build
+++ b/contrib/mobile/build
@@ -7,6 +7,7 @@ set -ef
 PKGSRC=${PKGSRC:-github.com/yggdrasil-network/yggdrasil-go/src/version}
 PKGNAME=${PKGNAME:-$(sh contrib/semver/name.sh)}
 PKGVER=${PKGVER:-$(sh contrib/semver/version.sh --bare)}
+GOVER=$(go version | { read _ _ version _; echo ${version#go}; })
 
 LDFLAGS="-X $PKGSRC.buildName=$PKGNAME -X $PKGSRC.buildVersion=$PKGVER"
 ARGS="-v"
@@ -31,6 +32,15 @@ fi
 if [ ! $IOS ] && [ ! $ANDROID ]; then 
   echo "Must specify -a (Android), -i (iOS) or both"
   exit 1
+fi
+
+ver_le() {
+    printf "$1\n$2\n" | sort -VC
+}
+
+if [ $ANDROID ] && ver_le 1.23.0 $GOVER ; then
+    # github.com/wlynxg/anet library relies on //go:linkname
+    LDFLAGS="$LDFLAGS -checklinkname=0"
 fi
 
 if [ $IOS ]; then


### PR DESCRIPTION
The `github.com/wlynxg/anet` library depends on the `//go:linkname` linker feature [1]. However, since Go 1.23.0, the usage of `//go:linkname` has been restricted [2]. And now it's necessary to explicitly specify `-checklinkname=0` linker flag to use it.

[1] https://github.com/wlynxg/anet/blob/main/README.md#how-to-build-with-go-1230-or-later
[2] https://tip.golang.org/doc/go1.23#linker

Resolves: #1165