### PR TITLE
Link costing based on average RTT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: stable
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.21", "1.22"]
+        goversion: ["1.21", "1.22", "1.23"]
 
     name: Build & Test (Linux, Go ${{ matrix.goversion }})
     needs: [lint]
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.21", "1.22"]
+        goversion: ["1.21", "1.22", "1.23"]
 
     name: Build & Test (Windows, Go ${{ matrix.goversion }})
     needs: [lint]
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.21", "1.22"]
+        goversion: ["1.21", "1.22", "1.23"]
 
     name: Build & Test (macOS, Go ${{ matrix.goversion }})
     needs: [lint]
@@ -123,7 +123,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goversion: ["1.21", "1.22"]
+        goversion: ["1.21", "1.22", "1.23"]
         goos:
           - freebsd
           - openbsd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: stable
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --issues-exit-code=1
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,8 @@ run:
   build-tags:
     - lint
   issues-exit-code: 0 # TODO: change this to 1 when we want it to fail builds
-  skip-dirs:
+issues:
+  exclude-dirs:
     - contrib/
     - misc/
 linters:

--- a/cmd/yggdrasilctl/main.go
+++ b/cmd/yggdrasilctl/main.go
@@ -174,7 +174,7 @@ func run() int {
 		if err := json.Unmarshal(recv.Response, &resp); err != nil {
 			panic(err)
 		}
-		table.SetHeader([]string{"URI", "State", "Dir", "IP Address", "Uptime", "RTT", "RX", "TX", "Pr", "Last Error"})
+		table.SetHeader([]string{"URI", "State", "Dir", "IP Address", "Uptime", "RTT", "RX", "TX", "Pr", "Cost", "Last Error"})
 		for _, peer := range resp.Peers {
 			state, lasterr, dir, rtt := "Up", "-", "Out", "-"
 			if !peer.Up {
@@ -200,6 +200,7 @@ func run() int {
 				peer.RXBytes.String(),
 				peer.TXBytes.String(),
 				fmt.Sprintf("%d", peer.Priority),
+				fmt.Sprintf("%d", peer.Cost),
 				lasterr,
 			})
 		}

--- a/contrib/mobile/mobile.go
+++ b/contrib/mobile/mobile.go
@@ -15,8 +15,6 @@ import (
 	"github.com/yggdrasil-network/yggdrasil-go/src/multicast"
 	"github.com/yggdrasil-network/yggdrasil-go/src/tun"
 	"github.com/yggdrasil-network/yggdrasil-go/src/version"
-
-	_ "golang.org/x/mobile/bind"
 )
 
 // Yggdrasil mobile package is meant to "plug the gap" for mobile support, as

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/yggdrasil-network/yggdrasil-go
 go 1.21
 
 require (
-	github.com/Arceliar/ironwood v0.0.0-20240529054413-b8e59574e2b2
+	github.com/Arceliar/ironwood v0.0.0-20240921214443-277f642d5db3
 	github.com/Arceliar/phony v0.0.0-20220903101357-530938a4b13d
 	github.com/cheggaaa/pb/v3 v3.1.5
 	github.com/gologme/log v1.3.0
@@ -14,10 +14,10 @@ require (
 	github.com/vishvananda/netlink v1.1.0
 	github.com/wlynxg/anet v0.0.4-0.20240806025826-e684438fc7c6
 	golang.org/x/crypto v0.25.0
-	golang.org/x/mobile v0.0.0-20240716161057-1ad2df20a8b6
 	golang.org/x/net v0.27.0
 	golang.org/x/sys v0.22.0
 	golang.org/x/text v0.16.0
+	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2
 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173
 	golang.zx2c4.com/wireguard/windows v0.5.3
 	nhooyr.io/websocket v1.8.11
@@ -36,7 +36,6 @@ require (
 	golang.org/x/mod v0.19.0 // indirect
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/tools v0.23.0 // indirect
-	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Arceliar/ironwood v0.0.0-20240529054413-b8e59574e2b2 h1:SBdYBKeXYUUFef5wi2CMhYmXFVGiYaRpTvbki0Bu+JQ=
-github.com/Arceliar/ironwood v0.0.0-20240529054413-b8e59574e2b2/go.mod h1:6WP4799FX0OuWdENGQAh+0RXp9FLh0y7NZ7tM9cJyXk=
+github.com/Arceliar/ironwood v0.0.0-20240921214443-277f642d5db3 h1:OJ49qTfdw5MNkpnRraNEsVQbHahSvShh8Z9WYpZrYa0=
+github.com/Arceliar/ironwood v0.0.0-20240921214443-277f642d5db3/go.mod h1:6WP4799FX0OuWdENGQAh+0RXp9FLh0y7NZ7tM9cJyXk=
 github.com/Arceliar/phony v0.0.0-20220903101357-530938a4b13d h1:UK9fsWbWqwIQkMCz1CP+v5pGbsGoWAw6g4AyvMpm1EM=
 github.com/Arceliar/phony v0.0.0-20220903101357-530938a4b13d/go.mod h1:BCnxhRf47C/dy/e/D2pmB8NkB3dQVIrkD98b220rx5Q=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
@@ -83,8 +83,6 @@ golang.org/x/crypto v0.25.0 h1:ypSNr+bnYL2YhwoMt2zPxHFmbAN1KZs/njMG3hxUp30=
 golang.org/x/crypto v0.25.0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 h1:2dVuKD2vS7b0QIHQbpyTISPd0LeHDbnYEryqj5Q1ug8=
 golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56/go.mod h1:M4RDyNAINzryxdtnbRXRL/OHtkFuWGRjvuhBJpk2IlY=
-golang.org/x/mobile v0.0.0-20240716161057-1ad2df20a8b6 h1:/VlmIrkuLf2wzPjkZ8imSpckHoW7Y71h66dxbLHSpi8=
-golang.org/x/mobile v0.0.0-20240716161057-1ad2df20a8b6/go.mod h1:TCsc78+c4cqb8IKEosz2LwJ6YRNkIjMuAYeHYjchGDE=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.19.0 h1:fEdghXQSo20giMthA7cd28ZC+jts4amQ3YMXiP5oMQ8=

--- a/src/admin/getpeers.go
+++ b/src/admin/getpeers.go
@@ -24,6 +24,7 @@ type PeerEntry struct {
 	PublicKey     string        `json:"key"`
 	Port          uint64        `json:"port"`
 	Priority      uint64        `json:"priority"`
+	Cost          uint64        `json:"cost"`
 	RXBytes       DataUnit      `json:"bytes_recvd,omitempty"`
 	TXBytes       DataUnit      `json:"bytes_sent,omitempty"`
 	Uptime        float64       `json:"uptime,omitempty"`
@@ -41,6 +42,7 @@ func (a *AdminSocket) getPeersHandler(_ *GetPeersRequest, res *GetPeersResponse)
 			Up:       p.Up,
 			Inbound:  p.Inbound,
 			Priority: uint64(p.Priority), // can't be uint8 thanks to gobind
+			Cost:     p.Cost,
 			URI:      p.URI,
 			RXBytes:  DataUnit(p.RXBytes),
 			TXBytes:  DataUnit(p.TXBytes),

--- a/src/core/api.go
+++ b/src/core/api.go
@@ -30,6 +30,7 @@ type PeerInfo struct {
 	Coords        []uint64
 	Port          uint64
 	Priority      uint8
+	Cost          uint64
 	RXBytes       uint64
 	TXBytes       uint64
 	Uptime        time.Duration
@@ -94,6 +95,7 @@ func (c *Core) GetPeers() []PeerInfo {
 				peerinfo.Port = p.Port
 				peerinfo.Priority = p.Priority
 				peerinfo.Latency = p.Latency
+				peerinfo.Cost = p.Cost
 			}
 			peers = append(peers, peerinfo)
 		}


### PR DESCRIPTION
This PR updates Ironwood to include the new RTT-based link costing and updates `yggdrasilctl` to report the cost in `getPeers`.