### PR TITLE
tun: bsd: remove redundant ioctl to set MTU

### DIFF
--- a/src/tun/tun_bsd.go
+++ b/src/tun/tun_bsd.go
@@ -54,11 +54,6 @@ struct  in6_ifreq {
  290 };
 */
 
-type in6_ifreq_mtu struct {
-	ifr_name [syscall.IFNAMSIZ]byte
-	ifru_mtu int
-}
-
 type in6_ifreq_addr struct {
 	ifr_name  [syscall.IFNAMSIZ]byte
 	ifru_addr sockaddr_in6
@@ -111,26 +106,6 @@ func (tun *TunAdapter) setupAddress(addr string) error {
 	tun.log.Infof("Interface name: %s", tun.Name())
 	tun.log.Infof("Interface IPv6: %s", addr)
 	tun.log.Infof("Interface MTU: %d", tun.mtu)
-
-	// Create the MTU request
-	var ir in6_ifreq_mtu
-	copy(ir.ifr_name[:], tun.Name())
-	ir.ifru_mtu = int(tun.mtu)
-
-	// Set the MTU
-	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(sfd), uintptr(syscall.SIOCSIFMTU), uintptr(unsafe.Pointer(&ir))); errno != 0 {
-		err = errno
-		tun.log.Errorf("Error in SIOCSIFMTU: %v", errno)
-
-		// Fall back to ifconfig to set the MTU
-		cmd := exec.Command("ifconfig", tun.Name(), "mtu", string(tun.mtu))
-		tun.log.Warnf("Using ifconfig as fallback: %v", strings.Join(cmd.Args, " "))
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			tun.log.Errorf("SIOCSIFMTU fallback failed: %v.", err)
-			tun.log.Traceln(string(output))
-		}
-	}
 
 	// Create the address request
 	// FIXME: I don't work!


### PR DESCRIPTION
wireguard's CreateTUN() sets the MTU using the same ioctl(2), on both FreeBSD and OpenBSD.

Tested on OpenBSD (outputwith this patch):

```
# ktrace ./yggdrasil -autoconf | grep Interface
2024/09/24 17:26:29 Interface name: tun0
2024/09/24 17:26:29 Interface IPv6: 201:26e:68f0:502e:f445:13eb:2fe1:f7cd/7
2024/09/24 17:26:29 Interface MTU: 16384
```

```
$ ifconfig tun0 | head -n1
tun0: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 16384
```

```
# kdump | grep ioctl
 53097 yggdrasil CALL  ioctl(10,SIOCGIFMTU,0xc0000376b8)
 53097 yggdrasil RET   ioctl 0
 53097 yggdrasil CALL  ioctl(10,SIOCSIFMTU,0xc0000376c0)
 53097 yggdrasil RET   ioctl 0
 53097 yggdrasil CALL  ioctl(10,SIOCGIFMTU,0xc0000377f8)
 53097 yggdrasil RET   ioctl 0
 53097 yggdrasil CALL  ioctl(10,_IOW('i',12,0x20),0xc00003777c)
 53097 yggdrasil RET   ioctl -1 errno 25 Inappropriate ioctl for device
       "2024/09/24 17:26:29 Error in SIOCSIFADDR_IN6: inappropriate ioctl for device
```

(The completely broken address ioctl is another story...)