### PR TITLE
Use UNIX socket patch from url struct

### DIFF
--- a/src/admin/admin.go
+++ b/src/admin/admin.go
@@ -238,28 +238,27 @@ func (a *AdminSocket) listen() {
 	if err == nil {
 		switch strings.ToLower(u.Scheme) {
 		case "unix":
-			file := strings.TrimPrefix(listenaddr, "unix://")
-			if _, err := os.Stat(file); err == nil {
-				a.log.Debugln("Admin socket", file, "already exists, trying to clean up")
-				if _, err := net.DialTimeout("unix", file, time.Second*2); err == nil || err.(net.Error).Timeout() {
-					a.log.Errorln("Admin socket", file, "already exists and is in use by another process")
+			if _, err := os.Stat(u.Path); err == nil {
+				a.log.Debugln("Admin socket", u.Path, "already exists, trying to clean up")
+				if _, err := net.DialTimeout("unix", u.Path, time.Second*2); err == nil || err.(net.Error).Timeout() {
+					a.log.Errorln("Admin socket", u.Path, "already exists and is in use by another process")
 					os.Exit(1)
 				} else {
-					if err := os.Remove(file); err == nil {
-						a.log.Debugln(file, "was cleaned up")
+					if err := os.Remove(u.Path); err == nil {
+						a.log.Debugln(u.Path, "was cleaned up")
 					} else {
-						a.log.Errorln(file, "already exists and was not cleaned up:", err)
+						a.log.Errorln(u.Path, "already exists and was not cleaned up:", err)
 						os.Exit(1)
 					}
 				}
 			}
-			a.listener, err = net.Listen("unix", file)
+			a.listener, err = net.Listen("unix", u.Path)
 			if err == nil {
-				switch file[:1] {
+				switch u.Path[:1] {
 				case "@": // maybe abstract namespace
 				default:
-					if err := os.Chmod(file, 0660); err != nil {
-						a.log.Warnln("WARNING:", file, "may have unsafe permissions!")
+					if err := os.Chmod(u.Path, 0660); err != nil {
+						a.log.Warnln("WARNING:", u.Path, "may have unsafe permissions!")
 					}
 				}
 			}


### PR DESCRIPTION
No need to extract it again when the url package provides it for us:
```
$ jq -n '{"AdminListen":"unix:///tmp/ygg.sock"}' | ./yggdrasil -useconf | grep 'admin socket'
2024/10/08 22:41:11 UNIX admin socket listening on /tmp/ygg.sock
```

Follow-up on #1176