### PR TITLE
Set groups when dropping privileges to not leak supplementary group access

### DIFF
--- a/cmd/yggdrasil/chuser_unix.go
+++ b/cmd/yggdrasil/chuser_unix.go
@@ -53,6 +53,9 @@ func chuser(user string) error {
 		gid, _ := strconv.ParseUint(g.Gid, 10, 32)
 		var err error
 		if gid < math.MaxInt {
+			if err := syscall.Setgroups([]int{int(gid)}); err != nil {
+				return fmt.Errorf("failed to setgroups %d: %v", gid, err)
+			}
 			err = syscall.Setgid(int(gid))
 		} else {
 			err = errors.New("gid too big")
@@ -63,6 +66,9 @@ func chuser(user string) error {
 		}
 	} else if u != nil {
 		gid, _ := strconv.ParseUint(u.Gid, 10, 32)
+		if err := syscall.Setgroups([]int{int(uint32(gid))}); err != nil {
+			return fmt.Errorf("failed to setgroups %d: %v", gid, err)
+		}
 		err := syscall.Setgid(int(uint32(gid)))
 		if err != nil {
 			return fmt.Errorf("failed to setgid %d: %v", gid, err)


### PR DESCRIPTION
Changing the real and effective user/group IDs and the saved set-user/group-ID is not enough to get rid of intial access permissions.

The list of groups must be cleared also, otherwise a process changing from, e.g. `root:root` to `nobody:nobody` retains rights to access `:wheel` files (assuming `root` is a member of the `wheel` group).

For example:
```
# id
uid=0(root) gid=0(wheel) groups=0(wheel), 2(kmem), 3(sys), 4(tty), 5(operator), 20(staff), 31(guest)
# ./yggdrasil -autoconf -logto /dev/null -user nobody &
[1] 4337
# ps -o command,user,group,supgrp -U nobody
COMMAND          USER     GROUP    SUPGRP
./yggdrasil -aut nobody   nobody   wheel,kmem,sys,tty,operator,staff,guest
```

Fix that so the process runs as mere
```
COMMAND          USER     GROUP    SUPGRP
./yggdrasil -aut nobody   nobody   nobody
```

Fixes #927.