### PR TITLE
Build portable zip version of yggdrasil go for windows

### DIFF
--- a/.github/workflows/pkg.yml
+++ b/.github/workflows/pkg.yml
@@ -102,6 +102,51 @@ jobs:
           path: "*.msi"
           if-no-files-found: error
 
+  build-zip-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        pkgarch: ["x64", "x86", "arm", "arm64"]
+
+    name: Package (Windows-zip, ${{ matrix.pkgarch }})
+
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v4
+
+      - name: Get info
+        id: vars
+        run: | 
+          echo "PKGNAME=$(contrib/semver/name.sh)" >> $GITHUB_ENV
+          echo "PKGVERSION=$(contrib/msi/msversion.sh --bare)" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Build package
+        run: sh contrib/zip/build-zip.sh ${{ matrix.pkgarch }}
+
+      - name: Archive Release
+        uses: thedoctor0/zip-release@0.7.5
+        with:
+          type: 'zip'
+          filename: '${{ env.PKGNAME }}-${{ env.PKGVERSION }}-${{ matrix.pkgarch }}.zip'
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Windows zip package (${{ matrix.pkgarch }})
+          path: "*.zip"
+          if-no-files-found: error
+
   build-packages-router:
     strategy:
       fail-fast: false

--- a/contrib/zip/build-zip.sh
+++ b/contrib/zip/build-zip.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+PKGARCH=$1
+if [ "${PKGARCH}" == "" ];
+then
+  echo "tell me the architecture: x86, x64, arm or arm64"
+  exit 1
+fi
+
+# Download the wix tools!
+dotnet tool install --global wix --version 5.0.0
+
+# Build Yggdrasil!
+[ "${PKGARCH}" == "x64" ] && GOOS=windows GOARCH=amd64 CGO_ENABLED=0 ./build
+[ "${PKGARCH}" == "x86" ] && GOOS=windows GOARCH=386 CGO_ENABLED=0 ./build
+[ "${PKGARCH}" == "arm" ] && GOOS=windows GOARCH=arm CGO_ENABLED=0 ./build
+[ "${PKGARCH}" == "arm64" ] && GOOS=windows GOARCH=arm64 CGO_ENABLED=0 ./build
+
+# Create the postinstall script
+cat > start.bat << EOF
+@echo off
+
+net session >nul 2>&1
+if %errorlevel% neq 0 (
+    powershell -Command "Start-Process '%~0' -Verb RunAs"
+    exit /b
+)
+
+set "SCRIPT_DIR=%~dp0"
+
+if not exist "%SCRIPT_DIR%yggdrasil.conf" (
+  if exist "%SCRIPT_DIR%yggdrasil.exe" (
+    echo Generating yggdrasil.conf...
+    "%SCRIPT_DIR%yggdrasil.exe" -genconf > "%SCRIPT_DIR%yggdrasil.conf"
+    if errorlevel 1 (
+      echo Failed to generate the configuration file!
+      pause
+      exit /b 1
+    )
+  ) else (
+    echo yggdrasil.exe not found!
+    pause
+    exit /b 1
+  )
+)
+
+if exist "%SCRIPT_DIR%yggdrasil.conf" (
+  echo Starting Yggdrasil with the configuration file...
+  "%SCRIPT_DIR%yggdrasil.exe" -useconffile "%SCRIPT_DIR%yggdrasil.conf"
+  if errorlevel 1 (
+    echo Failed to start Yggdrasil!
+    pause
+    exit /b 1
+  )
+) else (
+  echo yggdrasil.conf file is missing!
+  pause
+  exit /b 1
+)
+EOF
+
+# Download the Wintun driver
+if [ ! -d wintun ];
+then
+  curl -o wintun.zip https://www.wintun.net/builds/wintun-0.14.1.zip
+  if [ `sha256sum wintun.zip | cut -f 1 -d " "` != "07c256185d6ee3652e09fa55c0b673e2624b565e02c4b9091c79ca7d2f24ef51" ];
+  then
+    echo "wintun package didn't match expected checksum"
+    exit 1
+  fi
+  unzip wintun.zip
+fi
+
+if [ $PKGARCH = "x64" ]; then
+  mv ./wintun/bin/amd64/wintun.dll ./wintun.dll
+elif [ $PKGARCH = "x86" ]; then
+  mv ./wintun/bin/x86/wintun.dll ./wintun.dll
+elif [ $PKGARCH = "arm" ]; then
+  mv ./wintun/bin/arm/wintun.dll ./wintun.dll
+elif [ $PKGARCH = "arm64" ]; then
+  mv ./wintun/bin/arm64/wintun.dll ./wintun.dll
+else
+  echo "wasn't sure which architecture to get wintun for"
+  exit 1
+fi
+rm -rf ./wintun
+find . -type f ! -name 'yggdrasilctl.exe' ! -name 'yggdrasil.exe' ! -name 'wintun.dll' ! -name 'start.bat' -delete
+find . -depth -type d -empty -delete


### PR DESCRIPTION
This pull request refines the **build-zip-windows** job by creating the process to generate a Windows ZIP archive. The changes are isolated to the Windows ZIP build and do not affect the Debian, macOS, MSI, or Router package jobs.

## How `start.bat` Works

The generated `start.bat` is a post-install script that enhances the user experience by automating configuration and launch tasks:

- **Elevation Check:**  
  - The script checks if it is running with administrative privileges. If not, it re-launches itself with elevated permissions using PowerShell. This ensures that subsequent operations requiring admin rights can proceed.

- **Configuration File Generation:**  
  - It verifies the existence of `yggdrasil.conf` in the current directory.
  - If the configuration file is missing but `yggdrasil.exe` is present, the script generates a new configuration file by running `yggdrasil.exe -genconf`.
  - Error handling is provided so that if the configuration generation fails, the user is informed and the script exits appropriately.

- **Launching Yggdrasil:**  
  - Once the configuration file is confirmed to exist, the script launches Yggdrasil using the `-useconffile` flag.
  - The script ensures that errors during startup are caught and communicated to the user, pausing execution if needed.