### PR TITLE
fix go version in go.mod for toolchain downloads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yggdrasil-network/yggdrasil-go
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Arceliar/ironwood v0.0.0-20241213013129-743fe2fccbd3


### PR DESCRIPTION
as go downloads from https://go.dev/dl/go{version.in.godotmod}.{platform}-{arch}.tar.gz if the system toolchain is too old, the line `go 1.22` should be `go 1.22.0` in go.mod in order for it to not fail for <1.22, even though `go 1.22` is legal and toolchains with a version number >= it will recognize it fine and will build normally.

this does not break existing builds.

![image](https://github.com/user-attachments/assets/91dcedfb-aa79-4f80-a95a-ee33bf19f8b2)
