### PR TITLE
[deb] Don't run as root

### DIFF
--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -79,9 +79,7 @@ cat > /tmp/$PKGNAME/debian/postinst << EOF
 
 systemctl daemon-reload
 
-if ! getent group yggdrasil 2>&1 > /dev/null; then
-  groupadd --system --force yggdrasil
-fi
+adduser --system --home /nonexistant --no-create-home --group --quiet yggdrasil
 
 if [ ! -d /etc/yggdrasil ];
 then

--- a/contrib/systemd/yggdrasil.service.debian
+++ b/contrib/systemd/yggdrasil.service.debian
@@ -6,7 +6,7 @@ After=network-online.target
 After=yggdrasil-default-config.service
 
 [Service]
-Group=yggdrasil
+User=yggdrasil
 ProtectHome=true
 ProtectSystem=strict
 NoNewPrivileges=true


### PR DESCRIPTION
Any reason it needs to run as root? Seems to be working fine running as a user because it has the capabilities it needs.