### PR TITLE
Fix default config permissions

### DIFF
--- a/contrib/busybox-init/S42yggdrasil
+++ b/contrib/busybox-init/S42yggdrasil
@@ -3,7 +3,7 @@
 CONFFILE="/etc/yggdrasil.conf"
 
 genconf() {
-	/usr/bin/yggdrasil -genconf > "$1"
+	(umask 037 && /usr/bin/yggdrasil -genconf > "$1")
 	return $?
 }
 

--- a/contrib/deb/generate.sh
+++ b/contrib/deb/generate.sh
@@ -108,7 +108,7 @@ then
   chmod 640 /etc/yggdrasil/yggdrasil.conf
 else
   echo "Generating initial configuration file /etc/yggdrasil/yggdrasil.conf"
-  /usr/bin/yggdrasil -genconf > /etc/yggdrasil/yggdrasil.conf
+  (umask 037 && /usr/bin/yggdrasil -genconf > /etc/yggdrasil/yggdrasil.conf)
 
   chown root:yggdrasil /etc/yggdrasil/yggdrasil.conf
   chmod 640 /etc/yggdrasil/yggdrasil.conf

--- a/contrib/docker/entrypoint.sh
+++ b/contrib/docker/entrypoint.sh
@@ -6,7 +6,7 @@ CONF_DIR="/etc/yggdrasil-network"
 
 if [ ! -f "$CONF_DIR/config.conf" ]; then
   echo "generate $CONF_DIR/config.conf"
-  yggdrasil --genconf > "$CONF_DIR/config.conf"
+  (umask 037 && yggdrasil --genconf > "$CONF_DIR/config.conf")
 fi
 
 yggdrasil --useconf < "$CONF_DIR/config.conf"

--- a/contrib/freebsd/yggdrasil
+++ b/contrib/freebsd/yggdrasil
@@ -33,7 +33,7 @@ yggdrasil_start()
 
 	test ! -f /etc/yggdrasil.conf && (
 		logger -s -t yggdrasil "Generating new configuration file into /etc/yggdrasil.conf"
-		/usr/local/bin/yggdrasil -genconf > /etc/yggdrasil.conf
+		(umask 037 && /usr/local/bin/yggdrasil -genconf > /etc/yggdrasil.conf)
 	)
 
 	tap_path="$(cat /etc/yggdrasil.conf | egrep -o '/dev/tap[0-9]{1,2}$')"

--- a/contrib/macos/create-pkg.sh
+++ b/contrib/macos/create-pkg.sh
@@ -55,7 +55,7 @@ then
   echo "Normalising /etc/yggdrasil.conf"
   /usr/local/bin/yggdrasil -useconffile /Library/Preferences/Yggdrasil/yggdrasil.conf.`date +%Y%m%d` -normaliseconf > /etc/yggdrasil.conf
 else
-  /usr/local/bin/yggdrasil -genconf > /etc/yggdrasil.conf
+  (umask 037 && /usr/local/bin/yggdrasil -genconf > /etc/yggdrasil.conf)
 fi
 
 # Unload existing Yggdrasil launchd service, if possible

--- a/contrib/openrc/yggdrasil
+++ b/contrib/openrc/yggdrasil
@@ -14,7 +14,7 @@ depend() {
 start_pre() {
 	if [ ! -f "${CONFFILE}" ]; then
 		ebegin "Generating new configuration file into ${CONFFILE}"
-		if ! eval ${command} -genconf > ${CONFFILE}; then
+		if ! (umask 037 && eval ${command} -genconf > ${CONFFILE}); then
 			eerror "Failed to generate configuration file"
 			exit 1
 		fi

--- a/contrib/systemd/yggdrasil-default-config.service
+++ b/contrib/systemd/yggdrasil-default-config.service
@@ -8,6 +8,7 @@ After=local-fs.target
 [Service]
 Type=oneshot
 Group=yggdrasil
+UMask=037
 StandardOutput=file:/etc/yggdrasil.conf
 ExecStart=/usr/bin/yggdrasil -genconf
 ExecStartPost=/usr/bin/chmod 0640 /etc/yggdrasil.conf

--- a/contrib/systemd/yggdrasil-default-config.service.debian
+++ b/contrib/systemd/yggdrasil-default-config.service.debian
@@ -8,6 +8,7 @@ After=local-fs.target
 [Service]
 Type=oneshot
 Group=yggdrasil
+UMask=037
 ExecStartPre=/usr/bin/mkdir -p /etc/yggdrasil
 ExecStart=/usr/bin/yggdrasil -genconf > /etc/yggdrasil/yggdrasil.conf
 ExecStartPost=/usr/bin/chmod -R 0640 /etc/yggdrasil


### PR DESCRIPTION
Currently, all init scripts, except for systemd, will generate a config file with default permissions, which is usually `rw-r--r--`.
This is bad, because the config contains a private key.

The systemd service does `chmod 640` after creating the config, which is much better than just leaving it readable for everyone forever, but there is still a slight chance that some malicious program might steal the private key during the time window between key creation and chmod.

For this reason, in this pull request I use `umask 037`, so the config won't have read permission for others in the first place.

Note that I have only tested openrc and systemd services.

Also, I'm not sure what to do with the contrib/msi/build-msi.sh script, which creates a bat file that generates a config. I don't know anything about file permissions on windows, however, it seems that the bat file generates the config into a user's personal directory, so maybe it's already somewhat fine.