### PR TITLE
Update yggdrasil.service.debian

### DIFF
--- a/contrib/systemd/yggdrasil.service.debian
+++ b/contrib/systemd/yggdrasil.service.debian
@@ -12,6 +12,7 @@ ProtectSystem=strict
 NoNewPrivileges=true
 RuntimeDirectory=yggdrasil
 ReadWritePaths=/var/run/yggdrasil/ /run/yggdrasil/
+ReadOnlyPaths=/etc/yggdrasil
 SyslogIdentifier=yggdrasil
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE


### PR DESCRIPTION
Can't start service without reading config.
Without explicit allow directive it can't read it.