### PR TITLE
Fix outbound link-local connections on mobile

### DIFF
--- a/src/core/link_tcp.go
+++ b/src/core/link_tcp.go
@@ -69,6 +69,13 @@ func (l *linkTCP) dialerFor(dst *net.TCPAddr, sintf string) (*net.Dialer, error)
 		dialer.Control = l.getControl(sintf)
 		ief, err := net.InterfaceByName(sintf)
 		if err != nil {
+			// On mobile platforms (Android/iOS), InterfaceByName may fail due to
+			// permission restrictions (SELinux on Android), but for link-local
+			// addresses with zone identifiers, the zone is sufficient for routing
+			// and we can proceed without source binding
+			if dst.IP.IsLinkLocalUnicast() && dst.Zone != "" {
+				return dialer, nil
+			}
 			return nil, fmt.Errorf("interface %q not found", sintf)
 		}
 		if ief.Flags&net.FlagUp == 0 {
@@ -76,6 +83,10 @@ func (l *linkTCP) dialerFor(dst *net.TCPAddr, sintf string) (*net.Dialer, error)
 		}
 		addrs, err := ief.Addrs()
 		if err != nil {
+			// Same mobile platform handling for address lookup failures
+			if dst.IP.IsLinkLocalUnicast() && dst.Zone != "" {
+				return dialer, nil
+			}
 			return nil, fmt.Errorf("interface %q addresses not available: %w", sintf, err)
 		}
 		for addrindex, addr := range addrs {


### PR DESCRIPTION
On mobile platforms if multicast discovery enabled, we can get only inbound connections. Outbound connections doesn't work because of interface lookup errors.
For link-local addresses with zone set, we can proceed without binding. The zone identifier tells the kernel which interface to use


`2025/12/22 16:53:17 Discovered addresses for interface wlan0: [192.168.1.125/24 2a06:63c5:9304:c000:5038:f8e3:6d4a:39d6/64 2a06:63c5:9304:c000:8483:3eff:fe63:4b4b/64 fe80::8483:3eff:fe63:4b4b/64]`
`2025/12/22 16:53:17 Dialling tls://[fe80::d905:52e3:b183:5d01%25wlan0]:41315 reported error: interface "wlan0" not found`