### PR TITLE
Change ownership of admin socket before dropping permissions

### DIFF
--- a/cmd/yggdrasil/chuser_other.go
+++ b/cmd/yggdrasil/chuser_other.go
@@ -4,6 +4,6 @@ package main
 
 import "errors"
 
-func chuser(user string) error {
+func chuser(user, adminSockUrl string) error {
 	return errors.New("setting uid/gid is not supported on this platform")
 }

--- a/cmd/yggdrasil/chuser_unix.go
+++ b/cmd/yggdrasil/chuser_unix.go
@@ -4,6 +4,8 @@ package main
 
 import (
 	"fmt"
+	"net/url"
+	"os"
 	"os/user"
 	"strconv"
 	"strings"
@@ -11,7 +13,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func chuser(input string) error {
+func chuser(input, adminSockUrl string) error {
 	givenUser, givenGroup, _ := strings.Cut(input, ":")
 	if givenUser == "" {
 		return fmt.Errorf("user is empty")
@@ -46,6 +48,16 @@ func chuser(input string) error {
 		gid, _ = strconv.Atoi(grp.Gid)
 	} else {
 		gid, _ = strconv.Atoi(usr.Gid)
+	}
+
+	if adminSockUrl != "" {
+		u, err := url.Parse(adminSockUrl)
+		if err == nil && u.Scheme == "unix" {
+			err = os.Chown(u.Path, uid, gid)
+		}
+		if err != nil {
+			return fmt.Errorf("chown %s %d:%d: %v", adminSockUrl, uid, gid, err)
+		}
 	}
 
 	if err := unix.Setgroups([]int{gid}); err != nil {

--- a/cmd/yggdrasil/chuser_unix_test.go
+++ b/cmd/yggdrasil/chuser_unix_test.go
@@ -9,21 +9,21 @@ import (
 
 // Usernames must not contain a number sign.
 func TestEmptyString(t *testing.T) {
-	if chuser("") == nil {
+	if chuser("", "") == nil {
 		t.Fatal("the empty string is not a valid user")
 	}
 }
 
 // Either omit delimiter and group, or omit both.
 func TestEmptyGroup(t *testing.T) {
-	if chuser("0:") == nil {
+	if chuser("0:", "") == nil {
 		t.Fatal("the empty group is not allowed")
 	}
 }
 
 // Either user only or user and group.
 func TestGroupOnly(t *testing.T) {
-	if chuser(":0") == nil {
+	if chuser(":0", "") == nil {
 		t.Fatal("group only is not allowed")
 	}
 }
@@ -31,14 +31,14 @@ func TestGroupOnly(t *testing.T) {
 // Usenames must not contain the number sign.
 func TestInvalidUsername(t *testing.T) {
 	const username = "#user"
-	if chuser(username) == nil {
+	if chuser(username, "") == nil {
 		t.Fatalf("'%s' is not a valid username", username)
 	}
 }
 
 // User IDs must be non-negative.
 func TestInvalidUserid(t *testing.T) {
-	if chuser("-1") == nil {
+	if chuser("-1", "") == nil {
 		t.Fatal("User ID cannot be negative")
 	}
 }
@@ -54,7 +54,7 @@ func TestCurrentUserid(t *testing.T) {
 		t.Skip("setgroups(2): Only the superuser may set new groups.")
 	}
 
-	if err = chuser(usr.Uid); err != nil {
+	if err = chuser(usr.Uid, ""); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -70,7 +70,7 @@ func TestCommonUsername(t *testing.T) {
 		t.Skip("setgroups(2): Only the superuser may set new groups.")
 	}
 
-	if err := chuser("nobody"); err != nil {
+	if err := chuser("nobody", ""); err != nil {
 		if _, ok := err.(user.UnknownUserError); ok {
 			t.Skip(err)
 		}

--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -292,7 +292,7 @@ func main() {
 
 	// Change user if requested
 	if *chuserto != "" {
-		err = chuser(*chuserto)
+		err = chuser(*chuserto, cfg.AdminListen)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This is to allow access to the socket by members of the group that permissions are dropped to.