### PR TITLE
Add -notifyfd flag for s6-style readiness notification

### DIFF
--- a/cmd/yggdrasil/main.go
+++ b/cmd/yggdrasil/main.go
@@ -55,6 +55,7 @@ func main() {
 	getpkey := flag.Bool("publickey", false, "use in combination with either -useconf or -useconffile, outputs your public key")
 	loglevel := flag.String("loglevel", "info", "loglevel to enable")
 	chuserto := flag.String("user", "", "user (and, optionally, group) to set UID/GID to")
+	notifyFd := flag.Int("notifyfd", -1, "write a newline to this file-descriptor to indicate readiness to a service manager")
 	flag.Parse()
 
 	done := make(chan struct{})
@@ -311,6 +312,12 @@ func main() {
 	}
 	if err := protect.Pledge(strings.Join(promises, " ")); err != nil {
 		panic(fmt.Sprintf("pledge: %v: %v", promises, err))
+	}
+
+	if notifyFd != nil && *notifyFd > 0 {
+		f := os.NewFile(uintptr(*notifyFd), "notifyfd")
+		_, _ = f.Write([]byte{0x0a})
+		f.Close()
 	}
 
 	// Block until we are told to shut down.


### PR DESCRIPTION
Write a newline to the specified file-descriptor to signal that yggdrasil is fully initialised and ready.

s6 service startup notifications are described [here](https://skarnet.org/software/s6/notifywhenup.html).

Related: #1148