### PR TITLE
Implement peer state change callback for mobile

### DIFF
--- a/src/core/api.go
+++ b/src/core/api.go
@@ -39,6 +39,25 @@ type PeerInfo struct {
 	Latency       time.Duration
 }
 
+// PeerEventType identifies what kind of change triggered a peer notification.
+type PeerEventType string
+
+const (
+	PeerEventAdded   PeerEventType = "peer_added"   // URI entered the peer list (configured or multicast-discovered)
+	PeerEventRemoved PeerEventType = "peer_removed" // URI left the peer list
+	PeerEventUp      PeerEventType = "peer_up"      // transport connected and handshake completed
+	PeerEventDown    PeerEventType = "peer_down"    // transport disconnected
+)
+
+// PeerEvent is delivered to the callback registered via Core.SetPeerNotify.
+// Changed identifies the peer that triggered the event and holds its new state.
+// Peers is the full peer list captured at the moment the event fires.
+type PeerEvent struct {
+	EventType PeerEventType
+	Changed   PeerInfo
+	Peers     []PeerInfo
+}
+
 type TreeEntryInfo struct {
 	Key      ed25519.PublicKey
 	Parent   ed25519.PublicKey

--- a/src/core/core.go
+++ b/src/core/core.go
@@ -45,6 +45,7 @@ type Core struct {
 		groupPassword      string                     // immutable after startup
 	}
 	pathNotify func(ed25519.PublicKey)
+	peerNotify func(PeerEvent)
 }
 
 func New(cert *tls.Certificate, logger Logger, opts ...SetupOption) (*Core, error) {
@@ -230,6 +231,32 @@ func (c *Core) doPathNotify(key ed25519.PublicKey) {
 func (c *Core) SetPathNotify(notify func(ed25519.PublicKey)) {
 	c.Act(nil, func() {
 		c.pathNotify = notify
+	})
+}
+
+// SetPeerNotify registers a callback that is invoked whenever a peer's
+// membership in the peer list or its up/down state changes. The callback
+// is called synchronously on an internal goroutine; it must not block.
+// Passing nil unregisters any existing callback.
+func (c *Core) SetPeerNotify(notify func(PeerEvent)) {
+	c.Act(nil, func() {
+		c.peerNotify = notify
+	})
+}
+
+// notifyPeer assembles and dispatches a PeerEvent. It is safe to call from
+// any goroutine that does not hold the core or links actor locks.
+func (c *Core) notifyPeer(eventType PeerEventType, changed PeerInfo) {
+	var notify func(PeerEvent)
+	phony.Block(c, func() { notify = c.peerNotify })
+	if notify == nil {
+		return
+	}
+	peers := c.GetPeers()
+	notify(PeerEvent{
+		EventType: eventType,
+		Changed:   changed,
+		Peers:     peers,
 	})
 }
 

--- a/src/core/link.go
+++ b/src/core/link.go
@@ -3,6 +3,7 @@ package core
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -304,11 +305,21 @@ func (l *links) add(u *url.URL, sintf string, linkType linkType) error {
 		// then the loop will run endlessly, using backoffs as needed.
 		// Otherwise the loop will end, cleaning up the link entry.
 		go func() {
-			defer phony.Block(l, func() {
-				if l._links[info] == state {
-					delete(l._links, info)
+			// Notify that this URI has entered the peer list.
+			l.core.notifyPeer(PeerEventAdded, PeerInfo{URI: info.uri})
+
+			defer func() {
+				var removed bool
+				phony.Block(l, func() {
+					if l._links[info] == state {
+						delete(l._links, info)
+						removed = true
+					}
+				})
+				if removed {
+					l.core.notifyPeer(PeerEventRemoved, PeerInfo{URI: info.uri})
 				}
-			})
+			}()
 
 			// This loop will run each and every time we want to attempt
 			// a connection to this peer.
@@ -377,7 +388,12 @@ func (l *links) add(u *url.URL, sintf string, linkType linkType) error {
 
 				// Give the connection to the handler. The handler will block
 				// for the lifetime of the connection.
-				switch err = l.handler(linkType, options, lc, resetBackoff, false); {
+				connectedOnce := false
+				onConnected := func(key ed25519.PublicKey) {
+					connectedOnce = true
+					l.core.notifyPeer(PeerEventUp, PeerInfo{URI: info.uri, Up: true, Key: key})
+				}
+				switch err = l.handler(linkType, options, lc, resetBackoff, onConnected, false); {
 				case errors.Is(err, ErrLinkToSelf):
 					// This is a pretty permanent error, don't retry.
 					backoff = -1
@@ -400,6 +416,9 @@ func (l *links) add(u *url.URL, sintf string, linkType linkType) error {
 					state._err = err
 					state._errtime = time.Now()
 				})
+				if connectedOnce {
+					l.core.notifyPeer(PeerEventDown, PeerInfo{URI: info.uri})
+				}
 
 				// If the link is persistently configured, back off if needed
 				// and then try reconnecting. Otherwise, exit out.
@@ -564,18 +583,34 @@ func (l *links) listen(u *url.URL, sintf string, local bool) (*Listener, error) 
 					// Store the state of the link so that it can be queried later.
 					l._links[info] = state
 				})
-				defer phony.Block(l, func() {
-					if l._links[info] == state {
-						delete(l._links, info)
+				defer func() {
+					if lc == nil {
+						return
 					}
-				})
+					var removed bool
+					phony.Block(l, func() {
+						if l._links[info] == state {
+							delete(l._links, info)
+							removed = true
+						}
+					})
+					if removed {
+						l.core.notifyPeer(PeerEventDown, PeerInfo{URI: info.uri, Inbound: true})
+						l.core.notifyPeer(PeerEventRemoved, PeerInfo{URI: info.uri, Inbound: true})
+					}
+				}()
 				if lc == nil {
 					return
 				}
 
+				// Notify that this inbound peer has been added and is up.
+				l.core.notifyPeer(PeerEventAdded, PeerInfo{URI: info.uri, Inbound: true})
+
 				// Give the connection to the handler. The handler will block
 				// for the lifetime of the connection.
-				switch err = l.handler(linkTypeIncoming, options, lc, nil, local); {
+				switch err = l.handler(linkTypeIncoming, options, lc, nil, func(key ed25519.PublicKey) {
+					l.core.notifyPeer(PeerEventUp, PeerInfo{URI: info.uri, Up: true, Inbound: true, Key: key})
+				}, local); {
 				case err == nil:
 				case errors.Is(err, io.EOF):
 				case errors.Is(err, net.ErrClosed):
@@ -624,7 +659,7 @@ func (l *links) dialerFor(u *url.URL) (linkProtocol, error) {
 	return dialer, nil
 }
 
-func (l *links) handler(linkType linkType, options linkOptions, conn net.Conn, success func(), local bool) error {
+func (l *links) handler(linkType linkType, options linkOptions, conn net.Conn, success func(), connected func(ed25519.PublicKey), local bool) error {
 	meta := version_getBaseMetadata()
 	meta.publicKey = l.core.public
 	meta.priority = options.priority
@@ -703,6 +738,9 @@ func (l *links) handler(linkType linkType, options linkOptions, conn net.Conn, s
 		dir, remoteStr, localStr)
 	if success != nil {
 		success()
+	}
+	if connected != nil {
+		connected(meta.publicKey)
 	}
 
 	err = l.core.HandleConn(meta.publicKey, conn, priority)


### PR DESCRIPTION

The goal of this PR is to have a callback function that will be triggered on any peer state changes instead of polling peer status from Android side.
It adds a lightweight event notification API to `Core` so Android can react to peer list and connectivity changes without polling `GetPeers()`.


I've been working on [yggstack-android](https://github.com/DrewCyber/yggstack-android) version and I really miss this capability from yggdrasil-go.

With this feature yggdrasil-based Android apps could more accurately reflect the current network state. For example, it would enable:
 - UI: Updating the connected peers counter shown in icon badges.
 - UI: Changing the notification bar icon depending on whether at least one peer is connected.
 - Managing peer connections more intelligently. For example, keeping only one peer active while leaving the others idle to avoid transit traffic, then automatically switching to another peer if the active one goes offline.

Tested clean yggdrasil build on macOS and callback feature on Android.

I'd appreciate your feedback on this.

Json payload examples below.
We will get event type with "what was changed" section and current "Peers" state snapshot at the end.

```json
{
  "EventType": "peer_added",
  "Changed": {
    "URI": "tls://peer1.example.com:17241",
    "Up": false,
    "Inbound": false,
    "LastError": null,
    "LastErrorTime": "0001-01-01T00:00:00Z",
    "Key": null,
    "Root": null,
    "Coords": null,
    "Port": 0,
    "Priority": 0,
    "Cost": 0,
    "RXBytes": 0,
    "TXBytes": 0,
    "RXRate": 0,
    "TXRate": 0,
    "Uptime": 0,
    "Latency": 0
  },
  "Peers": [
    {
      "URI": "tls://peer1.example.com:17241",
      "Up": false,
      "Inbound": false,
      "LastError": null,
      "LastErrorTime": "0001-01-01T00:00:00Z",
      "Key": null,
      "Root": null,
      "Coords": null,
      "Port": 0,
      "Priority": 0,
      "Cost": 0,
      "RXBytes": 0,
      "TXBytes": 0,
      "RXRate": 0,
      "TXRate": 0,
      "Uptime": 0,
      "Latency": 0
    }
  ]
}
```
```json
{
  "EventType": "peer_up",
  "Changed": {
    "URI": "tls://peer1.example.com:17241",
    "Up": true,
    "Inbound": false,
    "LastError": null,
    "LastErrorTime": "0001-01-01T00:00:00Z",
    "Key": "q83v7w9zH5oJ2h0V5K0S3m2gY9b7n6p4r2t1u8w0xYI=",
    "Root": null,
    "Coords": null,
    "Port": 0,
    "Priority": 0,
    "Cost": 0,
    "RXBytes": 0,
    "TXBytes": 0,
    "RXRate": 0,
    "TXRate": 0,
    "Uptime": 0,
    "Latency": 0
  },
  "Peers": [
    {
      "URI": "tls://peer1.example.com:17241",
      "Up": true,
      "Inbound": false,
      "LastError": null,
      "LastErrorTime": "2026-07-04T11:10:22.123456Z",
      "Key": "q83v7w9zH5oJ2h0V5K0S3m2gY9b7n6p4r2t1u8w0xYI=",
      "Root": "q83v7w9zH5oJ2h0V5K0S3m2gY9b7n6p4r2t1u8w0xYI=",
      "Coords": [1, 2, 3],
      "Port": 2,
      "Priority": 0,
      "Cost": 512,
      "RXBytes": 1280,
      "TXBytes": 1024,
      "RXRate": 64,
      "TXRate": 32,
      "Uptime": 3500000000,
      "Latency": 47000000
    }
  ]
}
```